### PR TITLE
Improve pi mode steering during active turns

### DIFF
--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -14,7 +14,7 @@
         },
         {
           "label": "oxlint",
-          "command": "oxlint"
+          "command": "oxlint --deny-warnings"
         },
         {
           "label": "deadnix",

--- a/files/pi/agent/extensions/user/features/mode.ts
+++ b/files/pi/agent/extensions/user/features/mode.ts
@@ -1,6 +1,7 @@
 import type {
 	BeforeAgentStartEvent,
 	BeforeAgentStartEventResult,
+	ContextEvent,
 	ExtensionAPI,
 	ExtensionCommandContext,
 	ExtensionContext,
@@ -17,13 +18,16 @@ import {
 	MODE_NAMES,
 	MODE_STATE_TYPE,
 	type ModeController,
+	buildModeReminderPayload,
 	createModeController,
 	findPersistedMode,
 	findPersistedModeInSessionFile,
+	formatAllowedTools,
 	getMode,
 	getNextMode,
 	getStartupMode,
 	isModeName,
+	isModeReminderMessage,
 	registerBuiltInPolicies,
 	showModeSelector,
 } from "../lib/mode";
@@ -31,7 +35,10 @@ import { policyRegistry } from "../lib/policy";
 import { filterCompletionsByPrefix } from "../lib/ui";
 
 type BlockedToolCall = { block: true; reason: string };
+type ContextResult = { messages?: ContextEvent["messages"] };
 type SessionBeforeSwitchResult = { cancel?: boolean };
+
+let modeSteerReminderActive = false;
 
 function block(reason: string): BlockedToolCall {
 	return { block: true, reason };
@@ -53,7 +60,9 @@ function applyMode(
 	ctx: ExtensionContext,
 	target: Parameters<ModeController["setMode"]>[1],
 ): void {
+	const shouldSteerReminder = mode.current !== target && !ctx.isIdle();
 	mode.setMode(ctx, target, { persist: true });
+	if (shouldSteerReminder) modeSteerReminderActive = true;
 }
 
 const openModeSelector =
@@ -113,8 +122,10 @@ const injectSystemPrompt =
 		const prompt = getMode(mode.current).systemPrompt;
 		if (!prompt) return;
 
+		const allowedTools = policyRegistry.getAllowedToolsForMode(mode.current);
+		const tools = formatAllowedTools(allowedTools);
 		return {
-			systemPrompt: `${event.systemPrompt}\n\n[${mode.current.toUpperCase()} MODE]\n${prompt}`,
+			systemPrompt: `${event.systemPrompt}\n\n[${mode.current.toUpperCase()} MODE]\nAllowed tools in this mode: ${tools}\n${prompt}\n\nTool schemas may include tools that are blocked in the current mode; do not call tools that are not listed in "Allowed tools in this mode". If the user asks for a listed tool, call that tool rather than saying it is unavailable.`,
 		};
 	};
 
@@ -134,6 +145,7 @@ const restoreMode =
 		mode: ModeController,
 	): ExtensionHandler<SessionStartEvent> =>
 	async (event, ctx) => {
+		modeSteerReminderActive = false;
 		const inheritedMode =
 			event.reason === "new"
 				? findPersistedModeInSessionFile(event.previousSessionFile)
@@ -149,6 +161,36 @@ const restoreMode =
 			),
 			{ persist: false, force: true },
 		);
+	};
+
+const injectTransientModeReminder =
+	(mode: ModeController): ExtensionHandler<ContextEvent, ContextResult> =>
+	async (event) => {
+		// Steady state (no pending steer): only strip stale reminders if any
+		// exist, so the common per-turn path skips rebuilding the message array.
+		if (!modeSteerReminderActive) {
+			if (!event.messages.some(isModeReminderMessage)) return undefined;
+			return {
+				messages: event.messages.filter(
+					(message) => !isModeReminderMessage(message),
+				),
+			};
+		}
+
+		const messages = event.messages.filter(
+			(message) => !isModeReminderMessage(message),
+		);
+		const allowedTools = policyRegistry.getAllowedToolsForMode(mode.current);
+		return {
+			messages: [
+				...messages,
+				{
+					role: "custom",
+					...buildModeReminderPayload(mode.current, allowedTools),
+					timestamp: Date.now(),
+				},
+			],
+		};
 	};
 
 const guardToolCall =
@@ -182,6 +224,10 @@ function register(pi: ExtensionAPI): void {
 		handler: cycleMode(mode),
 	});
 	pi.on("before_agent_start", injectSystemPrompt(mode));
+	pi.on("context", injectTransientModeReminder(mode));
+	pi.on("agent_end", async () => {
+		modeSteerReminderActive = false;
+	});
 	pi.on("session_before_switch", persistModeBeforeNew(pi, mode));
 	pi.on("session_start", restoreMode(pi, mode));
 	pi.on("tool_call", guardToolCall(mode));

