### PR TITLE
ci: filter lint jobs by changed files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,7 @@ name: Lint
 
 permissions:
   contents: read
+  pull-requests: read
 
 on:
   - pull_request
@@ -14,9 +15,46 @@ env:
   CLICOLOR: 1
 
 jobs:
+  changes:
+    name: Detect lint changes
+    runs-on: ubuntu-latest
+    outputs:
+      fmt: ${{ steps.filter.outputs.fmt }}
+      nix: ${{ steps.filter.outputs.nix }}
+      node: ${{ steps.filter.outputs.node }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            fmt:
+              - 'treefmt.toml'
+              - '.oxfmtrc.json'
+              - 'stylua.toml'
+              - '**/*.nix'
+              - '**/*.ts'
+              - '**/*.json'
+              - '**/*.sh'
+              - '**/*.lua'
+              - '**/*.toml'
+            nix:
+              - 'flake.lock'
+              - '**/*.nix'
+            node:
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'tsconfig.json'
+              - '.oxlintrc.json'
+              - '**/*.ts'
+
   treefmt:
     name: treefmt
     runs-on: ubuntu-latest
+    needs:
+      - changes
+    if: ${{ needs.changes.outputs.fmt == 'true' }}
     steps:
       - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
@@ -32,6 +70,9 @@ jobs:
   deadnix:
     name: deadnix
     runs-on: ubuntu-latest
+    needs:
+      - changes
+    if: ${{ needs.changes.outputs.nix == 'true' }}
     steps:
       - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
@@ -47,6 +88,9 @@ jobs:
   statix:
     name: statix
     runs-on: ubuntu-latest
+    needs:
+      - changes
+    if: ${{ needs.changes.outputs.nix == 'true' }}
     steps:
       - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
@@ -62,6 +106,9 @@ jobs:
   oxlint:
     name: oxlint
     runs-on: ubuntu-latest
+    needs:
+      - changes
+    if: ${{ needs.changes.outputs.node == 'true' }}
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
@@ -75,6 +122,9 @@ jobs:
   tsc:
     name: tsc
     runs-on: ubuntu-latest
+    needs:
+      - changes
+    if: ${{ needs.changes.outputs.node == 'true' }}
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -3,12 +3,11 @@
   "tabWidth": 2,
   "printWidth": 80,
   "singleQuote": false,
-  "jsxSingleQuote": false,
   "quoteProps": "as-needed",
   "trailingComma": "all",
   "semi": true,
   "arrowParens": "always",
   "bracketSameLine": false,
   "bracketSpacing": true,
-  "ignorePatterns": ["*", "!*/", "!*.ts", "!*.tsx"]
+  "ignorePatterns": ["*", "!*/", "!*.ts"]
 }

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -8,7 +8,7 @@ includes = ["*.nix"]
 [formatter.oxfmt]
 command = "oxfmt"
 options = ["--no-error-on-unmatched-pattern"]
-includes = ["*.js", "*.jsx", "*.ts", "*.tsx", "*.json", "*.jsonc"]
+includes = ["*.ts", "*.json"]
 
 [formatter.sh]
 command = "shfmt"


### PR DESCRIPTION

## Summary

- Add a paths-filter step to the lint workflow.
- Run treefmt, Nix lint, and TypeScript lint jobs only when relevant files change.
- Align formatter config with the file types that exist in this repository.

## Notes

- JSON config syntax was checked with Node.
