### PR TITLE
fix(ghostty): add horizontal padding

### DIFF
--- a/modules/recipes/ghostty.nix
+++ b/modules/recipes/ghostty.nix
@@ -24,7 +24,7 @@ _:
         "liga"
       ];
 
-      "window-padding-x" = 0;
+      "window-padding-x" = 4;
       "window-padding-y" = 0;
       "window-padding-balance" = false;
 


### PR DESCRIPTION

## Summary

- Add 4px horizontal padding to Ghostty windows.
- Keep vertical padding unchanged.
