### PR TITLE
Add meta.description to flake apps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -199,16 +199,19 @@
           switch = {
             type = "app";
             program = "${switchApp}/bin/dot-switch";
+            meta.description = "Switch to the Home Manager configuration for this host";
           };
 
           gc = {
             type = "app";
             program = "${gcApp}/bin/dot-gc";
+            meta.description = "Expire old generations and garbage-collect the Nix store";
           };
 
           generations = {
             type = "app";
             program = "${generationsApp}/bin/dot-generations";
+            meta.description = "List Home Manager generations";
           };
         };
 


### PR DESCRIPTION
## Summary

- Add `meta.description` to the `switch`, `gc`, and `generations` flake apps

## Background

- `nix flake check --all-systems` warned `app 'apps.<system>.<name>' lacks attribute 'meta'` for every app across all systems (9 warnings total)
- Adding `meta.description` satisfies the recommended flake app schema and clears the warnings
