### PR TITLE
Improve neotest setting

### DIFF
--- a/files/nvim/lua/config/autocmds.lua
+++ b/files/nvim/lua/config/autocmds.lua
@@ -14,12 +14,13 @@ vim.api.nvim_create_autocmd("TextYankPost", {
 vim.api.nvim_create_autocmd("FileType", {
   group = augroup "close_with_q",
   pattern = {
-    "help",
-    "qf",
     "gitsigns.blame",
+    "help",
+    "neotest-output",
     "neotest-output-panel",
     "neotest-summary",
     "notify",
+    "qf",
   },
   callback = function(event)
     vim.bo[event.buf].buflisted = false

--- a/files/nvim/lua/plugins/test.lua
+++ b/files/nvim/lua/plugins/test.lua
@@ -1,8 +1,8 @@
 return {
   "nvim-neotest/neotest",
   dependencies = {
-    "nvim-neotest/neotest-go",
     "nvim-neotest/neotest-python",
+    "fredrikaverpil/neotest-golang",
     -- requirements
     "antoinemadec/FixCursorHold.nvim",
     "nvim-neotest/nvim-nio",
@@ -19,8 +19,8 @@ return {
     }, neotest_ns)
     require("neotest").setup {
       adapters = {
+        require "neotest-golang" {},
         require "neotest-python" {},
-        require "neotest-go" { recursive_run = true },
       },
     }
   end,


### PR DESCRIPTION
This pull request includes updates to the Neovim configuration, specifically related to autocmd patterns and plugin dependencies. The most important changes involve adding new patterns to the autocmd configuration and replacing a plugin dependency.

### Autocmd Configuration Updates:
* [`files/nvim/lua/config/autocmds.lua`](diffhunk://#diff-1d1f3a82e8b300145b4bd5d2e0de576bda25f48148390288d743478d8dad8278L17-R23): Added new patterns `neotest-output` to the `vim.api.nvim_create_autocmd("FileType", {` function.

### Plugin Dependency Updates:
* [`files/nvim/lua/plugins/test.lua`](diffhunk://#diff-9414388d1beda70b0c067d0a6b34c1e69be42b89f046a620373468ba0a7f47a5L4-R5): Replaced the `neotest-go` plugin with `neotest-golang` in the dependencies list.
* [`files/nvim/lua/plugins/test.lua`](diffhunk://#diff-9414388d1beda70b0c067d0a6b34c1e69be42b89f046a620373468ba0a7f47a5R22-L23): Updated the `adapters` section to use `neotest-golang` instead of `neotest-go`.