### PR TITLE
Update Home Manager stateVersion to 26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779143091,
-        "narHash": "sha256-qxiUVquHM09KOV1aD4We9q0ooPWO4qOc0v9J9NDWSAo=",
+        "lastModified": 1780099287,
+        "narHash": "sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "736c2084ea750a049ecdbdd7ff5817d2eeeef444",
+        "rev": "7d8127d308c3fb9664f7e643eec944be74ebb37d",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1779877693,
+        "narHash": "sha256-NOF9NAREhxr50bbBfVcVOq+ArCMSoe8dP79Pk2uyARk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "4100e830e085863741bc69b156ec4ccd53ab5be0",
         "type": "github"
       },
       "original": {
@@ -84,11 +84,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1779142999,
-        "narHash": "sha256-KcXaaS7489oPtzW51a7bKSsMeeF4yDjs9GWQ4qA9i4k=",
+        "lastModified": 1780079678,
+        "narHash": "sha256-Ld9FNgUvM3jzpyhqnb5hb3Ql42+/Tgsm+wMWtDmwBkA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "9b28a7e6e3e6f61b114a550941abfc9fce0645cc",
+        "rev": "bbadbd7319055d3633607a83b7d5a21550af2657",
         "type": "github"
       },
       "original": {
@@ -122,15 +122,16 @@
     },
     "systems_2": {
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "lastModified": 1774449309,
+        "narHash": "sha256-brhZ8DmuGtzkCYHJg4HEd602amKm89Y9ytsFZ5uWD1w=",
         "owner": "nix-systems",
         "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "rev": "c29398b59d2048c4ab79345812849c9bd15e9150",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
+        "ref": "future-26.11",
         "repo": "default",
         "type": "github"
       }

--- a/modules/recipes/default.nix
+++ b/modules/recipes/default.nix
@@ -3,7 +3,7 @@
 {
   xdg.enable = true;
   home = {
-    stateVersion = "26.11";
+    stateVersion = "26.05";
 
     sessionVariables = {
       NIX_CONFIG = "extra-experimental-features = nix-command flakes";

--- a/modules/recipes/default.nix
+++ b/modules/recipes/default.nix
@@ -3,7 +3,7 @@
 {
   xdg.enable = true;
   home = {
-    stateVersion = "24.11";
+    stateVersion = "26.11";
 
     sessionVariables = {
       NIX_CONFIG = "extra-experimental-features = nix-command flakes";

--- a/modules/recipes/lazygit.nix
+++ b/modules/recipes/lazygit.nix
@@ -44,7 +44,7 @@ _:
             return = "q";
           };
           files = {
-            commitChanges = "";
+            commitChanges = "C";
             commitChangesWithEditor = "c";
           };
         };


### PR DESCRIPTION
## Summary

- Set the shared Home Manager stateVersion to 26.05.
- Refresh flake.lock inputs for nixpkgs, home-manager, nixvim, and nix-systems.

## Testing

- Not run (configuration and lockfile update only).
