### PR TITLE
fix(neovim): migrate nvim-treesitter to main branch API for Neovim 0.12

### DIFF
--- a/files/nvim/lua/plugins/treesitter.lua
+++ b/files/nvim/lua/plugins/treesitter.lua
@@ -2,36 +2,29 @@ return {
   {
     "nvim-treesitter/nvim-treesitter",
     event = { "BufReadPost" },
-    cmd = { "TSInstall", "TSBufEnable", "TSBufDisable", "TSModuleInfo" },
     build = ":TSUpdate",
-    opts = {
-      sync_install = true,
-      auto_install = true,
-      ensure_installed = {
-        "diff",
-        "lua",
-        "luadoc",
-        "markdown",
-        "markdown_inline",
-        "printf",
-        "vim",
-        "vimdoc",
-      },
-      incremental_selection = { enable = true },
-      highlight = {
-        enable = true,
-        disable = function(lang)
+    config = function()
+      local wanted = { "diff", "lua", "luadoc", "markdown", "markdown_inline", "printf", "vim", "vimdoc" }
+      local installed = require("nvim-treesitter.config").get_installed()
+      local to_install = vim.iter(wanted)
+        :filter(function(p) return not vim.tbl_contains(installed, p) end)
+        :totable()
+      if #to_install > 0 then
+        require("nvim-treesitter").install(to_install)
+      end
+
+      vim.api.nvim_create_autocmd("FileType", {
+        group = vim.api.nvim_create_augroup("treesitter-start", { clear = true }),
+        callback = function(args)
           if require("util.file").is_big() then
-            return true
+            return
           end
-          return vim.list_contains({ "help" }, lang)
+          local lang = vim.treesitter.language.get_lang(vim.bo[args.buf].filetype)
+          if lang and not vim.list_contains({ "help" }, lang) then
+            pcall(vim.treesitter.start, args.buf)
+          end
         end,
-        use_languagetree = true,
-      },
-      indent = { enable = true },
-    },
-    config = function(_, opts)
-      require("nvim-treesitter.configs").setup(opts)
+      })
     end,
   },
   {

--- a/modules/neovim.nix
+++ b/modules/neovim.nix
@@ -2,7 +2,10 @@
 
 {
   config = {
-    home.packages = [ pkgs.neovim ];
+    home.packages = [
+      pkgs.neovim
+      pkgs.tree-sitter
+    ];
     home.sessionVariables = { EDITOR = "nvim"; };
     home.shellAliases = { v = "nvim"; };
 


### PR DESCRIPTION
## Summary

Migrate nvim-treesitter configuration from the legacy `master` branch API to the `main` branch API for Neovim 0.12 compatibility.

## Background

The `master` branch of nvim-treesitter is frozen and incompatible with Neovim 0.12. This caused treesitter runtime errors (e.g. `attempt to call method 'range' (a nil value)`) when render-markdown.nvim triggered injection parsing.

## Changes

- Migrate nvim-treesitter config to the new `main` branch API
  - Replace `require("nvim-treesitter.configs").setup()` with `require("nvim-treesitter").install()` + `vim.treesitter.start()`
  - Replace `ensure_installed` with manual install logic
  - Enable highlighting via `FileType` autocmd instead of plugin options
- Add `tree-sitter` CLI to `neovim.nix` packages (required for parser compilation on the `main` branch)
