### PR TITLE
navi nushell integration

### DIFF
--- a/files/cheats/misc.cheat
+++ b/files/cheats/misc.cheat
@@ -5,3 +5,6 @@ sudo !!
 
 # current directory
 pwd
+
+# lazy docker :: lg
+lazydocker

--- a/modules/navi.nix
+++ b/modules/navi.nix
@@ -20,7 +20,7 @@ let
     };
     finder = {
       command = "fzf";
-      overrides = "--no-exact";
+      overrides = "--no-exact --tiebreak chunk,begin,length";
       overrides_var = "--no-exact";
     };
     cheats.paths = [
@@ -50,6 +50,45 @@ in
         read -k 1
       }
     '';
+
+    programs.nushell = {
+      extraConfig = ''
+        export def navi_widget [] {
+          let input = (commandline)
+          let last_command = ($input | navi fn widget::last_command | str trim)
+
+          match ($last_command | is-empty) {
+            true => {^navi --print | complete | get "stdout"}
+            false => {
+              let find = $"($last_command)_NAVIEND"
+              let replacement = (^navi --print --query $'($last_command)' --best-match | complete | get "stdout")
+
+              match ($replacement | str trim | is-empty) {
+                false => {$"($input)_NAVIEND" | str replace $find $replacement}
+                true => $input
+              }
+            }
+          } 
+          | str trim
+          | commandline edit --replace $in
+
+          commandline set-cursor --end
+        }
+
+        let nav_keybinding = {
+          name: "navi",
+          modifier: control,
+          keycode: char_g,
+          mode: [emacs, vi_normal, vi_insert],
+          event: {
+            send: executehostcommand,
+            cmd: navi_widget,
+          }
+        }
+
+        $env.config.keybindings = ($env.config.keybindings | append $nav_keybinding)
+      '';
+    };
 
     xdg.configFile."navi/config.yaml" = mkIf (settings != { }) {
       source = yamlFormat.generate "navi-config" settings;

--- a/modules/nushell.nix
+++ b/modules/nushell.nix
@@ -37,9 +37,7 @@ in
         nuConfig = nuConfig;
 
         extraConfig = ''
-          ${cfg.initExtraFirst}
-          $env.config = ${builtins.toJSON cfg.nuConfig}
-          $env.config.keybindings = ${builtins.toJSON cfg.keybindings}
+          $env.config = ($env.config? | ${builtins.toJSON cfg.nuConfig})
         '';
       };
   };
@@ -47,50 +45,11 @@ in
   options.programs.nushell =
     let
       jsonFormat = pkgs.formats.json { };
-      keybindModifierType = types.enum [ "none" "control" "alt" "shift" "shift_alt" "alt_shift" "control_alt" "alt_control" "control_shift" "shift_control" "control_alt_shift" "control_shift_alt" ];
-      keybindModeType = types.enum [ "emacs" "vi_normal" "vi_insert" ];
-      keybindEventType = types.attrsOf types.anything;
     in
     {
-      initExtraFirst = mkOption {
-        default = "";
-        type = types.lines;
-        example = ''
-          def hello [name: string] -> string {
-            $ "Hello, ($name)!!"
-          }
-        '';
-      };
-
       nuConfig = mkOption {
         default = { };
         type = jsonFormat.type;
-      };
-
-      keybindings = mkOption {
-        default = [ ];
-        type = types.listOf
-          (types.submodule {
-            options = {
-              name = mkOption { type = types.str; };
-              modifier = mkOption {
-                default = "control";
-                type = keybindModifierType;
-              };
-              keycode = mkOption {
-                type = types.str;
-                example = "char_a";
-              };
-              mode = mkOption {
-                default = "vi_insert";
-                type = types.oneOf [ keybindModeType (types.listOf keybindModeType) ];
-              };
-              event = mkOption {
-                default = null;
-                type = types.nullOr (types.oneOf [ keybindEventType (types.listOf keybindEventType) ]);
-              };
-            };
-          });
       };
     };
 }


### PR DESCRIPTION
This pull request includes several changes to improve the configuration and functionality of various modules. The most important changes include adding a new lazydocker command, enhancing the `navi` module with additional overrides and a new widget, and refining the `nushell` module configuration.

Enhancements to `navi` module:

* [`modules/navi.nix`](diffhunk://#diff-fbe825cbd52f95b92c6c68451fa1b3e73cb75af4a1828973c77c5c6bddde8195L23-R23): Added new overrides to the `finder` command to improve search functionality.
* [`modules/navi.nix`](diffhunk://#diff-fbe825cbd52f95b92c6c68451fa1b3e73cb75af4a1828973c77c5c6bddde8195R54-R92): Introduced a new `navi_widget` for `nushell` that enhances command line completion and added keybindings for the widget.

Refinements to `nushell` module:

* [`modules/nushell.nix`](diffhunk://#diff-616c16fab538a276c244af6f9fe8f0d8f990bf305c60a140a8b6d781efa9215cL40-L94): Simplified the `extraConfig` by removing redundant `initExtraFirst` and `keybindings` options and ensuring the `config` is set correctly.

Miscellaneous:

* [`files/cheats/misc.cheat`](diffhunk://#diff-637ddf205600cd6fa02c0b97e785267075647db8a7d7b2394299372ac3b328c1R8-R10): Added a new lazydocker command under the "lazy docker" section.