### PR TITLE
fix: explicitly enable ruby idiomatic version files in mise configuration

### DIFF
--- a/modules/mise.nix
+++ b/modules/mise.nix
@@ -26,6 +26,7 @@ with lib;
           jobs = 2;
           trusted_config_paths = [ "~/.config/mise" ];
           idiomatic_version_file = true;
+          idiomatic_version_file_enable_tools = [ "ruby" ];
           not_found_auto_install = false;
           status = {
             missing_tools = "never";


### PR DESCRIPTION
## Summary
- Adds `idiomatic_version_file_enable_tools = [ "ruby" ]` setting to mise configuration
- Resolves deprecation warnings about .ruby-version files that will be disabled by default in mise 2025.10.0
- Ensures Ruby version management continues to work seamlessly

🤖 Generated with [Claude Code](https://claude.ai/code)