### PR TITLE
Preserve pi permission mode across new sessions

### DIFF
--- a/files/pi/agent/extensions/user/features/mode.ts
+++ b/files/pi/agent/extensions/user/features/mode.ts
@@ -5,6 +5,7 @@ import type {
 	ExtensionCommandContext,
 	ExtensionContext,
 	ExtensionHandler,
+	SessionBeforeSwitchEvent,
 	SessionStartEvent,
 	ToolCallEvent,
 	ToolCallEventResult,
@@ -14,9 +15,11 @@ import type { Feature } from "../feature";
 import {
 	MODE_DEFINITIONS,
 	MODE_NAMES,
+	MODE_STATE_TYPE,
 	type ModeController,
 	createModeController,
 	findPersistedMode,
+	findPersistedModeInSessionFile,
 	getMode,
 	getNextMode,
 	getStartupMode,
@@ -28,6 +31,7 @@ import { policyRegistry } from "../lib/policy";
 import { filterCompletionsByPrefix } from "../lib/ui";
 
 type BlockedToolCall = { block: true; reason: string };
+type SessionBeforeSwitchResult = { cancel?: boolean };
 
 function block(reason: string): BlockedToolCall {
 	return { block: true, reason };
@@ -114,16 +118,34 @@ const injectSystemPrompt =
 		};
 	};
 
+const persistModeBeforeNew =
+	(
+		pi: ExtensionAPI,
+		mode: ModeController,
+	): ExtensionHandler<SessionBeforeSwitchEvent, SessionBeforeSwitchResult> =>
+	async (event) => {
+		if (event.reason !== "new") return;
+		pi.appendEntry(MODE_STATE_TYPE, { mode: mode.current });
+	};
+
 const restoreMode =
 	(
 		pi: ExtensionAPI,
 		mode: ModeController,
 	): ExtensionHandler<SessionStartEvent> =>
-	async (_event, ctx) => {
+	async (event, ctx) => {
+		const inheritedMode =
+			event.reason === "new"
+				? findPersistedModeInSessionFile(event.previousSessionFile)
+				: undefined;
 		mode.setMode(
 			ctx,
-			getStartupMode(pi, ctx.cwd, findPersistedMode(ctx), (message) =>
-				ctx.ui.notify(message, "warning"),
+			getStartupMode(
+				pi,
+				ctx.cwd,
+				findPersistedMode(ctx),
+				(message) => ctx.ui.notify(message, "warning"),
+				inheritedMode,
 			),
 			{ persist: false, force: true },
 		);
@@ -160,6 +182,7 @@ function register(pi: ExtensionAPI): void {
 		handler: cycleMode(mode),
 	});
 	pi.on("before_agent_start", injectSystemPrompt(mode));
+	pi.on("session_before_switch", persistModeBeforeNew(pi, mode));
 	pi.on("session_start", restoreMode(pi, mode));
 	pi.on("tool_call", guardToolCall(mode));
 }

--- a/files/pi/agent/extensions/user/lib/mode/index.ts
+++ b/files/pi/agent/extensions/user/lib/mode/index.ts
@@ -16,5 +16,9 @@ export {
 	normalizeModeName,
 } from "./definitions";
 export { registerBuiltInPolicies } from "./policies";
-export { findPersistedMode, getStartupMode } from "./startup";
+export {
+	findPersistedMode,
+	findPersistedModeInSessionFile,
+	getStartupMode,
+} from "./startup";
 export { activateModeTools, applyModeStatus, showModeSelector } from "./ui";

--- a/files/pi/agent/extensions/user/lib/mode/startup.ts
+++ b/files/pi/agent/extensions/user/lib/mode/startup.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import {
 	type ExtensionAPI,
 	type ExtensionContext,
@@ -60,6 +61,7 @@ export function getStartupMode(
 	cwd: string,
 	persistedMode?: ModeName,
 	onWarning?: (message: string) => void,
+	inheritedMode?: ModeName,
 ): ModeName {
 	const flagValue = pi.getFlag("permission-mode");
 	const flagMode = normalizeModeName(flagValue);
@@ -69,12 +71,14 @@ export function getStartupMode(
 		);
 	}
 	const configuredMode = getConfiguredDefaultMode(cwd, onWarning);
-	return flagMode ?? persistedMode ?? configuredMode ?? DEFAULT_MODE;
+	return (
+		inheritedMode ?? flagMode ?? persistedMode ?? configuredMode ?? DEFAULT_MODE
+	);
 }
 
-export function findPersistedMode(ctx: ExtensionContext): ModeName | undefined {
-	const entries =
-		ctx.sessionManager.getEntries() as readonly CustomSessionEntry[];
+function findPersistedModeInEntries(
+	entries: readonly CustomSessionEntry[],
+): ModeName | undefined {
 	for (let i = entries.length - 1; i >= 0; i--) {
 		const entry = entries[i];
 		if (entry.type === "custom" && entry.customType === MODE_STATE_TYPE) {
@@ -82,4 +86,26 @@ export function findPersistedMode(ctx: ExtensionContext): ModeName | undefined {
 		}
 	}
 	return undefined;
+}
+
+export function findPersistedMode(ctx: ExtensionContext): ModeName | undefined {
+	return findPersistedModeInEntries(
+		ctx.sessionManager.getEntries() as readonly CustomSessionEntry[],
+	);
+}
+
+export function findPersistedModeInSessionFile(
+	sessionFile?: string,
+): ModeName | undefined {
+	if (!sessionFile) return undefined;
+
+	try {
+		const entries = readFileSync(sessionFile, "utf8")
+			.split(/\r?\n/u)
+			.filter(Boolean)
+			.map((line) => JSON.parse(line) as CustomSessionEntry);
+		return findPersistedModeInEntries(entries);
+	} catch {
+		return undefined;
+	}
 }

--- a/files/pi/agent/extensions/user/lib/mode/startup.ts
+++ b/files/pi/agent/extensions/user/lib/mode/startup.ts
@@ -3,6 +3,7 @@ import {
 	type ExtensionAPI,
 	type ExtensionContext,
 	SettingsManager,
+	parseSessionEntries,
 } from "@earendil-works/pi-coding-agent";
 import {
 	DEFAULT_MODE,
@@ -100,10 +101,9 @@ export function findPersistedModeInSessionFile(
 	if (!sessionFile) return undefined;
 
 	try {
-		const entries = readFileSync(sessionFile, "utf8")
-			.split(/\r?\n/u)
-			.filter(Boolean)
-			.map((line) => JSON.parse(line) as CustomSessionEntry);
+		const entries = parseSessionEntries(
+			readFileSync(sessionFile, "utf8"),
+		) as readonly CustomSessionEntry[];
 		return findPersistedModeInEntries(entries);
 	} catch {
 		return undefined;


### PR DESCRIPTION

## Summary

- keep the current pi permission mode when starting a new session with `/new`
- persist the mode before session replacement and restore it from the previous session file
- share the session-file mode lookup through the mode startup utilities

## Verification

- `pnpm lint`
- `nix fmt`
- `nix flake check`
