### PR TITLE
Disable Darwin app management

### DIFF
--- a/modules/home/macos.nix
+++ b/modules/home/macos.nix
@@ -4,5 +4,8 @@
   home.username = "issy";
   home.homeDirectory = "/Users/issy";
 
+  targets.darwin.copyApps.enable = false;
+  targets.darwin.linkApps.enable = false;
+
   imports = [ ../recipes ];
 }


### PR DESCRIPTION

## Summary

- Disable Home Manager Darwin app copy/link handling for macOS.

## Testing

- Not run (configuration-only change).
