### PR TITLE
Add pi debug extension loader

### DIFF
--- a/files/pi/agent/extensions/user/index.ts
+++ b/files/pi/agent/extensions/user/index.ts
@@ -1,21 +1,102 @@
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join, parse, resolve } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import type { Feature } from "./feature";
-import exitConfirmFeature from "./features/exit-confirm";
-import modeFeature from "./features/mode";
-import quickActionsFeature from "./features/quick-actions";
-import statusFeature from "./features/status";
-import thinkingFeature from "./features/thinking";
-import fileToolsFeature from "./features/tool";
+import type { createJiti as createJitiType } from "jiti";
+import deployedUser from "./main";
 
-const features: readonly Feature[] = [
-	exitConfirmFeature,
-	modeFeature,
-	quickActionsFeature,
-	statusFeature,
-	thinkingFeature,
-	fileToolsFeature,
-];
+const DEBUG_FLAG = "--debug";
+const DEBUG_MAIN_RELATIVE_PATH = join(
+	"files",
+	"pi",
+	"agent",
+	"extensions",
+	"user",
+	"main.ts",
+);
 
-export default function user(pi: ExtensionAPI): void {
-	for (const feature of features) feature.register(pi);
+type UserExtensionFactory = (pi: ExtensionAPI) => void | Promise<void>;
+
+function hasDebugFlag(
+	argv: readonly string[] = process.argv.slice(2),
+): boolean {
+	for (const arg of argv) {
+		if (arg === "--") return false;
+		if (arg === DEBUG_FLAG) return true;
+	}
+
+	return false;
+}
+
+function findDebugMain(cwd: string): string | undefined {
+	let dir = resolve(cwd);
+	const root = parse(dir).root;
+
+	while (true) {
+		const candidate = join(dir, DEBUG_MAIN_RELATIVE_PATH);
+		if (existsSync(candidate)) return candidate;
+		if (dir === root) return undefined;
+		dir = dirname(dir);
+	}
+}
+
+function isUserExtensionFactory(value: unknown): value is UserExtensionFactory {
+	return typeof value === "function";
+}
+
+async function loadUserExtension(path: string): Promise<UserExtensionFactory> {
+	const piModuleUrl = new URL(
+		import.meta.resolve("@earendil-works/pi-coding-agent"),
+	);
+	const piRequire = createRequire(piModuleUrl);
+	const { createJiti } = piRequire("jiti") as {
+		createJiti: typeof createJitiType;
+	};
+	const jiti = createJiti(import.meta.url, {
+		fsCache: false,
+		moduleCache: false,
+	});
+	const factory = await jiti.import<unknown>(path, { default: true });
+
+	if (!isUserExtensionFactory(factory)) {
+		throw new TypeError(
+			`Expected ${path} to export a default extension factory.`,
+		);
+	}
+
+	return factory;
+}
+
+export default async function userBootstrap(pi: ExtensionAPI): Promise<void> {
+	pi.registerFlag("debug", {
+		description:
+			"Load the user extension from the nearest dotfiles working tree instead of the deployed config.",
+		type: "boolean",
+		default: false,
+	});
+
+	// Read argv directly instead of pi.getFlag("debug"): the framework applies
+	// CLI flag values only after every extension factory has run, so getFlag
+	// would still return the default here. registerFlag above stays for --help
+	// and to suppress the "unknown option" error.
+	if (!hasDebugFlag()) {
+		await deployedUser(pi);
+		return;
+	}
+
+	const mainPath = findDebugMain(process.cwd());
+	if (!mainPath) {
+		throw new Error(
+			`Could not find ${DEBUG_MAIN_RELATIVE_PATH} from ${process.cwd()} for ${DEBUG_FLAG} mode.`,
+		);
+	}
+
+	pi.on("session_start", (_event, ctx) => {
+		if (!ctx.hasUI) return;
+		ctx.ui.setStatus("debug", ctx.ui.theme.fg("dim", "[debug]"));
+		ctx.ui.notify(`Loaded user extension from ${mainPath}`, "info");
+	});
+
+	const register = await loadUserExtension(mainPath);
+	await register(pi);
 }

--- a/files/pi/agent/extensions/user/index.ts
+++ b/files/pi/agent/extensions/user/index.ts
@@ -2,7 +2,6 @@ import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join, parse, resolve } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import type { createJiti as createJitiType } from "jiti";
 import deployedUser from "./main";
 
 const DEBUG_FLAG = "--debug";
@@ -16,6 +15,13 @@ const DEBUG_MAIN_RELATIVE_PATH = join(
 );
 
 type UserExtensionFactory = (pi: ExtensionAPI) => void | Promise<void>;
+type JitiLoader = {
+	import<T>(path: string, options: { default: true }): Promise<T>;
+};
+type CreateJiti = (
+	url: string,
+	options: { fsCache: boolean; moduleCache: boolean },
+) => JitiLoader;
 
 function hasDebugFlag(
 	argv: readonly string[] = process.argv.slice(2),
@@ -50,7 +56,7 @@ async function loadUserExtension(path: string): Promise<UserExtensionFactory> {
 	);
 	const piRequire = createRequire(piModuleUrl);
 	const { createJiti } = piRequire("jiti") as {
-		createJiti: typeof createJitiType;
+		createJiti: CreateJiti;
 	};
 	const jiti = createJiti(import.meta.url, {
 		fsCache: false,

--- a/files/pi/agent/extensions/user/main.ts
+++ b/files/pi/agent/extensions/user/main.ts
@@ -1,0 +1,21 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { Feature } from "./feature";
+import exitConfirmFeature from "./features/exit-confirm";
+import modeFeature from "./features/mode";
+import quickActionsFeature from "./features/quick-actions";
+import statusFeature from "./features/status";
+import thinkingFeature from "./features/thinking";
+import fileToolsFeature from "./features/tool";
+
+const features: readonly Feature[] = [
+	exitConfirmFeature,
+	modeFeature,
+	quickActionsFeature,
+	statusFeature,
+	thinkingFeature,
+	fileToolsFeature,
+];
+
+export default function user(pi: ExtensionAPI): void {
+	for (const feature of features) feature.register(pi);
+}


### PR DESCRIPTION

## Summary

- add a bootstrap entrypoint for the Pi user extension
- support `pi --debug` to load the user extension from the nearest dotfiles working tree
- move the normal feature registration into `main.ts` so regular `pi` startup keeps using the deployed extension
