### PR TITLE
Rewrite AGENTS.md as concise repo rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,30 +1,13 @@
 # AGENTS.md
 
 Nix Flakes + Home Manager dotfiles for Linux/macOS.
+Per-tool recipe in `modules/recipes/[tool].nix`, config files in `files/[tool]/`.
 
 ## Rules
 
-- Do not read, write, or access files under `~/` directly; always work through this repository, except when the user explicitly asks to test sandbox behavior
+- Do not write to files under `~/` directly; make changes through `files/` in this repository, except when the user explicitly asks to test sandbox behavior
 - Only `git add` files that were changed as part of the current task
-- Do not switch unless explicitly asked. When switching:
-  - `git add` changed files under `files/`, `modules/`, and `flake.nix` as needed, then `nix run .#switch`
-  - `.#switch` selects linux: `.#linux`, macOS Silicon: `.#macos`, macOS Intel: `.#macos_intel`
-
-## Structure
-
-| Directory  | Purpose                                |
-| ---------- | -------------------------------------- |
-| `modules/home/`     | Home Manager entry modules per platform |
-| `modules/recipes/`  | Per-tool configuration recipes (HM `programs.<tool>` wrappers, file deployments, activation scripts, etc.) |
-| `modules/programs/` | (reserved) Self-authored HM modules that define new `options.programs.<tool>` |
-| `files/`            | Application config files                |
-
-Module pattern: `modules/recipes/[tool].nix` + `files/[tool]/`
-Platform entry modules: `modules/home/linux.nix`, `modules/home/macos.nix`
-
-## Adding / Modifying Tools
-
-1. Find or create `modules/recipes/[tool].nix`
-2. Config files go in `files/[tool]/`
-3. New modules must be imported in `modules/recipes/default.nix`
-4. Remind to `git add` new files (Nix Flakes only tracks git-managed files)
+- `git add` new files before relying on them — Nix Flakes only sees git-tracked files
+- To deploy files from `files/`, prefer the `dot.*` options (`dot.xdg.configFile` / `dot.home.file`) over raw `home.file` / `xdg.configFile`
+- Do not switch unless explicitly asked. To apply: `nix run .#switch` (auto-selects the host config)
+- Format with `nix fmt`; verify with `nix flake check` (runs treefmt, deadnix, statix, oxlint, actionlint, zizmor)


### PR DESCRIPTION
## Summary

Trim AGENTS.md to enforceable, code-irrecoverable rules and fix outdated content.

## Why

- Described a `modules/programs/` directory that no longer exists, and never mentioned the `dot` module layer that now drives file deployment — the doc had drifted from the code.
- Structure tables and API details duplicated what the code already states, so they rot on every refactor.

## Changes

- Drop the structure table and `dot.*` API reference (discoverable by reading the code).
- Keep only rules that code cannot convey: no direct writes under `~/` (reads are fine), changes go through `files/`, `git add` new files for Flakes to see them, prefer `dot.*` options over raw `home.file`/`xdg.configFile`, switch only when asked.
- Use `nix fmt` for formatting and `nix flake check` for verification.
