### PR TITLE
Revert "chore(deps): update dependency junegunn/fzf to v0.54.2"

### DIFF
--- a/home/dot_config/aqua/aqua.yaml
+++ b/home/dot_config/aqua/aqua.yaml
@@ -25,7 +25,7 @@ packages:
   - name: jesseduffield/lazydocker@v0.23.3
   - name: jesseduffield/lazygit@v0.43.1
   - name: jqlang/jq@jq-1.7.1
-  - name: junegunn/fzf@v0.54.2
+  - name: junegunn/fzf@v0.54.1
   - name: koalaman/shellcheck@v0.10.0
   - name: neovim/neovim@v0.10.1
   - name: noahgorstein/jqp@v0.7.0


### PR DESCRIPTION
Reverts d-issy/dotfiles#257

対応されるまで revert

> ❯ fzf
INFO[0000] download and unarchive the package            aqua_version=2.29.0 env=darwin/amd64 exe_name=fzf package_name=junegunn/fzf package_version=v0.54.2 program=aqua registry=standard
FATA[0000] aqua failed                                   aqua_version=2.29.0 env=darwin/amd64 error="install the package: the asset isn't found: fzf-0.54.2-darwin_amd64.zip" exe_name=fzf package_name=junegunn/fzf package_version=v0.54.2 program=aqua
