### PR TITLE
feat(direnv): enable nix-direnv and shell hooks

### DIFF
--- a/modules/misc.nix
+++ b/modules/misc.nix
@@ -21,7 +21,12 @@
     ];
 
     programs = {
-      direnv.enable = true;
+      direnv = {
+        enable = true;
+        nix-direnv.enable = true;
+        enableZshIntegration = true;
+        enableNushellIntegration = true;
+      };
       zoxide.enable = true;
     };
   };


### PR DESCRIPTION
## Summary

Wire up `nix-direnv` and shell integrations so that entering a project with a `flake.nix` (or `shell.nix`) automatically loads its dev environment via `direnv`.

## Changes

- `modules/misc.nix`: expand `programs.direnv` from a one-line enable into an attrset.
  - `nix-direnv.enable = true` for cached `use flake` evaluation.
  - `enableZshIntegration = true` so the hook fires under zsh (also used by Claude Code internally).
  - `enableNushellIntegration = true` for the interactive nushell session.

## Verification

- `nix run . -- switch --flake .#linux` succeeds.
- In a fresh nushell session, `cd` into a project with `use flake` in `.envrc` triggers `direnv: loading .envrc` and the dev shell PATH is loaded automatically; leaving the directory unloads it.
- Generated `~/.config/nushell/config.nu` contains the `pre_prompt` hook calling `direnv export json`.
