### PR TITLE
fix(zsh): update key bindings and history widget

### DIFF
--- a/files/zsh/rc
+++ b/files/zsh/rc
@@ -1,16 +1,3 @@
-###########
-# bindkey #
-###########
-# vi
-bindkey -v
-bindkey -M viins '^A' beginning-of-line
-bindkey -M viins '^E' end-of-line
-bindkey -M viins '^N' down-line-or-history
-bindkey -M viins '^P' up-line-or-history
-
-# own
-bindkey -M viins '^R' zsh-history
-
 ##############
 # completion #
 ##############
@@ -51,7 +38,11 @@ function zsh-history() {
   CURSOR=$#BUFFER
   zle reset-prompt
 }
-zle -N zsh-history
+
+function zvm_after_init() {
+  zvm_define_widget zsh-history zsh-history
+  zvm_bindkey viins '^R' zsh-history
+}
 
 function tm() {
   if ! tmux has-session 2>/dev/null; then

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728041527,
-        "narHash": "sha256-03liqiJtk9UP7YQHW4r8MduKCK242FQzud8iWvvlK+o=",
+        "lastModified": 1729551526,
+        "narHash": "sha256-7LAGY32Xl14OVQp3y6M43/0AtHYYvV6pdyBcp3eoz0s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "509dbf8d45606b618e9ec3bbe4e936b7c5bc6c1e",
+        "rev": "5ec753a1fc4454df9285d8b3ec0809234defb975",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728061008,
-        "narHash": "sha256-qjyJDtwmJckqDyXHmBIiN04kzby/TX/kPYmclBXlROA=",
+        "lastModified": 1729428082,
+        "narHash": "sha256-xb4/Y+Y7ZlkQaA5rXnrXplDzdt2Jfgdmar3+qkb56UA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8bca501bf31b54ae2022fe5065ab475d75f7560e",
+        "rev": "ca30f584e18024baf39c395001262ed936f27ebd",
         "type": "github"
       },
       "original": {

--- a/modules/eza.nix
+++ b/modules/eza.nix
@@ -5,7 +5,7 @@
     programs.eza = {
       enable = true;
       git = true;
-      icons = true;
+      icons = "auto";
     };
   };
 }


### PR DESCRIPTION
This pull request includes changes to the `files/zsh/rc` and `modules/eza.nix` files, focusing on keybinding adjustments and configuration updates. The most important changes include removing custom keybindings for vi mode in Zsh and updating the `eza` module configuration.

Keybinding adjustments:

* [`files/zsh/rc`](diffhunk://#diff-557ce4d155735588103fc675049264a22d59db4f99ccc45d7fdde7d6d0613da2L1-L13): Removed custom vi mode keybindings and added a function `zvm_after_init` to define and bind the `zsh-history` widget. [[1]](diffhunk://#diff-557ce4d155735588103fc675049264a22d59db4f99ccc45d7fdde7d6d0613da2L1-L13) [[2]](diffhunk://#diff-557ce4d155735588103fc675049264a22d59db4f99ccc45d7fdde7d6d0613da2L54-R45)

Configuration updates:

* [`modules/eza.nix`](diffhunk://#diff-839de687c7c63e6a0d9fe97f0ea13ea132ec4768fbdb818d963666660a7ef266L8-R8): Changed the `icons` setting from `true` to `"auto"` for the `eza` program configuration.