### PR TITLE
Introduce treefmt

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,8 +14,8 @@ env:
   CLICOLOR: 1
 
 jobs:
-  nixfmt:
-    name: nixfmt
+  treefmt:
+    name: treefmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -25,9 +25,9 @@ jobs:
             experimental-features = nix-command flakes
       - uses: nix-community/cache-nix-action@v7
         with:
-          primary-key: nix-nixfmt-${{ runner.os }}-${{ hashFiles('**/flake.lock') }}
-          restore-prefixes-first-match: nix-nixfmt-${{ runner.os }}-
-      - run: nix run nixpkgs#nixfmt -- --check $(git ls-files '*.nix')
+          primary-key: nix-treefmt-${{ runner.os }}-${{ hashFiles('**/flake.lock') }}
+          restore-prefixes-first-match: nix-treefmt-${{ runner.os }}-
+      - run: nix fmt -- --fail-on-change
 
   deadnix:
     name: deadnix
@@ -59,21 +59,6 @@ jobs:
           restore-prefixes-first-match: nix-statix-${{ runner.os }}-
       - run: nix run nixpkgs#statix -- check .
 
-  stylua:
-    name: stylua
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-      - uses: nix-community/cache-nix-action@v7
-        with:
-          primary-key: nix-stylua-${{ runner.os }}-${{ hashFiles('**/flake.lock') }}
-          restore-prefixes-first-match: nix-stylua-${{ runner.os }}-
-      - run: nix run nixpkgs#stylua -- --check files/
-
   oxlint:
     name: oxlint
     runs-on: ubuntu-latest
