### PR TITLE
fix: go cheat

### DIFF
--- a/files/cheats/go.cheat
+++ b/files/cheats/go.cheat
@@ -3,4 +3,4 @@
 # go run
 go run <main-file>
 
-$ main-file: find -name main.go
+$ main-file: find . -name main.go


### PR DESCRIPTION
This pull request includes a small change to the `files/cheats/go.cheat` file. The change modifies the command to find the `main.go` file by adding a dot to specify the current directory.

* [`files/cheats/go.cheat`](diffhunk://#diff-10b987fc0237e7551a463936455f62c43f1c2fb78fa09db41cfadf91485aa66aL6-R6): Changed the command from `find -name main.go` to `find . -name main.go` to ensure it searches from the current directory.