### PR TITLE
fix: bug in navi and nushell

### DIFF
--- a/modules/navi.nix
+++ b/modules/navi.nix
@@ -43,10 +43,13 @@ in
           let cmd = navi --print | complete | get "stdout" | str trim
           match ($cmd | is-empty) {
             true => { return }
-            false => { exec $cmd }
+            false => {
+              try {
+                nu -c $cmd
+              } catch { |err| $err.msg }
+            }
           }
-          echo "\n(process exit)"
-          input
+          input "\n(process exit)"
         }
 
         export def _navi_widget [] {


### PR DESCRIPTION
This pull request makes changes to the `modules/navi.nix` file to improve error handling and streamline the user interface. The most important changes include adding a `try-catch` block for command execution and modifying the `input` function call.

Error handling improvements:

* Added a `try-catch` block to handle errors when executing commands using `nu -c $cmd`. If an error occurs, it will output the error message. (`modules/navi.nix`)

User interface improvements:

* Modified the `input` function call to include the process exit message directly as an argument, simplifying the code. (`modules/navi.nix`)