--- a/files/pi/agent/extensions/user/lib/mode/controller.ts
+++ b/files/pi/agent/extensions/user/lib/mode/controller.ts
@@ -8,7 +8,93 @@ import {
 	type ModeName,
 	getMode,
 } from "./definitions";
+import { policyRegistry } from "../policy";
 import { activateModeTools, applyModeStatus } from "./ui";
+
+export const MODE_REMINDER_TYPE = "system-reminder";
+
+/** Render an allowed-tool list for prompts, or "none" when empty. */
+export function formatAllowedTools(allowedTools: readonly string[]): string {
+	return allowedTools.length > 0 ? allowedTools.join(", ") : "none";
+}
+
+export function getModeReminder(
+	modeName: ModeName,
+	allowedTools: readonly string[],
+): string {
+	const mode = getMode(modeName);
+	const modeInstruction = mode.systemPrompt;
+	const tools = formatAllowedTools(allowedTools);
+
+	return `<system-reminder>
+Permission mode changed while you were working.
+
+Current mode: ${modeName}
+Allowed tools now: ${tools}
+
+${modeInstruction}
+
+The tool names above are the complete current allowed tool set. If the user asks for a listed tool, call that tool rather than saying it is unavailable. Tool schemas may include tools that are blocked in the current mode; do not call tools that are not listed above.
+Follow the current mode and current allowed tools. Do not rely on any earlier mode reminder.
+</system-reminder>`;
+}
+
+/**
+ * The shared shape of a mode-reminder custom message. Construction and
+ * detection stay in one place; detection also accepts the previous
+ * `details.activeTools` field so stale reminders from older sessions are
+ * stripped from context. Callers add their own delivery-specific fields
+ * (e.g. `role`/`timestamp` for context injection).
+ */
+export type ModeReminderPayload = {
+	customType: string;
+	content: string;
+	display: boolean;
+	details: { mode: ModeName; allowedTools: readonly string[] };
+};
+
+export function buildModeReminderPayload(
+	modeName: ModeName,
+	allowedTools: readonly string[],
+): ModeReminderPayload {
+	return {
+		customType: MODE_REMINDER_TYPE,
+		content: getModeReminder(modeName, allowedTools),
+		display: false,
+		details: { mode: modeName, allowedTools },
+	};
+}
+
+export function isModeReminderMessage(message: {
+	role: string;
+	customType?: string;
+	details?: unknown;
+}): boolean {
+	if (message.role !== "custom" || message.customType !== MODE_REMINDER_TYPE) {
+		return false;
+	}
+
+	return (
+		typeof message.details === "object" &&
+		message.details !== null &&
+		"mode" in message.details &&
+		("allowedTools" in message.details || "activeTools" in message.details)
+	);
+}
+
+function steerModeReminder(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	modeName: ModeName,
+	allowedTools: readonly string[],
+): void {
+	if (ctx.isIdle()) return;
+
+	pi.sendMessage(buildModeReminderPayload(modeName, allowedTools), {
+		deliverAs: "steer",
+		triggerTurn: true,
+	});
+}
 
 export type SetModeOptions = {
 	/** Persist the choice so the next session starts in this mode. */
@@ -46,8 +132,10 @@ export function createModeController(pi: ExtensionAPI): ModeController {
 				pi.appendEntry(MODE_STATE_TYPE, { mode: modeName });
 			}
 			currentMode = modeName;
+			const allowedTools = policyRegistry.getAllowedToolsForMode(modeName);
 			activateModeTools(pi, modeName);
 			applyModeStatus(ctx, getMode(modeName));
+			if (changed) steerModeReminder(pi, ctx, modeName, allowedTools);
 		},
 	};
 }

--- a/files/pi/agent/extensions/user/lib/mode/definitions.ts
+++ b/files/pi/agent/extensions/user/lib/mode/definitions.ts
@@ -29,6 +29,8 @@ export const MODE_DEFINITIONS: readonly Mode[] = [
 		name: "yolo",
 		description: "Read, write, edit, and run shell commands.",
 		color: "alert",
+		systemPrompt:
+			"You are in yolo mode. Use the currently active tools to inspect and modify files and run shell commands. You may use active tools, including arbitrary shell command execution when available. If a requested action matches an active tool, call that tool rather than saying it is unavailable. However, avoid exposing secrets or credentials in the conversation context. If a command may print secrets, prefer a safer command or mask sensitive output. If an action is in a gray area for safety, privacy, or destructive impact, ask the user for confirmation before proceeding.",
 	},
 ];
 

