### PR TITLE
fix(util): correct trace log level key

### DIFF
--- a/files/nvim/lua/util/log.lua
+++ b/files/nvim/lua/util/log.lua
@@ -4,7 +4,7 @@ local M = {}
 --- @enum (key) util.log.LEVELS
 M.levels = {
   debug = vim.log.levels.DEBUG,
-  trance = vim.log.levels.TRACE,
+  trace = vim.log.levels.TRACE,
   info = vim.log.levels.INFO,
   warn = vim.log.levels.WARN,
   error = vim.log.levels.ERROR,


### PR DESCRIPTION
## Summary
- correct the key for the trace log level in util.log

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68436306e548832cac1a3ebcc2abde72