### PR TITLE
Add Nix LSP to Neovim

### DIFF
--- a/modules/neovim/lsp/default.nix
+++ b/modules/neovim/lsp/default.nix
@@ -13,6 +13,7 @@ in
     ./copilot.nix
     ./gopls.nix
     ./lua-ls.nix
+    ./nil-ls.nix
     ./typos-lsp.nix
     ./vtsls.nix
   ];

--- a/modules/neovim/lsp/nil-ls.nix
+++ b/modules/neovim/lsp/nil-ls.nix
@@ -1,0 +1,8 @@
+{ pkgs, ... }:
+
+{
+  programs.nixvim.lsp.servers.nil_ls = {
+    enable = true;
+    config.settings.nil.formatting.command = [ "${pkgs.nixfmt}/bin/nixfmt" ];
+  };
+}


### PR DESCRIPTION
## Summary

- Enable the nil Nix language server in the Nixvim LSP configuration.
- Add a dedicated nil_ls module and use nixfmt for Nix formatting.

## Validation

- Ran `nix run . -- switch --flake .#macos` successfully.