### PR TITLE
Add Diffview.nvim

### DIFF
--- a/files/nvim/lua/config/keymaps.lua
+++ b/files/nvim/lua/config/keymaps.lua
@@ -49,6 +49,5 @@ map.setup {
 
   -- lazygit
   { "<leader>gg", lazygit.open, desc = "Lazygit" },
-  { "<leader>gf", lazygit.file_history, desc = "Current File History" },
   { "<leader>gl", lazygit.commit_log, desc = "Commit Log" },
 }

--- a/files/nvim/lua/config/theme.lua
+++ b/files/nvim/lua/config/theme.lua
@@ -24,6 +24,11 @@ local palette = {
   add = "#a3be8c",
   change = "#ebcb8b",
   delete = "#bf616a",
+  diff_text = "#81a1c1",
+
+  add_bg = "#204510",
+  change_bg = "#605000",
+  delete_bg = "#9f514a",
 }
 
 local hl = {
@@ -131,6 +136,14 @@ local hl = {
   GitSignsChange = { fg = palette.change },
   GitSignsDelete = { fg = palette.delete },
 
+  -- DiffView
+  DiffviewFolderSign = { fg = palette.folder },
+  DiffviewFilePanelInsertions = { fg = palette.add },
+  DiffViewFilePanelDeletions = { fg = palette.delete },
+  diffAdded = { fg = palette.add },
+  diffChanaged = { fg = palette.change },
+  diffRemoved = { fg = palette.delete },
+
   -----------
   -- other --
   -----------
@@ -147,9 +160,10 @@ local hl = {
   DiagnosticUnnecessary = { link = "DiagnosticUnderlineHint" },
   DiagnosticDeprecated = { strikethrough = true, sp = palette.warning },
 
-  DiffAdd = { fg = palette.bg, bg = palette.add },
-  DiffChange = { fg = palette.bg, bg = palette.change },
-  DiffDelete = { fg = palette.bg, bg = palette.delete },
+  DiffAdd = { bg = palette.add_bg },
+  DiffChange = { bg = palette.change_bg },
+  DiffDelete = { bg = palette.delete_bg },
+  DiffText = { fg = palette.bg, bg = palette.change },
 }
 
 -- colorschme load

--- a/files/nvim/lua/plugins/git.lua
+++ b/files/nvim/lua/plugins/git.lua
@@ -44,4 +44,74 @@ return {
       end,
     },
   },
+  {
+    "sindrets/diffview.nvim",
+    cmd = {
+      "DiffviewOpen",
+      "DiffviewClose",
+      "DiffviewToggleFiles",
+      "DiffviewFocusFiles",
+      "DiffviewFileHistory",
+      "DifviewRefresh",
+    },
+    keys = {
+      { "<leader>gd", "<cmd>DiffviewOpen<cr>", desc = "Open DiffView" },
+      { "<leader>gf", "<cmd>DiffviewFileHistory %<cr>", desc = "File History" },
+    },
+    opts = function()
+      local actions = require "diffview.actions"
+      local select_entry = function()
+        actions.select_entry()
+        actions.focus_entry()
+      end
+      return {
+        qrsnhyg_netf = {
+          DiffviewOpen = { "--imply-local" },
+        },
+        keymaps = {
+          disable_defaults = false, -- Disable the default keymaps
+          view = {
+            { "n", "q", actions.close, { desc = "Close" } },
+            { "n", "<c-e>", actions.goto_file_edit, { desc = "File Edit" } },
+            { "n", "<c-t>", actions.goto_file, { desc = "File Eidt (Tab)" } },
+            { "n", "<leader>x", actions.cycle_layout, { desc = "Cycle Layout" } },
+            { "n", "]f", actions.select_next_entry, { desc = "Next File" } },
+            { "n", "[f", actions.select_prev_entry, { desc = "Prev File" } },
+            { "n", "<tab>", false },
+            { "n", "<s-tab>", false },
+          },
+          file_panel = {
+            { "n", "q", actions.close, { desc = "Close" } },
+            { "n", "<leader>e", actions.focus_entry, { desc = "Focus Entry" } },
+            { "n", "<cr>", select_entry, { desc = "Select Entry" } },
+            { "n", "o", select_entry, { desc = "Select Entry" } },
+            { "n", "l", select_entry, { desc = "Select Entry" } },
+            { "n", "<2-LeftMouse>", select_entry, { desc = "Select Entry" } },
+          },
+          diff1 = {
+            { "n", "q", actions.close, { desc = "Close" } },
+          },
+          diff2 = {
+            { "n", "q", actions.close, { desc = "Close" } },
+          },
+          diff3 = {
+            { "n", "q", actions.close, { desc = "Close" } },
+          },
+          diff4 = {
+            { "n", "q", actions.close, { desc = "Close" } },
+          },
+          file_history_panel = {
+            { "n", "q", actions.close, { desc = "Close" } },
+            { "n", "<leader>e", actions.focus_entry, { desc = "Focus Entry" } },
+          },
+          option_panel = {
+            { "n", "q", actions.close, { desc = "Close" } },
+          },
+          help_panel = {
+            { "n", "q", actions.close, { desc = "Close" } },
+          },
+        },
+      }
+    end,
+  },
 }


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the Neovim configuration, focusing on adding new plugins and improving the theme and key mappings. The most important changes include the addition of the `diffview.nvim` plugin, updates to the theme configuration to support new diff-related colors, and modifications to key mappings.

### Plugin Additions:
* Added `diffview.nvim` plugin with commands and key mappings for viewing diffs and file history. (`files/nvim/lua/plugins/git.lua`)

### Theme Enhancements:
* Added new color definitions for diff-related backgrounds and text. (`files/nvim/lua/config/theme.lua`)
* Updated highlight groups to use the new diff-related colors. (`files/nvim/lua/config/theme.lua`) [[1]](diffhunk://#diff-8020602b3441499f1f64b8ff0d4d6d267d8467b0a0a0f3821aa82e44ed361533R139-R146) [[2]](diffhunk://#diff-8020602b3441499f1f64b8ff0d4d6d267d8467b0a0a0f3821aa82e44ed361533L150-R166)

### Key Mapping Changes:
* Removed the key mapping for `lazygit.file_history`. (`files/nvim/lua/config/keymaps.lua`)