### PR TITLE
Remove pi mode switch notification

### DIFF
--- a/files/pi/agent/extensions/user/features/mode.ts
+++ b/files/pi/agent/extensions/user/features/mode.ts
@@ -50,7 +50,6 @@ function applyMode(
 	target: Parameters<ModeController["setMode"]>[1],
 ): void {
 	mode.setMode(ctx, target, { persist: true });
-	ctx.ui.notify(`Permission mode switched to ${target}.`, "info");
 }
 
 const promptMode =


### PR DESCRIPTION

## Summary

- remove the transient notification shown after switching pi permission modes
- keep the active permission mode visible in the status bar
