### PR TITLE
Fix snacks input keymap mode handling

### DIFF
--- a/modules/recipes/neovim/plugins/snacks.nix
+++ b/modules/recipes/neovim/plugins/snacks.nix
@@ -119,28 +119,28 @@ in
         toggle.enabled = true;
         words.enabled = true;
         styles.input.keys = {
-          i_esc = [
-            "<esc>"
-            "stopinsert"
-            { mode = "i"; }
-          ];
-          i_cr = [
-            "<cr>"
-            "confirm"
-            { mode = "i"; }
-          ];
-          i_tab = [
-            "<tab>"
-            [
+          i_esc = {
+            "__unkeyed-1" = "<esc>";
+            "__unkeyed-2" = "stopinsert";
+            mode = "i";
+          };
+          i_cr = {
+            "__unkeyed-1" = "<cr>";
+            "__unkeyed-2" = "confirm";
+            mode = "i";
+          };
+          i_tab = {
+            "__unkeyed-1" = "<tab>";
+            "__unkeyed-2" = [
               "cmp_select_next"
               "cmp"
-            ]
-            { mode = "i"; }
-          ];
-          cr = [
-            "<cr>"
-            [ "confirm" ]
-          ];
+            ];
+            mode = "i";
+          };
+          cr = {
+            "__unkeyed-1" = "<cr>";
+            "__unkeyed-2" = [ "confirm" ];
+          };
           q = "cancel";
         };
       };


### PR DESCRIPTION
## Summary

- Fix the `invalid key: 3` error and the duplicate `<CR>` mapping warning shown when opening a snacks input (e.g. LSP rename).

## Background

`styles.input.keys` specs passed `{ mode = "i"; }` as a Nix list element, so it became a positional Lua entry (`opts[3]`) instead of a named `mode` field. snacks forwarded that leftover index to `nvim_buf_set_keymap` (`invalid key: 3`), and the lost `mode` made the insert mappings register in normal mode — colliding with the normal-mode `<CR>` spec.

## Changes

- Use the nixvim `__unkeyed` prefix in `styles.input.keys` so `mode` is emitted as a named field, producing the mixed array+keyed Lua table snacks expects.
