### PR TITLE
add nvim-dap configuration for debugging

### DIFF
--- a/files/nvim/lua/plugins/dap.lua
+++ b/files/nvim/lua/plugins/dap.lua
@@ -1,0 +1,78 @@
+return {
+  {
+    "mfussenegger/nvim-dap",
+    dependencies = {
+      "rcarriga/nvim-dap-ui",
+      "nvim-neotest/nvim-nio",
+      -- languages
+      "leoluz/nvim-dap-go",
+    },
+    -- stylua: ignore
+    keys = {
+      { "<leader>d", "", desc = "+debug", mode = {"n", "v"} },
+      { "<leader>dB", function() require("dap").set_breakpoint(vim.fn.input('Breakpoint condition: ')) end, desc = "Breakpoint Condition" },
+      { "<leader>db", function() require("dap").toggle_breakpoint() end, desc = "Toggle Breakpoint" },
+      { "<leader>dc", function() require("dap").continue() end, desc = "Continue" },
+      -- { "<leader>da", function() require("dap").continue({ before = get_args }) end, desc = "Run with Args" },
+      { "<leader>dC", function() require("dap").run_to_cursor() end, desc = "Run to Cursor" },
+      { "<leader>dg", function() require("dap").goto_() end, desc = "Go to Line (No Execute)" },
+      { "<leader>di", function() require("dap").step_into() end, desc = "Step Into" },
+      { "<leader>dj", function() require("dap").down() end, desc = "Down" },
+      { "<leader>dk", function() require("dap").up() end, desc = "Up" },
+      { "<leader>dl", function() require("dap").run_last() end, desc = "Run Last" },
+      { "<leader>do", function() require("dap").step_out() end, desc = "Step Out" },
+      { "<leader>dO", function() require("dap").step_over() end, desc = "Step Over" },
+      { "<leader>dp", function() require("dap").pause() end, desc = "Pause" },
+      { "<leader>dr", function() require("dap").repl.toggle() end, desc = "Toggle REPL" },
+      { "<leader>ds", function() require("dap").session() end, desc = "Session" },
+      { "<leader>dt", function() require("dap").terminate() end, desc = "Terminate" },
+      -- ui
+      { "<leader>dw", function() require("dap.ui.widgets").hover() end, desc = "Widgets" },
+      { "<leader>du", function() require("dapui").toggle({ }) end, desc = "Dap UI" },
+      { "<leader>de", function() require("dapui").eval() end, desc = "Eval", mode = {"n", "v"} },
+    },
+    config = function()
+      local dap = require "dap"
+      local dapui = require "dapui"
+
+      dapui.setup()
+
+      dap.listeners.before.attach.dapui_config = function()
+        dapui.open()
+      end
+      dap.listeners.before.launch.dapui_config = function()
+        dapui.open()
+      end
+      dap.listeners.before.event_terminated.dapui_config = function()
+        dapui.close()
+      end
+      dap.listeners.before.event_exited.dapui_config = function()
+        dapui.close()
+      end
+
+      -- languages
+      require("dap-go").setup {
+        dap_configurations = {
+          {
+            type = "go",
+            name = "Attach remote",
+            mode = "remote",
+            request = "attach",
+          },
+        },
+        delve = {
+          path = "dlv",
+          initialize_timeout_sec = 20,
+          port = "${port}",
+          args = {},
+          build_flags = {},
+          detached = vim.fn.has "win32" == 0,
+          cwd = nil,
+        },
+        tests = {
+          verbose = false,
+        },
+      }
+    end,
+  },
+}