@@ -86,19 +71,6 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec oxlint
-
-  oxfmt:
-    name: oxfmt
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: lts/*
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm exec oxfmt --check
 
   tsc:
     name: tsc

--- a/files/claude/statusline.sh
+++ b/files/claude/statusline.sh
@@ -11,11 +11,11 @@ CYAN='\033[36m'
 RESET='\033[0m'
 
 format_k() {
-  awk -v n="$1" 'BEGIN { printf "%.1fK", n/1000 }'
+	awk -v n="$1" 'BEGIN { printf "%.1fK", n/1000 }'
 }
 
 format_tokens() {
-  awk -v n="$1" 'BEGIN {
+	awk -v n="$1" 'BEGIN {
     if (n == 1000000) { printf "1M" }
     else if (n >= 1000000) { printf "%.1fM", n/1000000 }
     else if (n >= 1000) { printf "%.0fK", n/1000 }
@@ -47,36 +47,36 @@ LINES_REMOVED=$(echo "$input" | jq -r '.cost.total_lines_removed // 0')
 
 # Git branch
 GIT_BRANCH=""
-if git rev-parse --git-dir > /dev/null 2>&1; then
-  BRANCH=$(git branch --show-current 2>/dev/null)
-  if [[ -n "$BRANCH" ]]; then
-    GIT_BRANCH="${DIM}:${RESET}${CYAN}${BRANCH}${RESET}"
-  fi
+if git rev-parse --git-dir >/dev/null 2>&1; then
+	BRANCH=$(git branch --show-current 2>/dev/null)
+	if [[ -n "$BRANCH" ]]; then
+		GIT_BRANCH="${DIM}:${RESET}${CYAN}${BRANCH}${RESET}"
+	fi
 fi
 
 # Build output
 OUTPUT="${DIM}[${RESET}${MODEL}${DIM}]${RESET} $CWD_SHORT${GIT_BRANCH}"
 
 if [[ "$TOTAL_INPUT_TOKENS" != "0" || "$TOTAL_OUTPUT_TOKENS" != "0" ]]; then
-  OUTPUT+=" ${DIM}|${RESET} ${DIM}↑${RESET}${GREEN}${INPUT_K}${RESET} ${DIM}↓${RESET}${YELLOW}${OUTPUT_K}${RESET}"
+	OUTPUT+=" ${DIM}|${RESET} ${DIM}↑${RESET}${GREEN}${INPUT_K}${RESET} ${DIM}↓${RESET}${YELLOW}${OUTPUT_K}${RESET}"
 fi
 
 if [[ "$TOTAL_USED" != "0" ]]; then
-  USED_FMT=$(format_tokens "$TOTAL_USED")
-  SIZE_FMT=$(format_tokens "$CONTEXT_SIZE")
-  # Color based on remaining context percentage
-  if awk -v r="$REMAINING" 'BEGIN { exit !(r >= 50) }'; then
-    CTX_COLOR="$GREEN"
-  elif awk -v r="$REMAINING" 'BEGIN { exit !(r >= 20) }'; then
-    CTX_COLOR="$YELLOW"
-  else
-    CTX_COLOR="$RED"
-  fi
-  OUTPUT+=" ${CTX_COLOR}${USED_FMT}/${SIZE_FMT} (${REMAINING}%)${RESET}"
+	USED_FMT=$(format_tokens "$TOTAL_USED")
+	SIZE_FMT=$(format_tokens "$CONTEXT_SIZE")
+	# Color based on remaining context percentage
+	if awk -v r="$REMAINING" 'BEGIN { exit !(r >= 50) }'; then
+		CTX_COLOR="$GREEN"
+	elif awk -v r="$REMAINING" 'BEGIN { exit !(r >= 20) }'; then
+		CTX_COLOR="$YELLOW"
+	else
+		CTX_COLOR="$RED"
+	fi
+	OUTPUT+=" ${CTX_COLOR}${USED_FMT}/${SIZE_FMT} (${REMAINING}%)${RESET}"
 fi
 
 if [[ "$LINES_ADDED" != "0" || "$LINES_REMOVED" != "0" ]]; then
-  OUTPUT+=" ${DIM}|${RESET} ${GREEN}+${LINES_ADDED}${RESET} ${RED}-${LINES_REMOVED}${RESET}"
+	OUTPUT+=" ${DIM}|${RESET} ${GREEN}+${LINES_ADDED}${RESET} ${RED}-${LINES_REMOVED}${RESET}"
 fi
 
 echo -e "$OUTPUT"

--- a/flake.lock
+++ b/flake.lock
@@ -21,6 +21,24 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -63,7 +81,7 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1778906310,
@@ -81,12 +99,28 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
         "nixvim": "nixvim"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,7 @@
       url = "github:nix-community/nixvim";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
   outputs =
@@ -18,9 +19,16 @@
       nixpkgs,
       home-manager,
       nixvim,
+      flake-utils,
       ...
     }:
     let
+      systems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
       mkPkgs =
         system:
         import nixpkgs {
@@ -32,7 +40,38 @@
             ];
         };
     in
-    {
+    flake-utils.lib.eachSystem systems (
+      system:
+      let
+        pkgs = mkPkgs system;
+        formatterPackages = [
+          pkgs.nixfmt
+          pkgs.oxfmt
+          pkgs.shfmt
+          pkgs.stylua
+          pkgs.taplo
+          pkgs.treefmt
+        ];
+        devShellPackages = formatterPackages ++ [
+          pkgs.nodejs_24
+          pkgs.pnpm
+        ];
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = devShellPackages;
+        };
+
+        formatter = pkgs.writeShellApplication {
+          name = "treefmt";
+          runtimeInputs = formatterPackages;
+          text = ''
+            exec treefmt "$@"
+          '';
+        };
+      }
+    )
+    // {
       packages = {
         inherit (home-manager.packages) x86_64-linux;
         inherit (home-manager.packages) x86_64-darwin;

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "scripts": {
-    "lint": "oxlint && oxfmt --check && tsc --noEmit",
-    "lint:fix": "oxlint --fix",
-    "format": "oxfmt"
+    "lint": "oxlint && tsc --noEmit",
+    "lint:fix": "oxlint --fix"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",
@@ -11,7 +10,6 @@
   },
   "devDependencies": {
     "@types/node": "^25.8.0",
-    "oxfmt": "^0.50.0",
     "oxlint": "^1.65.0",
     "typescript": "^6.0.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,9 +21,6 @@ importers:
       '@types/node':
         specifier: ^25.8.0
         version: 25.8.0
-      oxfmt:
-        specifier: ^0.50.0
-        version: 0.50.0
       oxlint:
         specifier: ^1.65.0
         version: 1.65.0
@@ -251,128 +248,6 @@ packages:
 
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
-
-  '@oxfmt/binding-android-arm-eabi@0.50.0':
-    resolution: {integrity: sha512-ICXQVKrDvsWUtfx6EiVJxfWrajKTwTfRV8vz2XiMkxZeuCKJLgD4YAj6dE3BWvpqDlkVkie4VSTAtMUWO9LDXg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [android]
-
-  '@oxfmt/binding-android-arm64@0.50.0':
-    resolution: {integrity: sha512-quwjLQFkuW6OwLHeDeIXsTzOmipQFQbqsYN9HLk2B5I01IlAQZHP1UiLIg0O7pP+dUgPD2AD7SCYA3gs6NH5/g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
-  '@oxfmt/binding-darwin-arm64@0.50.0':
-    resolution: {integrity: sha512-ikU5umElcMi78/TNI334wtjr5WZ5F4nWa1aIDseAKKGL0W3ygxeYKkrIJ0fggWa8MOon66BmG3xCqmX1m9YAOw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@oxfmt/binding-darwin-x64@0.50.0':
-    resolution: {integrity: sha512-WT4MOYG4mv9IXrH0m60vHsJh+rRMPSOKTQmwDpwmgQ+DuW/i5dU4pqc0HDO5uclO5vjz5IFX5z/taW86LSVe/g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@oxfmt/binding-freebsd-x64@0.50.0':
-    resolution: {integrity: sha512-gH0rycVXqV4juWkvLs2uPMtTyppDc7qEUVzXAxnQ7FpcSZNXqKowUgtjH8q67ngj416r8+4NnAlyR/D35zwwhQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@oxfmt/binding-linux-arm-gnueabihf@0.50.0':
-    resolution: {integrity: sha512-wL/k+o0hiTeRvi/gPzeC1L/yTHTXIeHDKWU09s2zTBmv7ma59wTm+fADNSGYxhJQDxyavQbwTf1QpW3Zj924tQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxfmt/binding-linux-arm-musleabihf@0.50.0':
-    resolution: {integrity: sha512-Y59FKqoUM3Gf00E395b4ixfWyJGwO2GzaZawF5MZoVWcb3f6CkWUXyao0jyOvoIxDMzMybcVRuXyG7ih/Nxweg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxfmt/binding-linux-arm64-gnu@0.50.0':
-    resolution: {integrity: sha512-OvXbfTjMignXWyJXg/NOFsiy996vFe8wb9tkxJaUq8ylq0XrzJg3ttavC5Tcmm6F8/GUs2r3XFJWWu9q/27uYw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxfmt/binding-linux-arm64-musl@0.50.0':
-    resolution: {integrity: sha512-rqmvHZm7vMa3NLYa0khwkhReCmp9tqKnF23TFZ7S5cYJLvIE4b0k8famWE7kO897/DXznJe675n5SohFBggbxA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxfmt/binding-linux-ppc64-gnu@0.50.0':
-    resolution: {integrity: sha512-49bAdYbMSde42tzPDtuHnBWzOgmoS0PT9THCjvMnDVYMQYiHzPc2Mv5rkpBHVQOXM+PHfafJlxgK0anXSWBVvw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxfmt/binding-linux-riscv64-gnu@0.50.0':
-    resolution: {integrity: sha512-VFT25/6kckkIM62KeWB2bi+xCEmC/zC+DcMaIpEfaio8ulkGDLSiTz11TyK0eqgTl3x5OklYEGDWohvAgOr8Bw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxfmt/binding-linux-riscv64-musl@0.50.0':
-    resolution: {integrity: sha512-BBJMuNy6jjkXjUUINF5UTQqb/nvjmtJad43Gp7bab0AAURAdthhJvduR7rHpWInpWYiaMzYsdrmURNcrmpxdZA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxfmt/binding-linux-s390x-gnu@0.50.0':
-    resolution: {integrity: sha512-Xd4y+yjAYHKmryXhyUUwbyRD01iKfcvI74iE01L6p4F8SwjhZQXDshK+T8PcrPZLiFqH263P5xqJk94amjkjzQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxfmt/binding-linux-x64-gnu@0.50.0':
-    resolution: {integrity: sha512-Qp96rYJru7l++7mk4R+eh8qq9GFfFAMdmoN6VGoRHI8AA1XMnUIzH4u+zOcKZZwY+irHdsaBldDearwB4nOH7A==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxfmt/binding-linux-x64-musl@0.50.0':
-    resolution: {integrity: sha512-5XLGp+yd5w2Key5LMqJO+X3XVsJKgeeUKljy32+MBF/J/JZ5m8WHl6dI5eOQOr3ixopxPiXIyDAxn3slI3UXiQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxfmt/binding-openharmony-arm64@0.50.0':
-    resolution: {integrity: sha512-QAxwzh7+GHugCD7WuERolVs8TKQwXNIAZXAHHTecbKVc9oWBkWzOiLauQuezXS57tVcof5zhi1IjZ8tOV0htTg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@oxfmt/binding-win32-arm64-msvc@0.50.0':
-    resolution: {integrity: sha512-3nKN/kqClm9iCFWTwtJ9UpR5SGyExp5l3nw6uIiBt+3XitQtszin+vjHrL7JHfDksZ7Svigdaow2zqz/IKCfqw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@oxfmt/binding-win32-ia32-msvc@0.50.0':
-    resolution: {integrity: sha512-3r6XZ8+X6qlLbXaPW2NygfiAWSpKbkE36pAVzS83mY+cYY+pSMalJ+qnCgkr92tr+Iqv988XKQ1CpARTg9ITbQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ia32]
-    os: [win32]
-
-  '@oxfmt/binding-win32-x64-msvc@0.50.0':
-    resolution: {integrity: sha512-BSE8D8KsvquMG9vU+Qt4qGuoOcZ36rxU5S6ZkHNguj+MlWkXWCBETnno3yJ9CfWvfCrbmieaN9LK6hdcdHNZ/w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
 
   '@oxlint/binding-android-arm-eabi@1.65.0':
     resolution: {integrity: sha512-jDVaGNURT5pEA9qcabh6WusIoBNybOMMDPCx+EFt+gxo6rVvoUf0+73Xy5x81+ZrxU+ewk5uRBYifjy5pgkcnA==}
@@ -909,16 +784,6 @@ packages:
       zod:
         optional: true
 
-  oxfmt@0.50.0:
-    resolution: {integrity: sha512-owwjTnhfM5aCOJhYeqDvk7iM504OeYFZpdRU7cxx7xtZMo4uVpjlryTUon+Cf76CugsvnqA32e6rC73pr1hXaw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      svelte: ^5.0.0
-    peerDependenciesMeta:
-      svelte:
-        optional: true
-
   oxlint@1.65.0:
     resolution: {integrity: sha512-ChUuE3Q7XnAbscvT4XLMsH7HFJmLgLVv9lu+RRgFL5wSXnDqUOzTp5IS8qWDBGd/ZDSzQ2tbX8fjAmijlGLC7A==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1044,10 +909,6 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
-
-  tinypool@2.1.0:
-    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
-    engines: {node: ^20.0.0 || >=22.0.0}
 
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
@@ -1528,63 +1389,6 @@ snapshots:
 
   '@nodable/entities@2.1.0': {}
 
-  '@oxfmt/binding-android-arm-eabi@0.50.0':
-    optional: true
-
-  '@oxfmt/binding-android-arm64@0.50.0':
-    optional: true
-
-  '@oxfmt/binding-darwin-arm64@0.50.0':
-    optional: true
-
-  '@oxfmt/binding-darwin-x64@0.50.0':
-    optional: true
-
-  '@oxfmt/binding-freebsd-x64@0.50.0':
-    optional: true
-
-  '@oxfmt/binding-linux-arm-gnueabihf@0.50.0':
-    optional: true
-
-  '@oxfmt/binding-linux-arm-musleabihf@0.50.0':
-    optional: true
-
-  '@oxfmt/binding-linux-arm64-gnu@0.50.0':
-    optional: true
-
-  '@oxfmt/binding-linux-arm64-musl@0.50.0':
-    optional: true
-
-  '@oxfmt/binding-linux-ppc64-gnu@0.50.0':
-    optional: true
-
-  '@oxfmt/binding-linux-riscv64-gnu@0.50.0':
-    optional: true
-
-  '@oxfmt/binding-linux-riscv64-musl@0.50.0':
-    optional: true
-
-  '@oxfmt/binding-linux-s390x-gnu@0.50.0':
-    optional: true
-
-  '@oxfmt/binding-linux-x64-gnu@0.50.0':
-    optional: true
-
-  '@oxfmt/binding-linux-x64-musl@0.50.0':
-    optional: true
-
-  '@oxfmt/binding-openharmony-arm64@0.50.0':
-    optional: true
-
-  '@oxfmt/binding-win32-arm64-msvc@0.50.0':
-    optional: true
-
-  '@oxfmt/binding-win32-ia32-msvc@0.50.0':
-    optional: true
-
-  '@oxfmt/binding-win32-x64-msvc@0.50.0':
-    optional: true
-
   '@oxlint/binding-android-arm-eabi@1.65.0':
     optional: true
 
@@ -2046,30 +1850,6 @@ snapshots:
       ws: 8.20.1
       zod: 4.4.3
 
-  oxfmt@0.50.0:
-    dependencies:
-      tinypool: 2.1.0
-    optionalDependencies:
-      '@oxfmt/binding-android-arm-eabi': 0.50.0
-      '@oxfmt/binding-android-arm64': 0.50.0
-      '@oxfmt/binding-darwin-arm64': 0.50.0
-      '@oxfmt/binding-darwin-x64': 0.50.0
-      '@oxfmt/binding-freebsd-x64': 0.50.0
-      '@oxfmt/binding-linux-arm-gnueabihf': 0.50.0
-      '@oxfmt/binding-linux-arm-musleabihf': 0.50.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.50.0
-      '@oxfmt/binding-linux-arm64-musl': 0.50.0
-      '@oxfmt/binding-linux-ppc64-gnu': 0.50.0
-      '@oxfmt/binding-linux-riscv64-gnu': 0.50.0
-      '@oxfmt/binding-linux-riscv64-musl': 0.50.0
-      '@oxfmt/binding-linux-s390x-gnu': 0.50.0
-      '@oxfmt/binding-linux-x64-gnu': 0.50.0
-      '@oxfmt/binding-linux-x64-musl': 0.50.0
-      '@oxfmt/binding-openharmony-arm64': 0.50.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.50.0
-      '@oxfmt/binding-win32-ia32-msvc': 0.50.0
-      '@oxfmt/binding-win32-x64-msvc': 0.50.0
-
   oxlint@1.65.0:
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.65.0
@@ -2234,8 +2014,6 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
-
-  tinypool@2.1.0: {}
 
   token-types@6.1.2:
     dependencies:

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -1,0 +1,25 @@
+[global]
+excludes = ["*.lock", "node_modules/**"]
+
+[formatter.nix]
+command = "nixfmt"
+includes = ["*.nix"]
+
+[formatter.oxfmt]
+command = "oxfmt"
+options = ["--no-error-on-unmatched-pattern"]
+includes = ["*.js", "*.jsx", "*.ts", "*.tsx", "*.json", "*.jsonc"]
+
+[formatter.sh]
+command = "shfmt"
+options = ["-w"]
+includes = ["*.sh"]
+
+[formatter.stylua]
+command = "stylua"
+includes = ["*.lua"]
+
+[formatter.toml]
+command = "taplo"
+options = ["format"]
+includes = ["*.toml"]

--- a/typos.toml
+++ b/typos.toml
@@ -1,7 +1,5 @@
 [files]
-extend-exclude = [
-  ".git/",
-]
+extend-exclude = [".git/"]
 ignore-hidden = false
 
 [default.extend-words]


### PR DESCRIPTION

## Summary

- add treefmt configuration and expose it through the flake formatter
- keep formatter tooling scoped to the project instead of Home Manager globals
- update lint workflow to use `nix fmt -- --fail-on-change`
- remove oxfmt from pnpm devDependencies and keep pnpm scripts focused on lint/typecheck

## Verification

- `nix fmt -- --fail-on-change`
- `nix develop -c pnpm lint`
