### PR TITLE
Refine Renovate GitHub Actions updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "automerge": true,
   "automergeType": "pr",

--- a/renovate.json
+++ b/renovate.json
@@ -41,6 +41,12 @@
     },
     {
       "matchManagers": [
+        "github-actions"
+      ],
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "matchManagers": [
         "npm"
       ],
       "matchFileNames": [


### PR DESCRIPTION

## Summary

- configure Renovate to pin GitHub Actions digests to semver references
- add a 3-day minimum release age for GitHub Actions updates
- keep action updates more stable while retaining digest pinning
