### PR TITLE
Add Claude Code Setting

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git add:*)"
+    ],
+    "deny": []
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(git add:*)"
-    ],
-    "deny": []
-  }
-}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 See @README.md for setup and apply commands.
 
 ### GitHub CLI
-- `gh pr create` - Creates pull request and pushes branch automatically (no need for separate `git push`)
+- `git push -u origin [branch]` is required before `gh pr create`
+- `gh pr create` - Creates pull request after branch is pushed
 - Pull request body should not include "Test plan" section - keep it simple
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+**Important: Always respond in Japanese when working in this repository.**
+
+## Commands
+
+See @README.md for setup and apply commands.
+
+### GitHub CLI
+- `gh pr create` - Creates pull request and pushes branch automatically (no need for separate `git push`)
+- Pull request body should not include "Test plan" section - keep it simple
+
+## Architecture
+
+This is a **Nix Flakes-based Home Manager configuration** that manages user environment and dotfiles across Linux and macOS platforms using a modular architecture.
+
+### Key Structure
+- `flake.nix` - Main flake configuration defining homeConfigurations for linux/macos/macos_intel
+- `home.linux.nix` / `home.macos.nix` - Platform-specific entry points
+- `modules/common.nix` - Central hub importing all shared modules (37 total)
+- `modules/` - Individual tool/program configurations
+- `files/` - Application-specific configuration files
+
+### Module Patterns
+
+**Simple Package Installation** (misc.nix):
+```nix
+{ config, pkgs, ... }: {
+  config = {
+    home.packages = [ pkgs.curl pkgs.jq ];
+    home.shellAliases = { dc = "docker compose"; };
+  };
+}
+```
+
+**Program Configuration** (fzf.nix, gh.nix):
+```nix
+programs.fzf = {
+  enable = true;
+  defaultOptions = [ "--reverse" "--border" ];
+};
+```
+
+**File Symlinking** (neovim.nix, hammerspoon.nix):
+```nix
+xdg.configFile."nvim" = {
+  source = ../files/nvim;
+  recursive = true;
+};
+```
+
+### Platform Differences
+- **Linux**: Only imports common.nix
+- **macOS**: Imports common.nix + hammerspoon.nix (macOS-only window manager)
+- **Architecture**: Separate flake outputs handle Intel vs Apple Silicon
+
+### Configuration Management
+1. **Nix modules** define program enablement and basic settings
+2. **Files directory** contains detailed application configurations  
+3. Modules link to files using `source = ../files/[app]` pattern
+4. All changes require `nix run . -- switch --flake .#[platform]` to apply
+
+### Adding New Tools
+1. Create module in `modules/[tool].nix` 
+2. Add to imports in `modules/common.nix`
+3. Place config files in `files/[tool]/` if needed
+4. Apply configuration with platform-specific command

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,16 +2,9 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-**Important: Always respond in Japanese when working in this repository.**
-
 ## Commands
 
 See @README.md for setup and apply commands.
-
-### GitHub CLI
-- `git push -u origin [branch]` is required before `gh pr create`
-- `gh pr create` - Creates pull request after branch is pushed
-- Pull request body should not include "Test plan" section - keep it simple
 
 ## Architecture
 

--- a/modules/claude.nix
+++ b/modules/claude.nix
@@ -5,10 +5,14 @@
       text = ''
         # Global Claude Code Instructions
 
-        **Important: Always respond in Japanese when working with code.**
+        ## Language Settings
+        - Always respond in the same language as the user's message
+        - If the user writes in Japanese, respond in Japanese
+        - If the user writes in English, respond in English
+        - Code comments and documentation should follow the project's existing language conventions
 
         ## Git Commit Messages
-        Follow Conventional Commits format:
+        Follow Conventional Commits format (always in English):
         - `feat:` for new features
         - `fix:` for bug fixes
         - `docs:` for documentation changes
@@ -22,7 +26,7 @@
         - Create focused PRs with clear titles
         - Keep PR body concise and descriptive
         - No "Test plan" sections unless specifically requested
-        - PR title and body should use the language requested by the user (default to their language)
+        - PR title and body should follow LanguageSettings.
 
         ## General Development
         - Always check existing code patterns before implementing

