### PR TITLE
Remove duplicate cmd_duration from starship config

### DIFF
--- a/modules/starship.nix
+++ b/modules/starship.nix
@@ -23,7 +23,6 @@ let
     right_format = lib.strings.concatStringsSep "" [
       "$git_branch"
       "$git_metrics"
-      "$cmd_duration"
       "$memory_usage"
       "$battery"
       "$time"


### PR DESCRIPTION
This pull request includes a small change to the `modules/starship.nix` file. The change removes the `$cmd_duration` variable from the `right_format` concatenation.

* [`modules/starship.nix`](diffhunk://#diff-b9c6d4d39e7fdda1678972296f6882018b5837d9a61c562cf67564de26b24441L26): Removed the duplicate `$cmd_duration` variable from the `right_format` concatenation.