### PR TITLE
fix(nvim): lazy-install treesitter parsers

### DIFF
--- a/files/nvim/lua/plugins/treesitter.lua
+++ b/files/nvim/lua/plugins/treesitter.lua
@@ -1,16 +1,23 @@
 return {
   {
     "nvim-treesitter/nvim-treesitter",
+    branch = "main",
     event = { "BufReadPost" },
     build = ":TSUpdate",
     config = function()
+      local treesitter = require "nvim-treesitter"
+      local treesitter_config = require "nvim-treesitter.config"
+      local available = treesitter_config.get_available()
+
       local wanted = { "diff", "lua", "luadoc", "markdown", "markdown_inline", "printf", "vim", "vimdoc" }
-      local installed = require("nvim-treesitter.config").get_installed()
-      local to_install = vim.iter(wanted)
-        :filter(function(p) return not vim.tbl_contains(installed, p) end)
+      local to_install = vim
+        .iter(wanted)
+        :filter(function(p)
+          return not vim.tbl_contains(treesitter_config.get_installed(), p)
+        end)
         :totable()
       if #to_install > 0 then
-        require("nvim-treesitter").install(to_install)
+        treesitter.install(to_install)
       end
 
       vim.api.nvim_create_autocmd("FileType", {
@@ -20,8 +27,20 @@ return {
             return
           end
           local lang = vim.treesitter.language.get_lang(vim.bo[args.buf].filetype)
-          if lang and not vim.list_contains({ "help" }, lang) then
+          if not lang or vim.list_contains({ "help" }, lang) then
+            return
+          end
+          if not vim.list_contains(available, lang) then
+            return
+          end
+          if vim.list_contains(treesitter_config.get_installed(), lang) then
             pcall(vim.treesitter.start, args.buf)
+          else
+            treesitter.install({ lang }):await(function()
+              if vim.api.nvim_buf_is_valid(args.buf) then
+                pcall(vim.treesitter.start, args.buf)
+              end
+            end)
           end
         end,
       })

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775457580,
-        "narHash": "sha256-ikws/ssAmG20AGrEwBuwspwPlkubJu34mB+Uz2fJBJs=",
+        "lastModified": 1777518431,
+        "narHash": "sha256-SwgiG2T5pbyo33Vz7/vUCAhEMgwCK8Pa2nDSx5a6/WE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5de7dbd151b0bd65d45785553d4a22d832733ffc",
+        "rev": "2e54a938cdd4c8e414b2518edc3d82308027c670",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775464765,
-        "narHash": "sha256-nex6TL2x1/sVHCyDWcvl1t/dbTedb9bAGC4DLf/pmYk=",
+        "lastModified": 1777395829,
+        "narHash": "sha256-HposVFZcsBCevgqLR73w/BpSe8J1lMgw5kASnnxO3A4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "83e29f2b8791f6dec20804382fcd9a666d744c07",
+        "rev": "e75f25705c2934955ee5075e62530d74aca973c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Follow-up fixes for #467 which migrated `nvim-treesitter` to the `main` branch API. After that change the following issues showed up at runtime:

- `Failed to run \`config\` for nvim-treesitter` (`module 'nvim-treesitter.config' not found`)
- The old `auto_install = true` behaviour was gone, so opening a filetype that wasn't pre-listed never installed its parser.
- Opening snacks.nvim windows whose filetype isn't a real Tree-sitter language (e.g. `snacks_notif`) printed `[nvim-treesitter] warning: skipping unsupported language: ...`.

## Changes

- Pin the plugin spec to `branch = \"main\"` so lazy.nvim resolves the rewrite API (`nvim-treesitter.config`, `nts.install`).
- In the `FileType` autocmd, install the parser on demand via `install({ lang }):await(...)` and only then call `vim.treesitter.start()`. Restores the previous \"open file → highlight just works\" UX.
- Cache `treesitter_config.get_available()` once and bail out early in the autocmd for filetypes that aren't real Tree-sitter languages, suppressing the `snacks_notif`-style warnings without an explicit deny-list.
- Bump `flake.lock` (nixpkgs / home-manager).

## Verification

- `nix run . -- switch --flake .#linux` succeeds.
- Restarted Neovim: pre-installed parsers highlight immediately; previously-uninstalled ones build in the background on first open and start highlighting once ready.
- Opening snacks notification windows no longer emits the unsupported-language warning.