### PR TITLE
Bump Home Manager stateVersion to 26.11

### DIFF
--- a/modules/recipes/default.nix
+++ b/modules/recipes/default.nix
@@ -3,7 +3,7 @@
 {
   xdg.enable = true;
   home = {
-    stateVersion = "24.11";
+    stateVersion = "26.11";
 
     sessionVariables = {
       NIX_CONFIG = "extra-experimental-features = nix-command flakes";


### PR DESCRIPTION

## Summary

- Bump the shared Home Manager stateVersion to 26.11.

## Status

- Pending until the unstable channel update includes support for this stateVersion.

## Testing

- Not run (configuration-only change).
