### PR TITLE
feat: add Claude Code cheat sheet and clean up shell aliases

### DIFF
--- a/files/cheats/claude.cheat
+++ b/files/cheats/claude.cheat
@@ -1,0 +1,22 @@
+% claude, claude-code, ai
+
+# Start Claude Code session :: cc
+claude
+
+# Start Claude Code session with specific model :: ccm
+claude --model <model>
+
+# Continue most recent conversation :: ccc
+claude --continue
+
+# Resume session with selection interface :: ccr
+claude --resume
+
+# Resume session with specific model :: ccrm
+claude --resume --model <model>
+
+# Run one-off query and exit :: ccp
+claude -p "<query>"
+
+$ model: echo -e "sonnet\nopus"
+$ query: echo -e "explain this code\nreview my changes\nhelp with debugging"

--- a/modules/misc.nix
+++ b/modules/misc.nix
@@ -4,7 +4,6 @@
     home.shellAliases = {
       ".." = "cd..";
       dc = "docker compose";
-      cc = "claude";
     };
 
     home.packages = [


### PR DESCRIPTION
## Summary
- Add comprehensive Claude Code cheat sheet with common commands and aliases
- Remove redundant `cc` alias from shell aliases (now covered by cheat sheet)

## Changes
- Added `files/cheats/claude.cheat` with Claude Code commands and options
- Removed `cc = "claude"` alias from `modules/misc.nix` to avoid duplication

🤖 Generated with [Claude Code](https://claude.ai/code)