### PR TITLE
Fix pnpm session path

### DIFF
--- a/modules/node.nix
+++ b/modules/node.nix
@@ -22,7 +22,7 @@
 
     sessionPath = [
       "${config.home.homeDirectory}/.npm-global/bin"
-      "${config.home.homeDirectory}/.local/share/pnpm"
+      "${config.home.homeDirectory}/.local/share/pnpm/bin"
     ];
   };
 }


### PR DESCRIPTION
## Summary

- Update the Home Manager session path to point at pnpm's bin directory.
- Ensure globally installed pnpm executables are discoverable on PATH.

## Testing

- Not run (configuration path change only).
