### PR TITLE
feat: enable URL link detection in Ghostty terminal

### DIFF
--- a/files/ghostty/config
+++ b/files/ghostty/config
@@ -19,6 +19,7 @@ window-padding-balance = true
 
 mouse-hide-while-typing = true
 resize-overlay = never
+link-url = true
 
 # macOS specific
 macos-option-as-alt = left


### PR DESCRIPTION
## Summary
- Enable URL link detection in Ghostty terminal by adding `link-url = true` configuration

🤖 Generated with [Claude Code](https://claude.ai/code)