### PR TITLE
Delay Renovate npm updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,12 @@
       "matchManagers": [
         "npm"
       ],
+      "minimumReleaseAge": "1 day"
+    },
+    {
+      "matchManagers": [
+        "npm"
+      ],
       "matchFileNames": [
         "pnpm-lock.yaml"
       ],


### PR DESCRIPTION

## Summary

- Add a Renovate package rule for npm-managed dependencies.
- Require a 1 day minimum release age before npm updates are proposed.

## Background

This gives npm releases a short stabilization window before Renovate opens update PRs.
