### PR TITLE
Fix workflow: specify stylua version

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,21 @@
+name: Lua Format
+
+permissions:
+  contents: read
+
+on: [pull_request]
+
+env:
+  CLICOLOR: 1
+
+jobs:
+  stylua:
+    name: Stylua
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: JohnnyMorganz/stylua-action@v4
+        with:
+          token: ${{ github.token }}
+          version: v2.1.0
+          args: --check .


### PR DESCRIPTION
## Summary
- fix Stylua workflow by adding token
- specify Stylua version v2.1.0 for formatting workflow

## Testing
- `stylua --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684362e449ac832c96f5237689aa40a3