### PR TITLE
Show effort level in Claude statusline

### DIFF
--- a/files/claude/statusline.sh
+++ b/files/claude/statusline.sh
@@ -24,6 +24,7 @@ format_tokens() {
 }
 
 MODEL=$(echo "$input" | jq -r '.model.display_name // "Unknown"')
+EFFORT=$(echo "$input" | jq -r '.effort.level // empty')
 CWD=$(echo "$input" | jq -r '.workspace.current_dir // "."')
 CWD_SHORT="${CWD##*/}"
 
@@ -55,7 +56,11 @@ if git rev-parse --git-dir >/dev/null 2>&1; then
 fi
 
 # Build output
-OUTPUT="${DIM}[${RESET}${MODEL}${DIM}]${RESET} $CWD_SHORT${GIT_BRANCH}"
+MODEL_DISPLAY="${MODEL}"
+if [[ -n "$EFFORT" ]]; then
+	MODEL_DISPLAY+="${DIM}:${RESET}${EFFORT}"
+fi
+OUTPUT="${MODEL_DISPLAY} ${DIM}|${RESET} $CWD_SHORT${GIT_BRANCH}"
 
 if [[ "$TOTAL_INPUT_TOKENS" != "0" || "$TOTAL_OUTPUT_TOKENS" != "0" ]]; then
 	OUTPUT+=" ${DIM}|${RESET} ${DIM}↑${RESET}${GREEN}${INPUT_K}${RESET} ${DIM}↓${RESET}${YELLOW}${OUTPUT_K}${RESET}"


### PR DESCRIPTION
## Summary

- Display the reasoning effort level (e.g. `low` / `high` / `max`) next to the model name in the Claude Code statusline.
- The effort segment is omitted when the active model does not expose `.effort.level`, so older models stay clean.
- Drop the `[...]` brackets around the model name and add a pipe separator between the model and the cwd to keep visual rhythm consistent with the rest of the bar.

## Before / After

```
# Before
[Opus 4.7] dotfiles:main | ↑1.2K ↓0.6K 50K/1M (95.0%) | +12 -3

# After
Opus 4.7:high | dotfiles:main | ↑1.2K ↓0.6K 50K/1M (95.0%) | +12 -3
```

## Notes

- Source for the new field: `.effort.level` from the statusline JSON input ([Claude Code docs](https://docs.claude.com/en/docs/claude-code/statusline)).
- Uses `// empty` (not a default like `medium`) so models that do not surface effort do not show a misleading value.
