### PR TITLE
update(claude): allow wc, unblock find/grep

### DIFF
--- a/files/claude/settings.json
+++ b/files/claude/settings.json
@@ -56,6 +56,7 @@
       "Bash(git status:*)",
       "Bash(git switch:*)",
       "Bash(ls:*)",
+      "Bash(wc:*)",
       "Bash(pwd:*)",
       "Bash(rg:*)",
       "Read(~/.claude/skills/**)"
@@ -67,9 +68,7 @@
       "Read(*.envrc)",
       "Edit(*.envrc)",
       "Write(*.envrc)",
-      "Bash(find:*)",
       "Bash(git checkout:*)",
-      "Bash(grep:*)",
       "Bash(sudo:*)"
     ],
     "ask": [


### PR DESCRIPTION
## Summary

Adjust Bash permissions in `files/claude/settings.json`.

## Changes

- Allow `wc` so token/line counting runs without prompting.
- Drop `find` and `grep` from `deny` so they fall back to the default ask behavior instead of being blocked outright.
