### PR TITLE
duckdb in manual management

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727246346,
-        "narHash": "sha256-TcUaKtya339Asu+g6KTJ8h7KiKcKXKp2V+At+7tksyY=",
+        "lastModified": 1728041527,
+        "narHash": "sha256-03liqiJtk9UP7YQHW4r8MduKCK242FQzud8iWvvlK+o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1e22ef1518fb175d762006f9cae7f6312b8caedb",
+        "rev": "509dbf8d45606b618e9ec3bbe4e936b7c5bc6c1e",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727140925,
-        "narHash": "sha256-ZHSasdLwEEjSOD/WTW1o7dr3/EjuYsdwYB4NSgICZ2I=",
+        "lastModified": 1728061008,
+        "narHash": "sha256-qjyJDtwmJckqDyXHmBIiN04kzby/TX/kPYmclBXlROA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "189e5f171b163feb7791a9118afa778d9a1db81f",
+        "rev": "8bca501bf31b54ae2022fe5065ab475d75f7560e",
         "type": "github"
       },
       "original": {

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -12,6 +12,7 @@
     ./aws.nix
     ./bat.nix
     ./bottom.nix
+    ./duckdb.nix
     ./delta.nix
     ./difftastic.nix
     ./eza.nix

--- a/modules/duckdb.nix
+++ b/modules/duckdb.nix
@@ -1,0 +1,38 @@
+{ config, pkgs, ... }:
+
+let
+  version = "1.1.1";
+
+  platform =
+    if pkgs.stdenv.isDarwin then "osx-universal"
+    else if pkgs.stdenv.system == "x86_64-linux" then "linux-amd64"
+    else if pkgs.stdenv.system == "aarch64-linux" then "linux-aarch64"
+    else throw "Unsupported platform";
+
+  hashs = {
+    "linux-amd64" = "7f3f1a26e98b3f1fcc673ffb81d2daf43c07689ed60e88173d6a4fd307f118ae";
+    "linux-aarch64" = "9e1d2183453451050f6151bffb2425b78aa278f98acaca68a2671e36a9583be7";
+    "osx-universal" = "d6db79a6651ad6b0a35bb11fe9affdac9758ebef7b61b8e3f3f6a5a66fb4bf56";
+  };
+
+  duckdb = pkgs.stdenv.mkDerivation {
+    name = "duckdb";
+    src = pkgs.fetchurl {
+      url = "https://github.com/duckdb/duckdb/releases/download/v${version}/duckdb_cli-${platform}.zip";
+      sha256 = hashs.${platform};
+    };
+    buildInputs = [ pkgs.unzip ];
+
+    unpackPhase = ''
+      mkdir -p $out/bin
+      unzip $src -d $out/bin
+    '';
+
+    installPhase = ''
+      chmod +x $out/bin/duckdb
+    '';
+  };
+in
+{
+  home.packages = [ duckdb ];
+}

--- a/modules/misc.nix
+++ b/modules/misc.nix
@@ -4,7 +4,6 @@
     home.packages = [
       pkgs.curl
       pkgs.devbox
-      pkgs.duckdb
       pkgs.glow
       pkgs.gnumake
       pkgs.grpcurl


### PR DESCRIPTION
This pull request introduces support for DuckDB in the Nix configuration, including adding a new module for DuckDB and updating relevant package lists.

### DuckDB Support:

* Added DuckDB module configuration in `modules/duckdb.nix`, including platform-specific handling and fetch URL setup.
* Included `duckdb.nix` in the common modules list in `modules/common.nix`.
* Removed `pkgs.duckdb` from the `home.packages` list in `modules/misc.nix` to avoid redundancy.