### PR TITLE
Fix architecture typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ d-issy's dotfiles
 ## Require
 
 - os
-  - macOS (aarch64/x64_86)
+  - macOS (aarch64/x86_64)
   - WSL2 on Windows / Linux
 - nix
 


### PR DESCRIPTION
## Summary
- fix x86_64 typo in README

## Testing
- `nix flake check` *(fails: `nix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684362ed90e0832c845a2b03da9299e0