### PR TITLE
feat: add Ghostty terminal emulator configuration

### DIFF
--- a/files/ghostty/config
+++ b/files/ghostty/config
@@ -1,0 +1,32 @@
+# UI
+theme = catppuccin-macchiato
+font-size = 14
+
+font-family = ""
+font-family = "0xProto"
+font-family = "UDEV Gothic 35"
+font-family = "Hack Nerd Font Mono"
+font-family = "YuGothic"
+
+font-feature = -dlig
+font-feature = calt
+font-feature = clig
+font-feature = liga
+
+window-padding-x = 4
+window-padding-y = 0
+window-padding-balance = true
+
+mouse-hide-while-typing = true
+resize-overlay = never
+
+# macOS specific
+macos-option-as-alt = left
+macos-titlebar-style = tabs
+
+
+# keybind
+keybind = "ctrl+j=ignore"
+keybind = "shift+enter=text:\n"
+
+

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -22,6 +22,7 @@
     ./gcloud.nix
     ./gh.nix
     ./ghq.nix
+    ./ghostty.nix
     ./git.nix
     ./lazydocker.nix
     ./lazygit.nix

--- a/modules/ghostty.nix
+++ b/modules/ghostty.nix
@@ -1,0 +1,5 @@
+{ config, pkgs, ... }:
+
+{
+  xdg.configFile."ghostty/config".source = ../files/ghostty/config;
+}


### PR DESCRIPTION
## Summary
- Add Ghostty configuration with Catppuccin Macchiato theme
- Configure font fallback chain with 0xProto and UDEV Gothic  
- Set up macOS-specific titlebar and option key handling

🤖 Generated with [Claude Code](https://claude.ai/code)