### PR TITLE
Skip Nix build when Nix files are unchanged

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -100,7 +100,7 @@ jobs:
         env:
           RESULTS: ${{ join(needs.*.result, ',') }}
         run: |
-          if [[ "$RESULTS" == *failure* || "$RESULTS" == *cancelled* || "$RESULTS" == *skipped* ]]; then
-            echo "One or more jobs did not pass: $RESULTS"
+          if [[ "$RESULTS" == *failure* || "$RESULTS" == *cancelled* ]]; then
+            echo "One or more jobs failed or were cancelled: $RESULTS"
             exit 1
           fi

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -2,6 +2,7 @@ name: Nix Build
 
 permissions:
   contents: read
+  pull-requests: read
 
 on:
   - pull_request
@@ -14,9 +15,27 @@ env:
   CLICOLOR: 1
 
 jobs:
+  changes:
+    name: Detect Nix changes
+    runs-on: ubuntu-latest
+    outputs:
+      nix: ${{ steps.filter.outputs.nix }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            nix:
+              - 'flake.lock'
+              - '**/*.nix'
+
   home-manager-activation-package:
     name: home-manager activationPackage (${{ matrix.config }})
     runs-on: ${{ matrix.os }}
+    needs:
+      - changes
+    if: ${{ needs.changes.outputs.nix == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -39,6 +58,7 @@ jobs:
     name: All Nix Build Passed
     runs-on: ubuntu-latest
     needs:
+      - changes
       - home-manager-activation-package
     if: ${{ always() }}
     steps:
@@ -46,7 +66,7 @@ jobs:
         env:
           RESULTS: ${{ join(needs.*.result, ',') }}
         run: |
-          if [[ "$RESULTS" == *failure* || "$RESULTS" == *cancelled* || "$RESULTS" == *skipped* ]]; then
-            echo "One or more jobs did not pass: $RESULTS"
+          if [[ "$RESULTS" == *failure* || "$RESULTS" == *cancelled* ]]; then
+            echo "One or more jobs failed or were cancelled: $RESULTS"
             exit 1
           fi

--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779075347,
-        "narHash": "sha256-ZqttlFPw0meQMdABi8/vgle14OWQ3FkIqUkb4/Mrc+0=",
+        "lastModified": 1779143091,
+        "narHash": "sha256-qxiUVquHM09KOV1aD4We9q0ooPWO4qOc0v9J9NDWSAo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "08c9d01457badce151aa4a983c475042d9dec018",
+        "rev": "736c2084ea750a049ecdbdd7ff5817d2eeeef444",
         "type": "github"
       },
       "original": {
@@ -84,11 +84,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1779023681,
-        "narHash": "sha256-K7RLGyiK3J6wHr/JDxXdlGF0+0DEsdBf1w9mXjSyL8I=",
+        "lastModified": 1779142999,
+        "narHash": "sha256-KcXaaS7489oPtzW51a7bKSsMeeF4yDjs9GWQ4qA9i4k=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "0d05726bfb060f6559f6d64c1d427f3663dba178",
+        "rev": "9b28a7e6e3e6f61b114a550941abfc9fce0645cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION

## Summary

- add a path filter for Nix-related changes in the Nix Build workflow
- skip the Home Manager activationPackage build when `flake.lock` and `**/*.nix` are unchanged
- allow aggregate check jobs to pass when dependent jobs are skipped

## Background

The Nix build check is expensive, so this avoids running it for PRs that do not touch Nix inputs or configuration files.
