### PR TITLE
Add Lua language server CI check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,7 @@ jobs:
       fmt: ${{ steps.filter.outputs.fmt }}
       nix: ${{ steps.filter.outputs.nix }}
       node: ${{ steps.filter.outputs.node }}
+      lua: ${{ steps.filter.outputs.lua }}
       actions: ${{ steps.filter.outputs.actions }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -51,6 +52,9 @@ jobs:
               - 'tsconfig.json'
               - '.oxlintrc.json'
               - '**/*.ts'
+            lua:
+              - '.luarc.json'
+              - '**/*.lua'
             actions:
               - '.github/workflows/**'
               - '.github/actions/**'
@@ -151,6 +155,37 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec tsc --noEmit
 
+  lua-language-server:
+    name: lua-language-server
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+    if: ${{ needs.changes.outputs.lua == 'true' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
+        with:
+          primary-key: nix-lua-language-server-${{ runner.os }}-${{ hashFiles('**/flake.lock') }}
+          restore-prefixes-first-match: nix-lua-language-server-${{ runner.os }}-
+      - name: Run lua-language-server --check
+        run: |
+          nix run nixpkgs#lua-language-server -- \
+            --check . \
+            --logpath "$PWD/.lua-ls" \
+            --checklevel Warning
+          if [ -f "$PWD/.lua-ls/check.json" ]; then
+            echo '::group::check.json'
+            cat "$PWD/.lua-ls/check.json"
+            echo '::endgroup::'
+            exit 1
+          fi
+
   actionlint:
     name: actionlint
     runs-on: ubuntu-latest
@@ -202,6 +237,7 @@ jobs:
       - statix
       - oxlint
       - tsc
+      - lua-language-server
       - actionlint
       - zizmor
     if: ${{ always() }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .direnv/
 .pnpm-store/
+.lua-ls/

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+  "runtime.version": "LuaJIT",
+  "diagnostics.globals": ["vim"],
+  "workspace.library": ["${3rd}/luv/library"],
+  "workspace.checkThirdParty": false,
+  "telemetry.enable": false
+}


### PR DESCRIPTION

## Summary

- Add a LuaLS configuration for repository Lua checks.
- Run `lua-language-server --check` in the lint workflow when Lua-related files change.
- Ignore the LuaLS log output directory.

## Background

This adds CI coverage for Lua files and Neovim-style Lua globals while keeping the check scoped to Lua-related changes.
