### PR TITLE
Add Claude auto permission alias

### DIFF
--- a/modules/recipes/claude.nix
+++ b/modules/recipes/claude.nix
@@ -14,6 +14,7 @@ in
   config = {
     home = {
       shellAliases.cld = "claude";
+      shellAliases.clda = "claude --permission-mode auto";
 
       file.".claude" = {
         source = claudeFilesFiltered;


### PR DESCRIPTION

## Summary

- Add a `clda` shell alias for launching Claude with `--permission-mode auto`.

## Background

- Keeps the auto-permission shortcut alongside the existing `cld` alias.
