### PR TITLE
Fix Neovim temp directory fallback

### DIFF
--- a/modules/recipes/neovim/config/default.nix
+++ b/modules/recipes/neovim/config/default.nix
@@ -3,6 +3,7 @@
     ./autocmds.nix
     ./keymaps.nix
     ./options.nix
+    ./runtime.nix
     ./theme.nix
   ];
 }

--- a/modules/recipes/neovim/config/runtime.nix
+++ b/modules/recipes/neovim/config/runtime.nix
@@ -1,0 +1,20 @@
+_:
+
+{
+  programs.nixvim.extraConfigLuaPre = ''
+    local function is_writable_directory(path)
+      local WRITABLE_DIRECTORY = 2
+      return path and path ~= "" and vim.fn.filewritable(path) == WRITABLE_DIRECTORY
+    end
+
+    local xdg_runtime_dir = vim.env.XDG_RUNTIME_DIR
+    if xdg_runtime_dir and xdg_runtime_dir ~= "" and not is_writable_directory(xdg_runtime_dir) then
+      vim.env.XDG_RUNTIME_DIR = nil
+    end
+
+    local tmpdir = vim.env.TMPDIR
+    if not is_writable_directory(tmpdir) then
+      vim.env.TMPDIR = (vim.uv or vim.loop).os_tmpdir()
+    end
+  '';
+}


### PR DESCRIPTION

## Summary

- ignore an invalid `XDG_RUNTIME_DIR` before Neovim plugins run
- fall back to libuv’s OS temp directory when `TMPDIR` is unset or not writable

## Background

This prevents plenary curl callbacks from failing when they try to write temporary header files under a missing or unwritable runtime directory.

## Checks

- `nix flake check --all-systems --no-build`
- `nix run .#switch`
