### PR TITLE
Switch TypeScript check to tsgo

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -135,8 +135,8 @@ jobs:
           restore-prefixes-first-match: nix-oxlint-${{ runner.os }}-
       - run: nix build .#checks.x86_64-linux.oxlint
 
-  tsc:
-    name: tsc
+  tsgo:
+    name: tsgo
     runs-on: ubuntu-latest
     needs:
       - changes
@@ -151,7 +151,7 @@ jobs:
           node-version: lts/*
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm exec tsc --noEmit
+      - run: pnpm exec tsgo --noEmit
 
   actionlint:
     name: actionlint
@@ -203,7 +203,7 @@ jobs:
       - deadnix
       - statix
       - oxlint
-      - tsc
+      - tsgo
       - actionlint
       - zizmor
     if: ${{ always() }}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -27,6 +27,7 @@
     "eslint/require-unicode-regexp": "warn",
     "no-duplicate-imports": ["error", { "allowSeparateTypeImports": true }],
     "import/no-cycle": "error",
+    "import/extensions": ["error", "never"],
     "sort-imports": ["warn", { "ignoreDeclarationSort": true }]
   },
   "env": {

--- a/files/pi/agent/extensions/mode.ts
+++ b/files/pi/agent/extensions/mode.ts
@@ -10,8 +10,8 @@ import {
 	SettingsManager,
 	type WriteToolInput,
 } from "@earendil-works/pi-coding-agent";
-import { type ColorName, catppuccin, fg } from "./lib/theme.js";
-import { type ModeName, policyRegistry } from "./tools/lib/policy.js";
+import { type ColorName, catppuccin, fg } from "./lib/theme";
+import { type ModeName, policyRegistry } from "./tools/lib/policy";
 
 function block(reason: string): { block: true; reason: string } {
 	return { block: true, reason };

--- a/files/pi/agent/extensions/status-bar.ts
+++ b/files/pi/agent/extensions/status-bar.ts
@@ -10,8 +10,8 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import type { Component, TUI } from "@earendil-works/pi-tui";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
-import type { Color } from "./lib/theme.js";
-import { catppuccin, fg } from "./lib/theme.js";
+import type { Color } from "./lib/theme";
+import { catppuccin, fg } from "./lib/theme";
 
 type RequestRender = () => void;
 type FooterFactory = NonNullable<

--- a/files/pi/agent/extensions/tools/index.ts
+++ b/files/pi/agent/extensions/tools/index.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import mvTool from "./mv.js";
-import rmTool from "./rm.js";
+import mvTool from "./mv";
+import rmTool from "./rm";
 
 export default function tools(pi: ExtensionAPI): void {
 	mvTool(pi);

--- a/files/pi/agent/extensions/tools/lib/args.ts
+++ b/files/pi/agent/extensions/tools/lib/args.ts
@@ -1,4 +1,4 @@
-import { ToolError } from "./errors.js";
+import { ToolError } from "./errors";
 
 export function normalizeStringOrArray(value: unknown): string[] {
 	if (typeof value === "string") return [value];

--- a/files/pi/agent/extensions/tools/lib/fs-guard.ts
+++ b/files/pi/agent/extensions/tools/lib/fs-guard.ts
@@ -2,7 +2,7 @@ import { execFile } from "node:child_process";
 import { lstat, readdir } from "node:fs/promises";
 import { dirname, relative, resolve, sep } from "node:path";
 import { promisify } from "node:util";
-import { ToolError, isErrnoCode } from "./errors.js";
+import { ToolError, isErrnoCode } from "./errors";
 
 type IgnoreCache = Map<string, boolean>;
 

--- a/files/pi/agent/extensions/tools/lib/policy.ts
+++ b/files/pi/agent/extensions/tools/lib/policy.ts
@@ -1,5 +1,5 @@
 import type { ToolCallEvent } from "@earendil-works/pi-coding-agent";
-import { isSecretPath } from "./secrets.js";
+import { isSecretPath } from "./secrets";
 
 export type ModeName = "read" | "write" | "yolo";
 

--- a/files/pi/agent/extensions/tools/mv.ts
+++ b/files/pi/agent/extensions/tools/mv.ts
@@ -3,17 +3,17 @@ import { access, lstat, rename } from "node:fs/promises";
 import { basename, resolve } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { type Static, Type } from "typebox";
-import { checkAbort, normalizeStringOrArray } from "./lib/args.js";
-import { ToolError, isErrnoCode } from "./lib/errors.js";
+import { checkAbort, normalizeStringOrArray } from "./lib/args";
+import { ToolError, isErrnoCode } from "./lib/errors";
 import {
 	assertNoIgnoredDescendants,
 	assertRepoPathAllowed,
 	createFsGuardContext,
 	displayRepoPath,
 	resolveRepoPath,
-} from "./lib/fs-guard.js";
-import { policyRegistry } from "./lib/policy.js";
-import { renderToolHeader } from "./lib/render.js";
+} from "./lib/fs-guard";
+import { policyRegistry } from "./lib/policy";
+import { renderToolHeader } from "./lib/render";
 
 const OPERATION = "Moving";
 const OPERATION_TO = "Moving to";

--- a/files/pi/agent/extensions/tools/rm.ts
+++ b/files/pi/agent/extensions/tools/rm.ts
@@ -1,16 +1,16 @@
 import { rm as remove } from "node:fs/promises";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { type Static, Type } from "typebox";
-import { checkAbort, normalizeStringOrArray } from "./lib/args.js";
-import { ToolError } from "./lib/errors.js";
+import { checkAbort, normalizeStringOrArray } from "./lib/args";
+import { ToolError } from "./lib/errors";
 import {
 	assertNoIgnoredDescendants,
 	createFsGuardContext,
 	displayRepoPath,
 	resolveRepoPath,
-} from "./lib/fs-guard.js";
-import { policyRegistry } from "./lib/policy.js";
-import { renderToolHeader } from "./lib/render.js";
+} from "./lib/fs-guard";
+import { policyRegistry } from "./lib/policy";
+import { renderToolHeader } from "./lib/render";
 
 const OPERATION = "Removing";
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "lint": "tsc --noEmit"
+    "lint": "tsgo --noEmit"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.9.1",
-    "typescript": "^6.0.3"
+    "@typescript/native-preview": "7.0.0-dev.20260522.1"
   },
   "packageManager": "pnpm@11.2.1"
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.9.1",
-    "@typescript/native-preview": "7.0.0-dev.20260522.1"
+    "@typescript/native-preview": "7.0.0-dev.20260521.1"
   },
   "packageManager": "pnpm@11.2.1"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: ^25.9.1
         version: 25.9.1
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260522.1
-        version: 7.0.0-dev.20260522.1
+        specifier: 7.0.0-dev.20260521.1
+        version: 7.0.0-dev.20260521.1
 
 packages:
 
@@ -320,50 +320,50 @@ packages:
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260522.1':
-    resolution: {integrity: sha512-kp2JX8wSCQ5i8f5Zr30t9TdAIEw8s3MCvT1zEe6PJAHU7aUHTnRCM+oAHEM8QxM29VD/PxR6b5dVKxHtX7Ny/A==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260521.1':
+    resolution: {integrity: sha512-DfwzV0Qc8VDHqQXG4uc0+bbHB23u/Twrl+D7H1Izo16MmwBse3kjdKAKCJDqeboYvofx/AetKZP9yo+VxjvOWg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260522.1':
-    resolution: {integrity: sha512-jX89E/hV/r0fOcP4+JWdKSugJXmWbOO74aC5a1U8+U7TBD1TTfK50Da+BL8Sf2Xud2ybqQ+2FUHAlBsLTC743g==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260521.1':
+    resolution: {integrity: sha512-tTtyAkx7VUgfRa+DGJa1/nR40/LsdbA5EUlSTnGV/3I6la7JB5hJxhWz+B99WjHjJbZrMrLxf6S4YHTj13GWew==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260522.1':
-    resolution: {integrity: sha512-XFLpJNscLKqT6LLSBrv78DzLdzwFYOePeluRBF616KUPEcfiXliTan1YuHQh4m9i9o6tvW/NnuAPlr/Q8DObsg==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260521.1':
+    resolution: {integrity: sha512-IMyER6SquHD/0rr7727rqTILbY7XWATFp/O1l9CRAEs9E0OY0yPmyHXFT8MYja5m4+isgsMBh618zLt8Ex1h/w==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260522.1':
-    resolution: {integrity: sha512-vItWfPtZfUQLaVJe0iClfsKSDtkUCUTp2LfEXBHqBCdWhoE3irg7Ivs41l3sp4zXlTio5SUvMzvO8/Mc2SImzA==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260521.1':
+    resolution: {integrity: sha512-R+KzxOA6M6AX4p757xNBy8bZgNTXUxjQkEnJk2UzDpB317pwBbrpOaOaIlgB6Giw79jvKH2E428VWhXAk4ydlw==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260522.1':
-    resolution: {integrity: sha512-r5wkbqL+qpI3QN3GiF0dg5A0PD5x9cfYSSCD744+Ov35P8inuJSySjR44gdoOF3IcFTupPEc/4q4to/gId1kZQ==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260521.1':
+    resolution: {integrity: sha512-xLfDu7chsn0TJagd2oX2Z4nj3m/TRiwQmijGUgF8O0+IblKgbQcp6Egjd9VCRsGwfPidoLgElVrfcAkYfUSnGA==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260522.1':
-    resolution: {integrity: sha512-Xtqw0dfE35WISVqN2J9hp21N6l5MT21DSgJ4w/cXisDZlaeT0Vq57CgUWUbLT4CEw5gs0QK6kmUFOSAP7Dga6Q==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260521.1':
+    resolution: {integrity: sha512-+kcewCXj0A0bpJOx/BVjjcTs8vglcxfYuZdzyQl8O9vM1GoA7LF+jUf5Z7E2qlpKt5By/8c7wXp+4/ACM9drzQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260522.1':
-    resolution: {integrity: sha512-CBTpf7skuTNgHzjwEbw3ujU76r/u9asENXc9xQmgj6qCJ1+ZHn34MMzolkUegwtHWfuem38ayYTJOMn2dmNQ5g==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260521.1':
+    resolution: {integrity: sha512-Uh2PjzN3S/TGTDERgaT4O5rexiWO0nn0oXdCnBVyo0d1rbgDxq/zxsSOZdzdrQn6BRGa8x+6fVtrVFcIw4B+7w==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260522.1':
-    resolution: {integrity: sha512-NgnE3PE3/nr4Qr8p1uCIkaM5YmNa8hQGhzb8Olb6w09aocg4Wq8bjrFHe4qZH2kgV+Hl4gGXRNb9ww1P2fwc9Q==}
+  '@typescript/native-preview@7.0.0-dev.20260521.1':
+    resolution: {integrity: sha512-JhaYbA+BVmHfya8h4QA1HsX6EZr7qaLOoOOHEwwR1ps42wN8LFDSSTbf1y2nPO3h927yh2Udl7gto1u7WGXjAQ==}
     engines: {node: '>=16.20.0'}
     hasBin: true
 
@@ -1103,36 +1103,36 @@ snapshots:
 
   '@types/retry@0.12.0': {}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260522.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260521.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260522.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260521.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260522.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260521.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260522.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260521.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260522.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260521.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260522.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260521.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260522.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260521.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260522.1':
+  '@typescript/native-preview@7.0.0-dev.20260521.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260522.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260522.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260522.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260522.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260522.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260522.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260522.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260521.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260521.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260521.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260521.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260521.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260521.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260521.1
 
   agent-base@7.1.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,9 +24,9 @@ importers:
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
-      typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260522.1
+        version: 7.0.0-dev.20260522.1
 
 packages:
 
@@ -320,6 +320,53 @@ packages:
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-kp2JX8wSCQ5i8f5Zr30t9TdAIEw8s3MCvT1zEe6PJAHU7aUHTnRCM+oAHEM8QxM29VD/PxR6b5dVKxHtX7Ny/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-jX89E/hV/r0fOcP4+JWdKSugJXmWbOO74aC5a1U8+U7TBD1TTfK50Da+BL8Sf2Xud2ybqQ+2FUHAlBsLTC743g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-XFLpJNscLKqT6LLSBrv78DzLdzwFYOePeluRBF616KUPEcfiXliTan1YuHQh4m9i9o6tvW/NnuAPlr/Q8DObsg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-vItWfPtZfUQLaVJe0iClfsKSDtkUCUTp2LfEXBHqBCdWhoE3irg7Ivs41l3sp4zXlTio5SUvMzvO8/Mc2SImzA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-r5wkbqL+qpI3QN3GiF0dg5A0PD5x9cfYSSCD744+Ov35P8inuJSySjR44gdoOF3IcFTupPEc/4q4to/gId1kZQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-Xtqw0dfE35WISVqN2J9hp21N6l5MT21DSgJ4w/cXisDZlaeT0Vq57CgUWUbLT4CEw5gs0QK6kmUFOSAP7Dga6Q==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-CBTpf7skuTNgHzjwEbw3ujU76r/u9asENXc9xQmgj6qCJ1+ZHn34MMzolkUegwtHWfuem38ayYTJOMn2dmNQ5g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-NgnE3PE3/nr4Qr8p1uCIkaM5YmNa8hQGhzb8Olb6w09aocg4Wq8bjrFHe4qZH2kgV+Hl4gGXRNb9ww1P2fwc9Q==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -562,11 +609,6 @@ packages:
 
   typebox@1.1.38:
     resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
-
-  typescript@6.0.3:
-    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
@@ -1061,6 +1103,37 @@ snapshots:
 
   '@types/retry@0.12.0': {}
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260522.1':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260522.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260522.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260522.1':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260522.1':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260522.1':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260522.1':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260522.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260522.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260522.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260522.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260522.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260522.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260522.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260522.1
+
   agent-base@7.1.4: {}
 
   balanced-match@4.0.4: {}
@@ -1293,8 +1366,6 @@ snapshots:
   tslib@2.8.1: {}
 
   typebox@1.1.38: {}
-
-  typescript@6.0.3: {}
 
   undici-types@7.24.6: {}
 


### PR DESCRIPTION

## Summary

- Replace the TypeScript check with tsgo from @typescript/native-preview
- Update the GitHub Actions lint job and aggregate status to use tsgo
- Remove .js suffixes from local TypeScript imports and enforce extensionless imports in oxlint

## Tests

- pnpm lint