--- a/files/pi/agent/extensions/user/lib/mode/index.ts
+++ b/files/pi/agent/extensions/user/lib/mode/index.ts
@@ -1,7 +1,12 @@
 export {
+	MODE_REMINDER_TYPE,
 	type ModeController,
 	type SetModeOptions,
+	buildModeReminderPayload,
 	createModeController,
+	formatAllowedTools,
+	getModeReminder,
+	isModeReminderMessage,
 } from "./controller";
 export {
 	DEFAULT_MODE,

--- a/files/pi/agent/extensions/user/lib/mode/ui.ts
+++ b/files/pi/agent/extensions/user/lib/mode/ui.ts
@@ -34,6 +34,11 @@ export function applyModeStatus(ctx: ExtensionContext, mode: Mode): void {
 	ctx.ui.setStatus(MODE_STATE_TYPE, fg(colors[mode.color], mode.name));
 }
 
-export function activateModeTools(pi: ExtensionAPI, modeName: ModeName): void {
-	pi.setActiveTools(policyRegistry.getActiveToolsForMode(modeName));
+export function activateModeTools(pi: ExtensionAPI, _modeName: ModeName): void {
+	// Tool schemas are captured for the duration of an agent run. Keep every
+	// policy-managed tool callable at the provider layer so mode changes made
+	// while the agent is working can take effect on the next LLM call in that
+	// same run. The policy guard remains the source of truth for whether a tool
+	// is actually allowed in the current mode.
+	pi.setActiveTools(policyRegistry.getKnownToolNames());
 }

--- a/files/pi/agent/extensions/user/lib/policy.ts
+++ b/files/pi/agent/extensions/user/lib/policy.ts
@@ -19,7 +19,8 @@ export type ToolPolicy<TInput = unknown> = {
 
 export type PolicyRegistry = {
 	register<TInput>(policy: ToolPolicy<TInput>): void;
-	getActiveToolsForMode(modeName: ModeName): string[];
+	getAllowedToolsForMode(modeName: ModeName): string[];
+	getKnownToolNames(): string[];
 	checkToolAllowed(
 		modeName: ModeName,
 		event: ToolCallEvent,
@@ -37,12 +38,15 @@ function createPolicyRegistry(): PolicyRegistry {
 		register(policy) {
 			policies.set(policy.name, policy as ToolPolicy);
 		},
-		getActiveToolsForMode(modeName) {
+		getAllowedToolsForMode(modeName) {
 			const tools: string[] = [];
 			for (const policy of policies.values()) {
 				if (policy.allowedModes.includes(modeName)) tools.push(policy.name);
 			}
 			return tools;
+		},
+		getKnownToolNames() {
+			return [...policies.keys()];
 		},
 		checkToolAllowed(modeName, event) {
 			const policy = policies.get(event.toolName);

--- a/files/pi/agent/extensions/user/lib/tool/project.ts
+++ b/files/pi/agent/extensions/user/lib/tool/project.ts
@@ -8,18 +8,18 @@ import { isAbsolute, join, relative, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { StringDecoder } from "node:string_decoder";
 import {
-	DEFAULT_MAX_BYTES,
-	DEFAULT_MAX_LINES,
-	SettingsManager,
-	createLocalBashOperations,
-	formatSize,
 	type AgentToolResult,
 	type AgentToolUpdateCallback,
+	DEFAULT_MAX_BYTES,
+	DEFAULT_MAX_LINES,
 	type ExtensionAPI,
 	type ExtensionContext,
+	SettingsManager,
 	type Theme,
 	type ToolDefinition,
 	type ToolResultEvent,
+	createLocalBashOperations,
+	formatSize,
 } from "@earendil-works/pi-coding-agent";
 import { type Component, Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
@@ -744,6 +744,7 @@ export function registerProjectTools(
 	}
 
 	const existingToolNames = new Set(pi.getAllTools().map((tool) => tool.name));
+	const newlyRegistered: string[] = [];
 	for (const [name, rawConfig] of Object.entries(projectSettings.tools)) {
 		try {
 			if (existingToolNames.has(name) || registeredNames.has(name)) {
@@ -757,12 +758,19 @@ export function registerProjectTools(
 			pi.registerTool(createProjectToolDefinition(resolved));
 			policyRegistry.register({ name, allowedModes: resolved.allowedModes });
 			registeredNames.add(name);
+			newlyRegistered.push(name);
 		} catch (error) {
 			notifyWarning(
 				ctx,
 				`Project tool '${name}' ignored: ${error instanceof Error ? error.message : String(error)}`,
 			);
 		}
+	}
+
+	if (newlyRegistered.length > 0) {
+		pi.setActiveTools([
+			...new Set([...pi.getActiveTools(), ...newlyRegistered]),
+		]);
 	}
 }
 

--- a/flake.nix
+++ b/flake.nix
@@ -137,7 +137,7 @@
 
         oxlint = pkgs.runCommand "oxlint-check" { nativeBuildInputs = [ pkgs.oxlint ]; } ''
           cd ${./.}
-          oxlint
+          oxlint --deny-warnings
           touch "$out"
         '';
 


### PR DESCRIPTION

## Summary

- send transient mode reminders when the permission mode changes while the agent is running
- keep policy-managed tool schemas available during a run while enforcing allowed tools via the mode guard
- distinguish allowed tools from provider-active tool schemas and make oxlint warnings fail checks

## Background

Mode changes made mid-response were reflected in the UI and policy state, but the model could keep following the earlier mode context or miss newly allowed project tools such as lint. This updates the mode extension to steer a temporary reminder, strip stale reminders from later context, and keep tool schema availability aligned with streaming turns.
