### PR TITLE
fix: update deprecated APIs for Neovim 0.12 and suppress Nix warnings

### DIFF
--- a/files/nvim/lua/util/file.lua
+++ b/files/nvim/lua/util/file.lua
@@ -23,7 +23,10 @@ M.disable_futures_for_bigfile = function(buf)
     buffer = buf,
     callback = function(args)
       vim.schedule(function()
-        vim.lsp.buf_detach_client(buf, args.data.client_id)
+        local client = vim.lsp.get_client_by_id(args.data.client_id)
+        if client then
+          client:buf_detach(buf)
+        end
       end)
     end,
   })

--- a/files/nvim/lua/util/fold.lua
+++ b/files/nvim/lua/util/fold.lua
@@ -5,8 +5,7 @@ local M = {}
 function M.expr()
   local buf = vim.api.nvim_get_current_buf()
 
-  local ok = pcall(vim.treesitter.get_parser, buf)
-  if ok then
+  if vim.treesitter.get_parser(buf) then
     return vim.treesitter.foldexpr()
   end
   return "0"

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772060133,
-        "narHash": "sha256-VuyRptb8v1lVGMlLp4/1vRX3Efwec0CN0S6mKmDPzLg=",
+        "lastModified": 1775457580,
+        "narHash": "sha256-ikws/ssAmG20AGrEwBuwspwPlkubJu34mB+Uz2fJBJs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ce9b6e52500a0ea0ec48f0bbf6d7a3e431d9dfa4",
+        "rev": "5de7dbd151b0bd65d45785553d4a22d832733ffc",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773597492,
-        "narHash": "sha256-hQ284SkIeNaeyud+LS0WVLX+WL2rxcVZLFEaK0e03zg=",
+        "lastModified": 1775464765,
+        "narHash": "sha256-nex6TL2x1/sVHCyDWcvl1t/dbTedb9bAGC4DLf/pmYk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a07d4ce6bee67d7c838a8a5796e75dff9caa21ef",
+        "rev": "83e29f2b8791f6dec20804382fcd9a666d744c07",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
   outputs = { nixpkgs, nixpkgs-mise, home-manager, ... }:
     let
       miseOverlay = final: prev: {
-        mise = (import nixpkgs-mise { system = final.system; }).mise;
+        mise = (import nixpkgs-mise { system = final.stdenv.hostPlatform.system; }).mise;
       };
     in
     {

--- a/modules/git.nix
+++ b/modules/git.nix
@@ -203,6 +203,7 @@ in
 {
   programs.git = {
     enable = true;
+    signing.format = null;
     settings = settings;
     ignores = ignores;
   };


### PR DESCRIPTION
## Summary

Fix deprecated APIs for Neovim 0.12.0 compatibility and suppress Nix evaluation warnings.

## Changes

### Neovim 0.12.0
- Replace `pcall(vim.treesitter.get_parser)` with direct nil check, since `get_parser()` now returns `nil` instead of throwing (`util/fold.lua`)
- Migrate `vim.lsp.buf_detach_client()` to `client:buf_detach()` method (`util/file.lua`)

### Nix warnings
- Use `final.stdenv.hostPlatform.system` instead of deprecated `final.system` in overlay (`flake.nix`)
- Set `programs.git.signing.format = null` to adopt the new default and silence stateVersion warning (`modules/git.nix`)
