### PR TITLE
feat: add pnpm

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777518431,
-        "narHash": "sha256-SwgiG2T5pbyo33Vz7/vUCAhEMgwCK8Pa2nDSx5a6/WE=",
+        "lastModified": 1778503501,
+        "narHash": "sha256-08L/X4/do7nET4rzidJ76eV/1r+mB7DchVpdPypsghc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2e54a938cdd4c8e414b2518edc3d82308027c670",
+        "rev": "85ba629c79449badf4338117c27f0ee92b4b9f1a",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777395829,
-        "narHash": "sha256-HposVFZcsBCevgqLR73w/BpSe8J1lMgw5kASnnxO3A4=",
+        "lastModified": 1778458615,
+        "narHash": "sha256-cY07EsdhBJ8tFXPzDYevgqxRev9ZLxFonuq9wmq5kwg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e75f25705c2934955ee5075e62530d74aca973c6",
+        "rev": "c6e5ca3c836a5f4dd9af9f2c1fc1c38f0fac988a",
         "type": "github"
       },
       "original": {

--- a/modules/node.nix
+++ b/modules/node.nix
@@ -11,5 +11,18 @@
     };
   };
 
-  home.sessionPath = [ "${config.home.homeDirectory}/.npm-global/bin" ];
+  home = {
+    packages = [
+      pkgs.pnpm
+    ];
+
+    sessionVariables = {
+      PNPM_HOME = "${config.home.homeDirectory}/.local/share/pnpm";
+    };
+
+    sessionPath = [
+      "${config.home.homeDirectory}/.npm-global/bin"
+      "${config.home.homeDirectory}/.local/share/pnpm"
+    ];
+  };
 }


### PR DESCRIPTION
## Summary

- Add `'pkgs.pnpm`' to the Node module so pnpm is available globally.
- Set `'PNPM_HOME=~/.local/share/pnpm`' and add it to `'home.sessionPath`' so `'pnpm install -g`' resolves a writable bin dir.
- Bump `'flake.lock`' (nixpkgs, home-manager) since inputs were ~2 weeks old.

## Notes

- pnpm 11 is not yet in nixpkgs; this lands 10.33.4. Will bump on next flake update once the upstream PR merges.