--- a/modules/claude.nix
+++ b/modules/claude.nix
@@ -1,0 +1,81 @@
+{ config, pkgs, ... }: {
+  config = {
+    # Global CLAUDE.md for general development practices
+    home.file.".claude/CLAUDE.md" = {
+      text = ''
+        # Global Claude Code Instructions
+
+        **Important: Always respond in Japanese when working with code.**
+
+        ## Git Commit Messages
+        Follow Conventional Commits format:
+        - `feat:` for new features
+        - `fix:` for bug fixes
+        - `docs:` for documentation changes
+        - `style:` for formatting, missing semi-colons, etc
+        - `refactor:` for code changes that neither fixes a bug nor adds a feature
+        - `perf:` for performance improvements
+        - `test:` for adding missing tests
+        - `chore:` for updating build tasks, package manager configs, etc
+
+        ## Pull Request Guidelines
+        - Create focused PRs with clear titles
+        - Keep PR body concise and descriptive
+        - No "Test plan" sections unless specifically requested
+        - PR title and body should use the language requested by the user (default to their language)
+
+        ## General Development
+        - Always check existing code patterns before implementing
+        - Run linters and tests before committing
+        - Follow the project's existing code style
+      '';
+    };
+
+    home.file.".claude/settings.json" = {
+      text = builtins.toJSON {
+        permissions = {
+          allow = [
+            # Git safe operations
+            "Bash(git status:*)"
+            "Bash(git diff:*)"
+            "Bash(git log:*)"
+            "Bash(git show:*)"
+            "Bash(git branch -a:*)"
+            "Bash(git remote -v:*)"
+            
+            # Package managers (read-only)
+            "Bash(npm list:*)"
+            "Bash(npm outdated:*)"
+            "Bash(yarn list:*)"
+            "Bash(pip list:*)"
+            "Bash(pip show:*)"
+            "Bash(go list:*)"
+            "Bash(cargo tree:*)"
+            
+            # Testing and linting (dry-run)
+            "Bash(npm run lint:*)"
+            "Bash(npm run test:*)"
+            
+            # Build tools (check only)
+            "Bash(make -n:*)"
+            "Bash(docker ps:*)"
+            "Bash(docker images:*)"
+            
+            # GitHub CLI (read-only)
+            "Bash(gh pr list:*)"
+            "Bash(gh pr view:*)"
+            "Bash(gh issue list:*)"
+            "Bash(gh issue view:*)"
+            "Bash(gh repo view:*)"
+            
+            # Documentation
+            "WebFetch(domain:docs.anthropic.com)"
+            "WebFetch(domain:github.com)"
+            "WebFetch(domain:*.github.io)"
+          ];
+          deny = [];
+        };
+      };
+    };
+  };
+}

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -13,6 +13,7 @@
     ./aws.nix
     ./bat.nix
     ./carapace.nix
+    ./claude.nix
     ./codex.nix
     ./bottom.nix
     ./delta.nix

--- a/modules/gh.nix
+++ b/modules/gh.nix
@@ -5,7 +5,6 @@
     enable = true;
     settings = {
       git_protocol = "ssh";
-      prefer_editor_prompt = "enabled";
       aliases = {
         prs = "f prs";
         grep = "f greps";

--- a/modules/misc.nix
+++ b/modules/misc.nix
@@ -4,6 +4,7 @@
     home.shellAliases = {
       ".." = "cd..";
       dc = "docker compose";
+      cc = "claude";
     };
 
     home.packages = [


### PR DESCRIPTION
## 概要
- gh.nixから`prefer_editor_prompt`設定を削除してGitHub CLIの設定を簡素化
- misc.nixに`cc`エイリアスを追加してClaude Codeへの簡単アクセスを実現
- プロジェクト固有の指示を含むCLAUDE.mdを追加
- Claude Codeの設定をNixでグローバルに管理するclaude.nixモジュールを追加
  - 柔軟な言語設定を含むグローバルCLAUDE.md（ユーザーの言語で応答）
  - 一般的な開発ツール用の安全な読み取り専用権限
  - perfタイプを含むConventional Commitsフォーマット
  - Gitコミット/ブランチは常に英語、PRの言語はユーザーのリクエストに従う

🤖 Generated with [Claude Code](https://claude.ai/code)