### PR TITLE
Fix navi config parsing

### DIFF
--- a/modules/recipes/navi.nix
+++ b/modules/recipes/navi.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ pkgs, ... }:
 
 {
   config.dot.programs.navi = {
@@ -12,18 +12,18 @@
       style = {
         tag = {
           color = "cyan";
-          with_percentage = 26;
+          width_percentage = 26;
           min_width = 20;
         };
-        comments = {
+        comment = {
           color = "blue";
-          with_percentage = 42;
+          width_percentage = 42;
           min_width = 45;
         };
         snippet.color = "white";
       };
       finder = {
-        command = config.dot.options.fuzzyFinder.command;
+        command = "fzf";
         overrides = "--no-exact --tiebreak chunk,begin,length";
         overrides_var = "--no-exact";
       };


### PR DESCRIPTION

## Summary

- Update navi to configure the supported `fzf` finder value.
- Align generated style keys with the navi YAML schema.

## Background

navi 2.24 parses `finder.command` as a fixed choice, so an absolute Nix store path caused startup config parsing to fall back to defaults.