--- a/files/nvim/lua/plugins/dap.lua
+++ b/files/nvim/lua/plugins/dap.lua
@@ -1,27 +1,25 @@
 return {
-  {
-    "mfussenegger/nvim-dap",
-    dependencies = {
-      "rcarriga/nvim-dap-ui",
-      "nvim-neotest/nvim-nio",
-      -- languages
-      "leoluz/nvim-dap-go",
-    },
+  "mfussenegger/nvim-dap",
+  dependencies = {
+    "rcarriga/nvim-dap-ui",
+    "nvim-neotest/nvim-nio",
+    -- languages
+    "leoluz/nvim-dap-go",
+  },
     -- stylua: ignore
     keys = {
       { "<leader>d", "", desc = "+debug", mode = {"n", "v"} },
-      { "<leader>dB", function() require("dap").set_breakpoint(vim.fn.input('Breakpoint condition: ')) end, desc = "Breakpoint Condition" },
       { "<leader>db", function() require("dap").toggle_breakpoint() end, desc = "Toggle Breakpoint" },
+      { "<leader>dB", function() require("dap").set_breakpoint(vim.fn.input('Breakpoint condition: ')) end, desc = "Breakpoint Condition" },
       { "<leader>dc", function() require("dap").continue() end, desc = "Continue" },
-      -- { "<leader>da", function() require("dap").continue({ before = get_args }) end, desc = "Run with Args" },
       { "<leader>dC", function() require("dap").run_to_cursor() end, desc = "Run to Cursor" },
       { "<leader>dg", function() require("dap").goto_() end, desc = "Go to Line (No Execute)" },
       { "<leader>di", function() require("dap").step_into() end, desc = "Step Into" },
       { "<leader>dj", function() require("dap").down() end, desc = "Down" },
       { "<leader>dk", function() require("dap").up() end, desc = "Up" },
       { "<leader>dl", function() require("dap").run_last() end, desc = "Run Last" },
-      { "<leader>do", function() require("dap").step_out() end, desc = "Step Out" },
-      { "<leader>dO", function() require("dap").step_over() end, desc = "Step Over" },
+      { "<leader>do", function() require("dap").step_over() end, desc = "Step Over" },
+      { "<leader>dO", function() require("dap").step_out() end, desc = "Step Out" },
       { "<leader>dp", function() require("dap").pause() end, desc = "Pause" },
       { "<leader>dr", function() require("dap").repl.toggle() end, desc = "Toggle REPL" },
       { "<leader>ds", function() require("dap").session() end, desc = "Session" },
@@ -31,48 +29,28 @@ return {
       { "<leader>du", function() require("dapui").toggle({ }) end, desc = "Dap UI" },
       { "<leader>de", function() require("dapui").eval() end, desc = "Eval", mode = {"n", "v"} },
     },
-    config = function()
-      local dap = require "dap"
-      local dapui = require "dapui"
+  config = function()
+    local dap = require "dap"
 
-      dapui.setup()
+    -- ui
+    local dapui = require "dapui"
+    dapui.setup()
 
-      dap.listeners.before.attach.dapui_config = function()
-        dapui.open()
-      end
-      dap.listeners.before.launch.dapui_config = function()
-        dapui.open()
-      end
-      dap.listeners.before.event_terminated.dapui_config = function()
-        dapui.close()
-      end
-      dap.listeners.before.event_exited.dapui_config = function()
-        dapui.close()
-      end
+    -- languages
+    require("dap-go").setup {}
+    require("dap.ext.vscode").load_launchjs()
 
-      -- languages
-      require("dap-go").setup {
-        dap_configurations = {
-          {
-            type = "go",
-            name = "Attach remote",
-            mode = "remote",
-            request = "attach",
-          },
-        },
-        delve = {
-          path = "dlv",
-          initialize_timeout_sec = 20,
-          port = "${port}",
-          args = {},
-          build_flags = {},
-          detached = vim.fn.has "win32" == 0,
-          cwd = nil,
-        },
-        tests = {
-          verbose = false,
-        },
-      }
-    end,
-  },
+    dap.listeners.before.attach.dapui_config = function()
+      dapui.open()
+    end
+    dap.listeners.before.launch.dapui_config = function()
+      dapui.open()
+    end
+    dap.listeners.before.event_terminated.dapui_config = function()
+      dapui.close()
+    end
+    dap.listeners.before.event_exited.dapui_config = function()
+      dapui.close()
+    end
+  end,
 }


### PR DESCRIPTION
This pull request adds a new configuration for the `nvim-dap` plugin to the `files/nvim/lua/plugins/dap.lua` file. The changes include adding dependencies, setting up key bindings for debugging actions, and configuring the UI and language-specific settings.

Key additions and configurations:

### Plugin and Dependencies:
* Added `mfussenegger/nvim-dap` plugin and its dependencies: `rcarriga/nvim-dap-ui`, `nvim-neotest/nvim-nio`, and `leoluz/nvim-dap-go`.

### Key Bindings:
* Configured key bindings for various debugging actions such as toggling breakpoints, stepping into/out of code, continuing execution, and more.

### UI and Language Support:
* Set up `dapui` for debugging UI and configured it to open/close on specific debugging events.
* Configured `dap-go` for Go language debugging support.
* Loaded VS Code launch configurations using `dap.ext.vscode`.