### PR TITLE
Fix big file comment typo

### DIFF
--- a/files/nvim/lua/util/file.lua
+++ b/files/nvim/lua/util/file.lua
@@ -10,7 +10,7 @@ M.is_big = function(buf)
   return file_size > 1572864 -- 1.5MB
 end
 
---- Disable futures for big file
+--- Disable features for big file
 --- @param buf? number
 M.disable_futures_for_bigfile = function(buf)
   buf = buf or vim.api.nvim_get_current_buf()


### PR DESCRIPTION
## Summary
- fix a typo in the big file handling comment in `file.lua`

## Testing
- `nix flake show` *(fails: `nix` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6843630080d8832c84a9e3de0e81ffbd