### PR TITLE
Add tmux pane metrics for Pi completions

### DIFF
--- a/files/pi/agent/extensions/user/features/status.ts
+++ b/files/pi/agent/extensions/user/features/status.ts
@@ -59,6 +59,7 @@ function register(pi: ExtensionAPI): void {
 
 	pi.on("thinking_level_select", render.trigger);
 	pi.on("model_select", render.trigger);
+	pi.on("message_end", render.trigger);
 	pi.on("session_start", initFooter(pi, render, notice));
 	pi.on(
 		"session_shutdown",

--- a/files/pi/agent/extensions/user/features/tmux-notice.ts
+++ b/files/pi/agent/extensions/user/features/tmux-notice.ts
@@ -5,7 +5,6 @@ import type {
 	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
 import type { Feature } from "../feature";
-import { formatCount, getAssistantTotals } from "../lib/status";
 
 const execFileAsync = promisify(execFile);
 
@@ -13,8 +12,6 @@ const DONE_ICONS = ["π", " "] as const;
 const DONE_ICON = DONE_ICONS[0];
 const WINDOW_NOTICE_OPTION = "@window_notice";
 const DONE_TOGGLE_INTERVAL_MS = 500;
-const TOKEN_TITLE_UPDATE_INTERVAL_MS = 500;
-const TITLE_METRICS_SEPARATOR = " - ";
 
 // Capture the pane at extension load. Using the active pane at completion time
 // would update whichever pane the user is looking at, not the pane running Pi.
@@ -22,18 +19,11 @@ const tmuxPane = process.env.TMUX_PANE;
 const isInsideTmux = Boolean(process.env.TMUX);
 
 let originalTitle: string | undefined;
-let agentStartedAtMs: number | undefined;
-// Token/cost totals only change when an assistant message completes, so cache
-// the rendered string and refresh it on agent_start / message_end / agent_end
-// instead of re-scanning the whole session branch on every timer tick.
-let tokenTotals = "↑0 ↓0";
-let doneDetails = "";
 let doneTitleIndex = 0;
 let cancelDoneBlink: (() => void) | undefined;
-let cancelTokenTitle: (() => void) | undefined;
 
 // Self-rescheduling async interval with a single re-entrancy guard, returning a
-// canceller. Shared by the working-title and done-blink timers.
+// canceller for the done-blink timer.
 function startInterval(ms: number, tick: () => Promise<void>): () => void {
 	let running = false;
 	const timer = setInterval(() => {
@@ -50,28 +40,6 @@ function startInterval(ms: number, tick: () => Promise<void>): () => void {
 function stopDoneBlink(): void {
 	cancelDoneBlink?.();
 	cancelDoneBlink = undefined;
-}
-
-function stopTokenTitleUpdates(): void {
-	cancelTokenTitle?.();
-	cancelTokenTitle = undefined;
-}
-
-function formatDuration(ms: number): string {
-	const totalSeconds = Math.max(0, Math.round(ms / 1000));
-	const seconds = totalSeconds % 60;
-	const totalMinutes = Math.floor(totalSeconds / 60);
-	const minutes = totalMinutes % 60;
-	const hours = Math.floor(totalMinutes / 60);
-
-	if (hours > 0) return `${hours}h${minutes}m`;
-	if (minutes > 0) return `${minutes}m${seconds}s`;
-	return `${seconds}s`;
-}
-
-function currentElapsed(): string {
-	if (agentStartedAtMs === undefined) return "0s";
-	return formatDuration(Date.now() - agentStartedAtMs);
 }
 
 async function getTmuxPaneFormat(format: string): Promise<string | undefined> {
@@ -145,54 +113,16 @@ async function setPaneTitle(
 	if (!isInsideTmux && ctx.hasUI) ctx.ui.setTitle(title);
 }
 
-function computeTokenTotals(ctx: ExtensionContext): string {
-	const totals = getAssistantTotals(ctx.sessionManager.getBranch());
-	const parts = [
-		`↑${formatCount(totals.input)}`,
-		`↓${formatCount(totals.output)}`,
-	];
-	if (totals.cost > 0) parts.push(`$${totals.cost.toFixed(3)}`);
-	return parts.join(" ");
-}
-
-function renderMetrics(): string {
-	const parts = [tokenTotals];
-	const elapsed = currentElapsed();
-	if (elapsed !== "0s") parts.push(elapsed);
-	return parts.join(TITLE_METRICS_SEPARATOR);
-}
-
-function withOriginalPrefix(suffix: string): string {
-	return originalTitle
-		? `${originalTitle}${TITLE_METRICS_SEPARATOR}${suffix}`
-		: suffix;
-}
-
-function renderWorkingTitle(): string {
-	return withOriginalPrefix(renderMetrics());
-}
-
-function renderDoneStablePaneTitle(): string {
-	return withOriginalPrefix(doneDetails);
-}
-
 function renderDonePaneTitle(icon: (typeof DONE_ICONS)[number]): string {
-	if (!originalTitle) return `${icon} ${doneDetails}`;
+	if (!originalTitle) return icon;
 
 	// If the original title already starts with the Pi icon, reuse that slot so
-	// the notification icon does not render as "π π ...".
+	// only the notification icon blinks and the rest of the title stays stable.
 	if (originalTitle.startsWith(DONE_ICON)) {
-		return `${icon}${originalTitle.slice(DONE_ICON.length)}${TITLE_METRICS_SEPARATOR}${doneDetails}`;
+		return `${icon}${originalTitle.slice(DONE_ICON.length)}`;
 	}
 
-	return `${icon} ${originalTitle}${TITLE_METRICS_SEPARATOR}${doneDetails}`;
-}
-
-function startTokenTitleUpdates(ctx: ExtensionContext): void {
-	stopTokenTitleUpdates();
-	cancelTokenTitle = startInterval(TOKEN_TITLE_UPDATE_INTERVAL_MS, () =>
-		setPaneTitle(ctx, renderWorkingTitle()),
-	);
+	return `${icon} ${originalTitle}`;
 }
 
 function startDoneBlinkUntilActive(): void {
@@ -201,16 +131,17 @@ function startDoneBlinkUntilActive(): void {
 	doneTitleIndex = 0;
 	cancelDoneBlink = startInterval(DONE_TOGGLE_INTERVAL_MS, async () => {
 		if (await isTmuxPaneVisibleActive()) {
-			await Promise.all([
-				setTmuxWindowNotice(undefined),
-				setTmuxPaneTitle(renderDoneStablePaneTitle()),
-			]);
+			await restoreOriginalTmuxPaneTitle();
 			stopDoneBlink();
 			return;
 		}
 
 		doneTitleIndex = (doneTitleIndex + 1) % DONE_ICONS.length;
-		await setTmuxPaneTitle(renderDonePaneTitle(DONE_ICONS[doneTitleIndex]));
+		const icon = DONE_ICONS[doneTitleIndex];
+		await Promise.all([
+			setTmuxPaneTitle(renderDonePaneTitle(icon)),
+			setTmuxWindowNotice(icon),
+		]);
 	});
 }
 
@@ -223,11 +154,8 @@ function isPiStatusTitle(title: string): boolean {
 }
 
 function register(pi: ExtensionAPI): void {
-	pi.on("agent_start", async (_event, ctx) => {
-		agentStartedAtMs = Date.now();
+	pi.on("agent_start", async () => {
 		stopDoneBlink();
-		tokenTotals = computeTokenTotals(ctx);
-		startTokenTitleUpdates(ctx);
 
 		// Clearing the stale notice is independent of reading the current title.
 		const [, currentTitle] = await Promise.all([
@@ -241,26 +169,11 @@ function register(pi: ExtensionAPI): void {
 		} else {
 			originalTitle = currentTitle;
 		}
-
-		await setPaneTitle(ctx, renderWorkingTitle());
-	});
-
-	pi.on("message_end", async (event, ctx) => {
-		if (event.message.role !== "assistant") return;
-		tokenTotals = computeTokenTotals(ctx);
-		await setPaneTitle(ctx, renderWorkingTitle());
 	});
 
 	pi.on("agent_end", async (_event, ctx) => {
-		tokenTotals = computeTokenTotals(ctx);
-		doneDetails = renderMetrics();
-		agentStartedAtMs = undefined;
-		stopTokenTitleUpdates();
 		if (await isTmuxPaneVisibleActive()) {
-			await Promise.all([
-				setTmuxWindowNotice(undefined),
-				setPaneTitle(ctx, renderDoneStablePaneTitle()),
-			]);
+			await restoreOriginalTmuxPaneTitle();
 			return;
 		}
 
@@ -273,9 +186,8 @@ function register(pi: ExtensionAPI): void {
 
 	pi.on("session_shutdown", async () => {
 		stopDoneBlink();
-		stopTokenTitleUpdates();
 		await restoreOriginalTmuxPaneTitle();
 	});
 }
 
-export default { name: "tmux-pane-title", register } satisfies Feature;
+export default { name: "tmux-notice", register } satisfies Feature;

--- a/files/pi/agent/extensions/user/features/tmux-pane-title.ts
+++ b/files/pi/agent/extensions/user/features/tmux-pane-title.ts
@@ -1,0 +1,281 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import type { Feature } from "../feature";
+import { formatCount, getAssistantTotals } from "../lib/status";
+
+const execFileAsync = promisify(execFile);
+
+const DONE_ICONS = ["π", " "] as const;
+const DONE_ICON = DONE_ICONS[0];
+const WINDOW_NOTICE_OPTION = "@window_notice";
+const DONE_TOGGLE_INTERVAL_MS = 500;
+const TOKEN_TITLE_UPDATE_INTERVAL_MS = 500;
+const TITLE_METRICS_SEPARATOR = " - ";
+
+// Capture the pane at extension load. Using the active pane at completion time
+// would update whichever pane the user is looking at, not the pane running Pi.
+const tmuxPane = process.env.TMUX_PANE;
+const isInsideTmux = Boolean(process.env.TMUX);
+
+let originalTitle: string | undefined;
+let agentStartedAtMs: number | undefined;
+// Token/cost totals only change when an assistant message completes, so cache
+// the rendered string and refresh it on agent_start / message_end / agent_end
+// instead of re-scanning the whole session branch on every timer tick.
+let tokenTotals = "↑0 ↓0";
+let doneDetails = "";
+let doneTitleIndex = 0;
+let cancelDoneBlink: (() => void) | undefined;
+let cancelTokenTitle: (() => void) | undefined;
+
+// Self-rescheduling async interval with a single re-entrancy guard, returning a
+// canceller. Shared by the working-title and done-blink timers.
+function startInterval(ms: number, tick: () => Promise<void>): () => void {
+	let running = false;
+	const timer = setInterval(() => {
+		if (running) return;
+		running = true;
+		void tick().finally(() => {
+			running = false;
+		});
+	}, ms);
+	timer.unref?.();
+	return () => clearInterval(timer);
+}
+
+function stopDoneBlink(): void {
+	cancelDoneBlink?.();
+	cancelDoneBlink = undefined;
+}
+
+function stopTokenTitleUpdates(): void {
+	cancelTokenTitle?.();
+	cancelTokenTitle = undefined;
+}
+
+function formatDuration(ms: number): string {
+	const totalSeconds = Math.max(0, Math.round(ms / 1000));
+	const seconds = totalSeconds % 60;
+	const totalMinutes = Math.floor(totalSeconds / 60);
+	const minutes = totalMinutes % 60;
+	const hours = Math.floor(totalMinutes / 60);
+
+	if (hours > 0) return `${hours}h${minutes}m`;
+	if (minutes > 0) return `${minutes}m${seconds}s`;
+	return `${seconds}s`;
+}
+
+function currentElapsed(): string {
+	if (agentStartedAtMs === undefined) return "0s";
+	return formatDuration(Date.now() - agentStartedAtMs);
+}
+
+async function getTmuxPaneFormat(format: string): Promise<string | undefined> {
+	if (!tmuxPane) return undefined;
+
+	try {
+		const { stdout } = await execFileAsync("tmux", [
+			"display-message",
+			"-p",
+			"-t",
+			tmuxPane,
+			format,
+		]);
+		return String(stdout).trimEnd();
+	} catch {
+		return undefined;
+	}
+}
+
+async function getTmuxPaneTitle(): Promise<string | undefined> {
+	return getTmuxPaneFormat("#{pane_title}");
+}
+
+async function isTmuxPaneVisibleActive(): Promise<boolean> {
+	return (await getTmuxPaneFormat("#{pane_active}:#{window_active}")) === "1:1";
+}
+
+async function setTmuxPaneTitle(title: string): Promise<boolean> {
+	if (!tmuxPane) return false;
+
+	try {
+		await execFileAsync("tmux", ["select-pane", "-t", tmuxPane, "-T", title]);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function setTmuxWindowNotice(notice: string | undefined): Promise<void> {
+	if (!tmuxPane) return;
+
+	try {
+		await execFileAsync("tmux", [
+			"set-option",
+			"-w",
+			"-t",
+			tmuxPane,
+			WINDOW_NOTICE_OPTION,
+			notice ?? "",
+		]);
+	} catch {
+		// Ignore: pane title updates are the primary signal.
+	}
+}
+
+async function restoreOriginalTmuxPaneTitle(): Promise<boolean> {
+	await setTmuxWindowNotice(undefined);
+	if (originalTitle === undefined) return false;
+	return setTmuxPaneTitle(originalTitle);
+}
+
+async function setPaneTitle(
+	ctx: ExtensionContext,
+	title: string,
+): Promise<void> {
+	const updatedTmux = await setTmuxPaneTitle(title);
+	if (updatedTmux) return;
+
+	// Do not fall back to terminal-title escapes inside tmux: depending on the
+	// terminal/tmux path they can appear to affect the active pane/window.
+	if (!isInsideTmux && ctx.hasUI) ctx.ui.setTitle(title);
+}
+
+function computeTokenTotals(ctx: ExtensionContext): string {
+	const totals = getAssistantTotals(ctx.sessionManager.getBranch());
+	const parts = [
+		`↑${formatCount(totals.input)}`,
+		`↓${formatCount(totals.output)}`,
+	];
+	if (totals.cost > 0) parts.push(`$${totals.cost.toFixed(3)}`);
+	return parts.join(" ");
+}
+
+function renderMetrics(): string {
+	const parts = [tokenTotals];
+	const elapsed = currentElapsed();
+	if (elapsed !== "0s") parts.push(elapsed);
+	return parts.join(TITLE_METRICS_SEPARATOR);
+}
+
+function withOriginalPrefix(suffix: string): string {
+	return originalTitle
+		? `${originalTitle}${TITLE_METRICS_SEPARATOR}${suffix}`
+		: suffix;
+}
+
+function renderWorkingTitle(): string {
+	return withOriginalPrefix(renderMetrics());
+}
+
+function renderDoneStablePaneTitle(): string {
+	return withOriginalPrefix(doneDetails);
+}
+
+function renderDonePaneTitle(icon: (typeof DONE_ICONS)[number]): string {
+	if (!originalTitle) return `${icon} ${doneDetails}`;
+
+	// If the original title already starts with the Pi icon, reuse that slot so
+	// the notification icon does not render as "π π ...".
+	if (originalTitle.startsWith(DONE_ICON)) {
+		return `${icon}${originalTitle.slice(DONE_ICON.length)}${TITLE_METRICS_SEPARATOR}${doneDetails}`;
+	}
+
+	return `${icon} ${originalTitle}${TITLE_METRICS_SEPARATOR}${doneDetails}`;
+}
+
+function startTokenTitleUpdates(ctx: ExtensionContext): void {
+	stopTokenTitleUpdates();
+	cancelTokenTitle = startInterval(TOKEN_TITLE_UPDATE_INTERVAL_MS, () =>
+		setPaneTitle(ctx, renderWorkingTitle()),
+	);
+}
+
+function startDoneBlinkUntilActive(): void {
+	stopDoneBlink();
+
+	doneTitleIndex = 0;
+	cancelDoneBlink = startInterval(DONE_TOGGLE_INTERVAL_MS, async () => {
+		if (await isTmuxPaneVisibleActive()) {
+			await Promise.all([
+				setTmuxWindowNotice(undefined),
+				setTmuxPaneTitle(renderDoneStablePaneTitle()),
+			]);
+			stopDoneBlink();
+			return;
+		}
+
+		doneTitleIndex = (doneTitleIndex + 1) % DONE_ICONS.length;
+		await setTmuxPaneTitle(renderDonePaneTitle(DONE_ICONS[doneTitleIndex]));
+	});
+}
+
+function isPiStatusTitle(title: string): boolean {
+	return (
+		title === DONE_ICON ||
+		title === DONE_ICONS[1] ||
+		/^(?:π| ).*↑.*↓/u.test(title)
+	);
+}
+
+function register(pi: ExtensionAPI): void {
+	pi.on("agent_start", async (_event, ctx) => {
+		agentStartedAtMs = Date.now();
+		stopDoneBlink();
+		tokenTotals = computeTokenTotals(ctx);
+		startTokenTitleUpdates(ctx);
+
+		// Clearing the stale notice is independent of reading the current title.
+		const [, currentTitle] = await Promise.all([
+			setTmuxWindowNotice(undefined),
+			getTmuxPaneTitle(),
+		]);
+		if (currentTitle === undefined) return;
+
+		if (isPiStatusTitle(currentTitle)) {
+			await restoreOriginalTmuxPaneTitle();
+		} else {
+			originalTitle = currentTitle;
+		}
+
+		await setPaneTitle(ctx, renderWorkingTitle());
+	});
+
+	pi.on("message_end", async (event, ctx) => {
+		if (event.message.role !== "assistant") return;
+		tokenTotals = computeTokenTotals(ctx);
+		await setPaneTitle(ctx, renderWorkingTitle());
+	});
+
+	pi.on("agent_end", async (_event, ctx) => {
+		tokenTotals = computeTokenTotals(ctx);
+		doneDetails = renderMetrics();
+		agentStartedAtMs = undefined;
+		stopTokenTitleUpdates();
+		if (await isTmuxPaneVisibleActive()) {
+			await Promise.all([
+				setTmuxWindowNotice(undefined),
+				setPaneTitle(ctx, renderDoneStablePaneTitle()),
+			]);
+			return;
+		}
+
+		await Promise.all([
+			setPaneTitle(ctx, renderDonePaneTitle(DONE_ICON)),
+			setTmuxWindowNotice(DONE_ICON),
+		]);
+		if (tmuxPane) startDoneBlinkUntilActive();
+	});
+
+	pi.on("session_shutdown", async () => {
+		stopDoneBlink();
+		stopTokenTitleUpdates();
+		await restoreOriginalTmuxPaneTitle();
+	});
+}
+
+export default { name: "tmux-pane-title", register } satisfies Feature;

--- a/files/pi/agent/extensions/user/lib/status.ts
+++ b/files/pi/agent/extensions/user/lib/status.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { sep } from "node:path";
+import { basename } from "node:path";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type {
 	ExtensionAPI,
@@ -101,7 +101,6 @@ type Totals = {
 };
 
 const HOME = homedir();
-const CODE = `${HOME}${sep}code`;
 
 export function formatCount(value: number): string {
 	if (!Number.isFinite(value) || value <= 0) return "0";
@@ -117,10 +116,9 @@ function formatPercent(value: number): string {
 }
 
 function formatCwd(cwd: string): string {
-	if (cwd.startsWith(CODE + sep)) return cwd.slice(CODE.length + 1);
 	if (cwd === HOME) return "~";
-	if (cwd.startsWith(HOME + sep)) return `~${cwd.slice(HOME.length)}`;
-	return cwd;
+	const name = basename(cwd);
+	return name || cwd;
 }
 
 function pickRemainingColor(remaining: number): Color {
@@ -182,12 +180,21 @@ export function createStatusBarFooter(
 
 		function renderContextUsage(): string {
 			const usage = ctx.getContextUsage();
-			const contextWindow = ctx.model?.contextWindow;
-			if (!usage?.tokens || !contextWindow) return "";
+			if (!usage?.tokens) return "";
 
 			const remaining = Math.max(0, 100 - (usage.percent ?? 0));
-			const text = `${formatCount(usage.tokens)}/${formatCount(contextWindow)} (${formatPercent(remaining)})`;
+			const text = `${formatCount(usage.tokens)} (${formatPercent(remaining)})`;
 			return fg(pickRemainingColor(remaining), text);
+		}
+
+		function renderMetrics(): string {
+			const totals = getAssistantTotals(ctx.sessionManager.getBranch());
+			const parts = [
+				`↑${formatCount(totals.input)}`,
+				`↓${formatCount(totals.output)}`,
+			];
+			if (totals.cost > 0) parts.push(`$${totals.cost.toFixed(3)}`);
+			return fg(colors.muted, parts.join(" "));
 		}
 
 		function renderExtensionStatuses(): string {
@@ -216,7 +223,9 @@ export function createStatusBarFooter(
 				]
 					.filter(Boolean)
 					.join(` ${separator} `);
-				const right = [renderContextUsage()].filter(Boolean).join(" ");
+				const right = [renderMetrics(), renderContextUsage()]
+					.filter(Boolean)
+					.join(` ${separator} `);
 				const gap = " ".repeat(
 					Math.max(1, width - visibleWidth(left) - visibleWidth(right)),
 				);

--- a/files/pi/agent/extensions/user/lib/status.ts
+++ b/files/pi/agent/extensions/user/lib/status.ts
@@ -103,7 +103,7 @@ type Totals = {
 const HOME = homedir();
 const CODE = `${HOME}${sep}code`;
 
-function formatCount(value: number): string {
+export function formatCount(value: number): string {
 	if (!Number.isFinite(value) || value <= 0) return "0";
 	if (value >= 1_000_000)
 		return `${(value / 1_000_000).toFixed(value >= 10_000_000 ? 0 : 1)}M`;
@@ -129,7 +129,7 @@ function pickRemainingColor(remaining: number): Color {
 	return colors.alert;
 }
 
-function getAssistantTotals(entries: readonly SessionEntry[]): Totals {
+export function getAssistantTotals(entries: readonly SessionEntry[]): Totals {
 	const totals: Totals = { input: 0, output: 0, cost: 0 };
 
 	for (const entry of entries) {
@@ -190,14 +190,6 @@ export function createStatusBarFooter(
 			return fg(pickRemainingColor(remaining), text);
 		}
 
-		function renderTokenTotals(): string {
-			const totals = getAssistantTotals(ctx.sessionManager.getBranch());
-			const input = fg(colors.positive, `↑${formatCount(totals.input)}`);
-			const output = fg(colors.caution, `↓${formatCount(totals.output)}`);
-			const cost = fg(colors.muted, `$${totals.cost.toFixed(3)}`);
-			return `${input} ${output} ${cost}`;
-		}
-
 		function renderExtensionStatuses(): string {
 			return [...footerData.getExtensionStatuses().values()]
 				.filter(Boolean)
@@ -224,9 +216,7 @@ export function createStatusBarFooter(
 				]
 					.filter(Boolean)
 					.join(` ${separator} `);
-				const right = [renderContextUsage(), renderTokenTotals()]
-					.filter(Boolean)
-					.join(" ");
+				const right = [renderContextUsage()].filter(Boolean).join(" ");
 				const gap = " ".repeat(
 					Math.max(1, width - visibleWidth(left) - visibleWidth(right)),
 				);

--- a/files/pi/agent/extensions/user/main.ts
+++ b/files/pi/agent/extensions/user/main.ts
@@ -5,7 +5,7 @@ import modeFeature from "./features/mode";
 import quickActionsFeature from "./features/quick-actions";
 import statusFeature from "./features/status";
 import thinkingFeature from "./features/thinking";
-import tmuxPaneTitleFeature from "./features/tmux-pane-title";
+import tmuxNoticeFeature from "./features/tmux-notice";
 import fileToolsFeature from "./features/tool";
 
 const features: readonly Feature[] = [
@@ -14,7 +14,7 @@ const features: readonly Feature[] = [
 	quickActionsFeature,
 	statusFeature,
 	thinkingFeature,
-	tmuxPaneTitleFeature,
+	tmuxNoticeFeature,
 	fileToolsFeature,
 ];
 

--- a/files/pi/agent/extensions/user/main.ts
+++ b/files/pi/agent/extensions/user/main.ts
@@ -5,6 +5,7 @@ import modeFeature from "./features/mode";
 import quickActionsFeature from "./features/quick-actions";
 import statusFeature from "./features/status";
 import thinkingFeature from "./features/thinking";
+import tmuxPaneTitleFeature from "./features/tmux-pane-title";
 import fileToolsFeature from "./features/tool";
 
 const features: readonly Feature[] = [
@@ -13,6 +14,7 @@ const features: readonly Feature[] = [
 	quickActionsFeature,
 	statusFeature,
 	thinkingFeature,
+	tmuxPaneTitleFeature,
 	fileToolsFeature,
 ];
 

--- a/files/pi/agent/keybindings.json
+++ b/files/pi/agent/keybindings.json
@@ -1,9 +1,10 @@
 {
   "app.thinking.cycle": [],
+  "app.tree.foldOrUp": ["ctrl+left", "alt+left", "alt+b"],
+  "app.tree.unfoldOrDown": ["ctrl+right", "alt+right", "alt+f"],
   "tui.editor.cursorLeft": ["left"],
   "tui.editor.cursorRight": ["right"],
-  "tui.select.up": ["up", "ctrl+p"],
+  "tui.input.newLine": ["shift+enter"],
   "tui.select.down": ["down", "ctrl+n"],
-  "app.tree.foldOrUp": ["ctrl+left", "alt+left", "alt+b"],
-  "app.tree.unfoldOrDown": ["ctrl+right", "alt+right", "alt+f"]
+  "tui.select.up": ["up", "ctrl+p"]
 }

--- a/modules/dot/programs/default.nix
+++ b/modules/dot/programs/default.nix
@@ -5,5 +5,6 @@
     ./gcloud.nix
     ./ghq.nix
     ./navi.nix
+    ./tmux
   ];
 }

--- a/modules/dot/programs/tmux/default.nix
+++ b/modules/dot/programs/tmux/default.nix
@@ -21,8 +21,10 @@ let
   mkSetGlobal = mkTmuxSet " -g";
   mkSetWindowGlobal = mkTmuxSet "w -g";
 
-  sourcePlugin = name: plugin: ''
-    source-file ${plugin}/share/tmux-plugins/${name}/${name}.tmux
+  pluginPath = name: plugin: "${plugin}/share/tmux-plugins/${name}";
+
+  runPlugin = name: plugin: ''
+    run-shell ${pluginPath name plugin}/${name}.tmux
   '';
 
   mkTerminalFeature = terminal: features: ''
@@ -50,17 +52,15 @@ let
   );
 
   pluginConfig = lib.concatStringsSep "\n" [
-    (lib.optionalString cfg.plugins.sensible.enable (sourcePlugin "sensible" pkgs.tmuxPlugins.sensible))
-    (lib.optionalString cfg.plugins.resurrect.enable (
-      sourcePlugin "resurrect" pkgs.tmuxPlugins.resurrect
-    ))
+    (lib.optionalString cfg.plugins.sensible.enable (runPlugin "sensible" pkgs.tmuxPlugins.sensible))
+    (lib.optionalString cfg.plugins.resurrect.enable (runPlugin "resurrect" pkgs.tmuxPlugins.resurrect))
     (lib.optionalString cfg.catppuccin.enable ''
       set -g @catppuccin_flavor "${cfg.catppuccin.flavor}" # latte, frappe, macchiato, mocha
       set -g @catppuccin_status_background "none"
       set -g @catppuccin_window_status_style "none"
       set -g @catppuccin_pane_status_enabled "off"
       set -g @catppuccin_pane_border_status "off"
-      ${sourcePlugin "catppuccin" pkgs.tmuxPlugins.catppuccin}
+      source-file ${pluginPath "catppuccin" pkgs.tmuxPlugins.catppuccin}/catppuccin_tmux.conf
     '')
   ];
 

--- a/modules/dot/programs/tmux/default.nix
+++ b/modules/dot/programs/tmux/default.nix
@@ -1,0 +1,367 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.dot.programs.tmux;
+  paneCommand = import ./pane-command.nix { inherit pkgs; };
+  sessionSelector = import ./session-selector.nix { inherit config; };
+
+  windowNotice = "#{?@window_notice, #{@window_notice},}";
+  borderToggle = ''if -F "#{==:#{window_panes},1}" "setw pane-border-status off" "setw pane-border-status top"'';
+
+  tmuxBoolean = value: if value then "on" else "off";
+
+  mkTmuxSet =
+    scope: name: value:
+    "set${scope} ${name} ${value}";
+  mkSetGlobal = mkTmuxSet " -g";
+  mkSetWindowGlobal = mkTmuxSet "w -g";
+
+  sourcePlugin = name: plugin: ''
+    source-file ${plugin}/share/tmux-plugins/${name}/${name}.tmux
+  '';
+
+  mkTerminalFeature = terminal: features: ''
+    set -as terminal-features ',${terminal}:${lib.concatStringsSep ":" features}'
+  '';
+
+  baseConfig = ''
+    ${mkSetGlobal "default-terminal" ''"${cfg.terminal}"''}
+    ${lib.optionalString (cfg.shell != null) (mkSetGlobal "default-shell" ''"${cfg.shell}"'')}
+    ${lib.optionalString (cfg.defaultCommand != null) (
+      mkSetGlobal "default-command" ''"${cfg.defaultCommand}"''
+    )}
+    ${mkSetGlobal "base-index" (toString cfg.baseIndex)}
+    ${mkSetWindowGlobal "pane-base-index" (toString cfg.baseIndex)}
+    ${mkSetGlobal "history-limit" (toString cfg.historyLimit)}
+    ${mkSetGlobal "mouse" (tmuxBoolean cfg.mouse)}
+    ${mkSetWindowGlobal "mode-keys" cfg.keyMode}
+    unbind-key C-b
+    ${mkSetGlobal "prefix" cfg.prefix}
+    bind-key ${cfg.prefix} send-prefix
+  '';
+
+  terminalFeaturesConfig = lib.concatStrings (
+    lib.mapAttrsToList mkTerminalFeature cfg.terminalFeatures
+  );
+
+  pluginConfig = lib.concatStringsSep "\n" [
+    (lib.optionalString cfg.plugins.sensible.enable (sourcePlugin "sensible" pkgs.tmuxPlugins.sensible))
+    (lib.optionalString cfg.plugins.resurrect.enable (
+      sourcePlugin "resurrect" pkgs.tmuxPlugins.resurrect
+    ))
+    (lib.optionalString cfg.catppuccin.enable ''
+      set -g @catppuccin_flavor "${cfg.catppuccin.flavor}" # latte, frappe, macchiato, mocha
+      set -g @catppuccin_status_background "none"
+      set -g @catppuccin_window_status_style "none"
+      set -g @catppuccin_pane_status_enabled "off"
+      set -g @catppuccin_pane_border_status "off"
+      ${sourcePlugin "catppuccin" pkgs.tmuxPlugins.catppuccin}
+    '')
+  ];
+
+  statusLeftCommand =
+    if cfg.status.paneForegroundCommand.enable then
+      "#(${paneCommand.command} #{pane_tty})"
+    else
+      "#{pane_current_command}";
+
+  windowNoticeText = lib.optionalString cfg.status.windowNotice.enable windowNotice;
+
+  catppuccinStatusConfig = lib.optionalString cfg.catppuccin.enable ''
+    set -g window-status-format " #I${windowNoticeText}#{?#{!=:#{window_name},Window},: #W,} "
+    set -g window-status-style "bg=#{@thm_bg},fg=#{@thm_rosewater}"
+    set -g window-status-last-style "bg=#{@thm_bg},fg=#{@thm_peach}"
+    set -g window-status-activity-style "bg=#{@thm_red},fg=#{@thm_bg}"
+    set -g window-status-bell-style "bg=#{@thm_red},fg=#{@thm_bg},bold"
+    set -gF window-status-separator "#[bg=#{@thm_bg},fg=#{@thm_overlay_0}]│"
+    set -g window-status-current-format " #I${windowNoticeText}#{?#{!=:#{window_name},Window},: #W,} "
+    set -g window-status-current-style "bg=#{@thm_peach},fg=#{@thm_bg},bold"
+
+    set -g  status-left-length 100
+    set -g status-left ""
+    set -ga status-left "#{?client_prefix,#{#[bg=#{@thm_red},fg=#{@thm_bg},bold]  #S },#{#[bg=#{@thm_bg},fg=#{@thm_green}]  #S }}"
+    set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_maroon}]  ${statusLeftCommand} "
+
+    set -g status-right-length 100
+    set -g status-right ""
+    set -ga status-right "#[bg=#{@thm_bg},fg=#{@thm_yellow}]#{?window_zoomed_flag,  zoom ,}"
+    set -ga status-right "#[bg=#{@thm_bg},fg=#{@thm_blue}] 󰭦 %Y-%m-%d 󰅐 %H:%M "
+
+    set -g status-justify "absolute-centre"
+  '';
+
+  customPaneNavigationAndResizeConfig = lib.optionalString cfg.customPaneNavigationAndResize ''
+    bind-key h select-pane -L
+    bind-key j select-pane -D
+    bind-key k select-pane -U
+    bind-key l select-pane -R
+    bind-key H resize-pane -L ${toString cfg.resizeAmount}
+    bind-key J resize-pane -D ${toString cfg.resizeAmount}
+    bind-key K resize-pane -U ${toString cfg.resizeAmount}
+    bind-key L resize-pane -R ${toString cfg.resizeAmount}
+  '';
+
+  paneBorderConfig = lib.optionalString cfg.paneBorder.enable ''
+    ${mkSetGlobal "pane-border-indicators" cfg.paneBorder.indicators}
+    ${mkSetGlobal "pane-border-lines" cfg.paneBorder.lines}
+    ${mkSetWindowGlobal "pane-border-status" cfg.paneBorder.status}
+    ${lib.optionalString cfg.paneBorder.title.enable ''
+      setw -g pane-border-format '${cfg.paneBorder.title.format}'
+    ''}
+    ${lib.optionalString cfg.paneBorder.autoHideSinglePane.enable ''
+      set-hook -g after-split-window '${borderToggle}'
+      set-hook -g after-kill-pane '${borderToggle}'
+      set-hook -g pane-exited '${borderToggle}'
+      set-hook -g after-select-window '${borderToggle}'
+    ''}
+    ${mkSetGlobal "pane-active-border-style" "'${cfg.paneBorder.activeStyle}'"}
+  '';
+
+  terminalTitleConfig = lib.optionalString cfg.terminalTitle.enable ''
+    set -g set-titles on
+    set -g set-titles-string "${cfg.terminalTitle.format}"
+  '';
+
+  generatedConfig = lib.concatStringsSep "\n" (
+    lib.filter (value: value != "") [
+      baseConfig
+      terminalFeaturesConfig
+      pluginConfig
+      catppuccinStatusConfig
+      (lib.optionalString cfg.extendedKeys.enable ''
+        set -g extended-keys on
+        set -g extended-keys-format csi-u
+      '')
+      (lib.optionalString cfg.popupBindings.sessionSelector.enable ''
+        bind-key -T prefix s display-popup -E "nu --login -i -c '${cfg.sessionSelector.commandName}'"
+      '')
+      (lib.optionalString cfg.popupBindings.navi.enable ''
+        bind-key -T prefix g display-popup -w '95%' -h '95%' -d "#{pane_current_path}" -E "nu --login -i -c 'nv'"
+      '')
+      (lib.optionalString cfg.splitBindings.enable ''
+        bind \" split-window -v -c '#{pane_current_path}'
+        bind \' split-window -h -c '#{pane_current_path}'
+      '')
+      customPaneNavigationAndResizeConfig
+      (lib.optionalString cfg.viCopyMode.enable ''
+        bind -T copy-mode-vi v   send -X begin-selection
+        bind -T copy-mode-vi V   send -X select-line
+        bind -T copy-mode-vi C-v send -X rectangle-toggle
+        bind -T copy-mode-vi y   send -X copy-selection
+        bind -T copy-mode-vi Y   send -X copy-line
+      '')
+      paneBorderConfig
+      (lib.optionalString cfg.bell.disable ''
+        set-option -g bell-action none
+        set-option -g visual-bell off
+      '')
+      (lib.optionalString cfg.passthrough.enable ''
+        set -g allow-passthrough on
+      '')
+      terminalTitleConfig
+      (lib.optionalString cfg.renumberWindows.enable ''
+        set -g renumber-windows on
+      '')
+      (lib.optionalString cfg.automaticRename.enable ''
+        setw -g automatic-rename on
+        set -g automatic-rename-format "${cfg.automaticRename.format}"
+      '')
+      cfg.extraConfig
+    ]
+  );
+in
+{
+  options.dot.programs.tmux = {
+    enable = lib.mkEnableOption "tmux";
+
+    package = lib.mkPackageOption pkgs "tmux" { };
+
+    terminal = lib.mkOption {
+      type = lib.types.str;
+      default = "screen-256color";
+      description = "Terminal type advertised by tmux.";
+    };
+
+    shell = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Shell used by tmux. When null, default-shell is not set.";
+    };
+
+    defaultCommand = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "tmux default-command. When null, it is not set.";
+    };
+
+    baseIndex = lib.mkOption {
+      type = lib.types.int;
+      default = 0;
+      description = "tmux base-index and pane-base-index.";
+    };
+
+    prefix = lib.mkOption {
+      type = lib.types.str;
+      default = "C-b";
+      description = "tmux prefix key.";
+    };
+
+    resizeAmount = lib.mkOption {
+      type = lib.types.int;
+      default = 5;
+      description = "Pane resize amount for custom pane resize bindings.";
+    };
+
+    historyLimit = lib.mkOption {
+      type = lib.types.int;
+      default = 50000;
+      description = "tmux history-limit.";
+    };
+
+    keyMode = lib.mkOption {
+      type = lib.types.enum [
+        "emacs"
+        "vi"
+      ];
+      default = "emacs";
+      description = "tmux copy mode key bindings.";
+    };
+
+    mouse = lib.mkEnableOption "tmux mouse support";
+    customPaneNavigationAndResize = lib.mkEnableOption "custom pane navigation and resize bindings";
+
+    plugins = {
+      sensible.enable = lib.mkEnableOption "tmux sensible plugin";
+      resurrect.enable = lib.mkEnableOption "tmux resurrect plugin";
+    };
+
+    catppuccin = {
+      enable = lib.mkEnableOption "catppuccin tmux status configuration";
+      flavor = lib.mkOption {
+        type = lib.types.str;
+        default = "macchiato";
+        description = "Catppuccin flavor.";
+      };
+    };
+
+    status = {
+      paneForegroundCommand.enable = lib.mkEnableOption "argv[0]-based pane command in status-left";
+      windowNotice.enable = lib.mkEnableOption "@window_notice marker in window status";
+    };
+
+    terminalFeatures = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.listOf lib.types.str);
+      default = { };
+      description = "tmux terminal-features entries keyed by terminal name.";
+    };
+
+    extendedKeys.enable = lib.mkEnableOption "tmux extended keys";
+    passthrough.enable = lib.mkEnableOption "tmux allow-passthrough";
+
+    terminalTitle = {
+      enable = lib.mkEnableOption "tmux set-titles";
+      format = lib.mkOption {
+        type = lib.types.str;
+        default = "#T";
+        description = "tmux set-titles-string value.";
+      };
+    };
+
+    popupBindings = {
+      sessionSelector.enable = lib.mkEnableOption "prefix+s session-selector popup";
+      navi.enable = lib.mkEnableOption "prefix+g navi popup";
+    };
+
+    splitBindings.enable = lib.mkEnableOption "split-window bindings that preserve pane_current_path";
+    viCopyMode.enable = lib.mkEnableOption "vi copy-mode bindings";
+
+    paneBorder = {
+      enable = lib.mkEnableOption "pane border configuration";
+      indicators = lib.mkOption {
+        type = lib.types.str;
+        default = "off";
+        description = "pane-border-indicators value.";
+      };
+      lines = lib.mkOption {
+        type = lib.types.str;
+        default = "single";
+        description = "pane-border-lines value.";
+      };
+      status = lib.mkOption {
+        type = lib.types.str;
+        default = "off";
+        description = "pane-border-status value.";
+      };
+      activeStyle = lib.mkOption {
+        type = lib.types.str;
+        default = "fg=green";
+        description = "pane-active-border-style value.";
+      };
+      title = {
+        enable = lib.mkEnableOption "pane border title format";
+        format = lib.mkOption {
+          type = lib.types.str;
+          default = " #P #{pane_title} ";
+          description = "pane-border-format value.";
+        };
+      };
+      autoHideSinglePane.enable = lib.mkEnableOption "pane border status auto-hide for single-pane windows";
+    };
+
+    bell.disable = lib.mkEnableOption "tmux bell and visual-bell disablement";
+
+    automaticRename = {
+      enable = lib.mkEnableOption "tmux automatic-rename";
+      format = lib.mkOption {
+        type = lib.types.str;
+        default = "Window";
+        description = "automatic-rename-format value.";
+      };
+    };
+
+    renumberWindows.enable = lib.mkEnableOption "tmux renumber-windows";
+
+    sessionSelector = {
+      enable = lib.mkEnableOption "tmux session selector shell function";
+      commandName = lib.mkOption {
+        type = lib.types.str;
+        default = "tm";
+        description = "Shell function name for selecting tmux sessions.";
+      };
+      defaultSessionName = lib.mkOption {
+        type = lib.types.str;
+        default = "main";
+        description = "Session created when no tmux sessions exist.";
+      };
+      zshIntegration.enable = lib.mkEnableOption "zsh integration";
+      nushellIntegration.enable = lib.mkEnableOption "nushell integration";
+    };
+
+    extraConfig = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      description = "Additional tmux configuration appended after generated configuration.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."tmux/tmux.conf".text = generatedConfig;
+
+    programs = {
+      zsh.initContent = lib.mkIf (
+        cfg.sessionSelector.enable && cfg.sessionSelector.zshIntegration.enable
+      ) sessionSelector.zsh;
+
+      nushell.extraConfig = lib.mkIf (
+        cfg.sessionSelector.enable && cfg.sessionSelector.nushellIntegration.enable
+      ) sessionSelector.nushell;
+    };
+  };
+}

--- a/modules/dot/programs/tmux/pane-command.nix
+++ b/modules/dot/programs/tmux/pane-command.nix
@@ -1,0 +1,22 @@
+{ pkgs, ... }:
+
+{
+  # Print a pane's foreground command by argv[0] (kernel comm can be a version-named binary).
+  command = pkgs.writeShellScript "tmux-pane-cmd" ''
+    tty=''${1#/dev/}
+    [ -n "$tty" ] || exit 0
+    fpgid=$(ps -t "$tty" -o tpgid= 2>/dev/null | ${pkgs.gawk}/bin/awk 'NR==1{gsub(/ /,"");print;exit}')
+    case "$fpgid" in
+      "" | *[!0-9]*) ;;
+      *)
+        argv0=$(ps -o command= -p "$fpgid" 2>/dev/null | ${pkgs.gawk}/bin/awk '{print $1; exit}')
+        if [ -n "$argv0" ]; then
+          name=''${argv0##*/}
+          printf '%s' "''${name#-}"
+          exit 0
+        fi
+        ;;
+    esac
+    ps -o comm= -p "$fpgid" 2>/dev/null | ${pkgs.gawk}/bin/awk '{sub(/.*\//,"",$1); print $1; exit}'
+  '';
+}

--- a/modules/dot/programs/tmux/session-selector.nix
+++ b/modules/dot/programs/tmux/session-selector.nix
@@ -1,0 +1,70 @@
+{
+  config,
+  ...
+}:
+
+let
+  cfg = config.dot.programs.tmux;
+  fuzzyFinderCommand = config.dot.options.fuzzyFinder.command;
+in
+{
+  zsh = ''
+    function ${cfg.sessionSelector.commandName}() {
+      if ! ${cfg.package}/bin/tmux has-session 2>/dev/null; then
+        ${cfg.package}/bin/tmux new-session -s ${cfg.sessionSelector.defaultSessionName} -c $HOME -d
+      fi
+
+      target=$(
+        ${cfg.package}/bin/tmux list-sessions -F "#S" | ${fuzzyFinderCommand} \
+          --header='Ctrl+C: new | Ctrl-D: delete' \
+          --bind='ctrl-c:reload(zoxide query --list)' \
+          --bind='ctrl-d:execute(${cfg.package}/bin/tmux kill-session -t {1})+reload(${cfg.package}/bin/tmux list-sessions -F "#S")'
+      )
+
+      if [ -z "$target" ]; then
+        return
+      fi
+
+      if ! ${cfg.package}/bin/tmux has-session -t "$target" 2>/dev/null; then
+        session_name=$(basename "$target")
+        ${cfg.package}/bin/tmux new-session -s $session_name -c "$target" -d
+        target="$session_name"
+      fi
+
+      if [ -z "$TMUX" ]; then
+        ${cfg.package}/bin/tmux attach-session -t "$target"
+      else
+        ${cfg.package}/bin/tmux switch-client -t "$target"
+      fi
+    }
+  '';
+
+  nushell = ''
+    export def ${cfg.sessionSelector.commandName} [] {
+      if (${cfg.package}/bin/tmux has-session | complete | get exit_code | $in != 0) {
+        ${cfg.package}/bin/tmux new-session -s ${cfg.sessionSelector.defaultSessionName} -c $env.HOME -d
+      }
+
+      mut target = (
+        ${cfg.package}/bin/tmux list-sessions -F "#S" | ${fuzzyFinderCommand}
+          --header='Ctrl+C: new | Ctrl-D: delete'
+          --bind='ctrl-c:reload(zoxide query --list)'
+          --bind='ctrl-d:execute(${cfg.package}/bin/tmux kill-session -t {1})+reload(${cfg.package}/bin/tmux list-sessions -F "#S")'
+        | complete | get "stdout" | str trim
+      )
+
+      if ($target | is-empty) { return }
+      if (${cfg.package}/bin/tmux has-session -t $target | complete | get exit_code | $in != 0) {
+        let session_name = $target | path basename
+        ${cfg.package}/bin/tmux new-session -s $session_name -c $target -d
+        $target = $session_name
+      }
+
+      if ($env.TMUX | is-empty) {
+        ${cfg.package}/bin/tmux attach-session -t $target
+      } else {
+        ${cfg.package}/bin/tmux switch-client -t $target
+      }
+    }
+  '';
+}

--- a/modules/recipes/ghostty.nix
+++ b/modules/recipes/ghostty.nix
@@ -39,7 +39,6 @@ _:
       # keybind
       keybind = [
         "ctrl+j=ignore"
-        "shift+enter=text:\\x1b\\r"
         "ctrl+shift+r=reload_config"
       ];
     };

--- a/modules/recipes/tmux.nix
+++ b/modules/recipes/tmux.nix
@@ -1,203 +1,113 @@
+{ pkgs, ... }:
+
 {
-  config,
-  lib,
-  pkgs,
-  ...
-}:
+  config.dot.programs.tmux = {
+    enable = true;
 
-with lib;
-let
-  # Print a pane's foreground command by argv[0] (kernel comm can be a version-named binary).
-  tmuxPaneCmd = pkgs.writeShellScript "tmux-pane-cmd" ''
-    tty=''${1#/dev/}
-    [ -n "$tty" ] || exit 0
-    # foreground pgid; its leader has pid == pgid == tpgid
-    fpgid=$(ps -t "$tty" -o tpgid= 2>/dev/null | ${pkgs.gawk}/bin/awk 'NR==1{gsub(/ /,"");print;exit}')
-    case "$fpgid" in
-      "" | *[!0-9]*) ;;
-      *)
-        argv0=$(ps -o command= -p "$fpgid" 2>/dev/null | ${pkgs.gawk}/bin/awk '{print $1; exit}')
-        if [ -n "$argv0" ]; then
-          name=''${argv0##*/}
-          printf '%s' "''${name#-}"
-          exit 0
-        fi
-        ;;
-    esac
-    # fallback: kernel comm basename
-    ps -o comm= -p "$fpgid" 2>/dev/null | ${pkgs.gawk}/bin/awk '{sub(/.*\//,"",$1); print $1; exit}'
-  '';
+    terminal = "tmux-256color";
+    shell = "${pkgs.zsh}/bin/zsh";
+    defaultCommand = "${pkgs.nushell}/bin/nu";
 
-  # Show the pane's window notice (set by the tmux-pane-title extension) before the window name.
-  windowNotice = "#{?@window_notice, #{@window_notice},}";
+    baseIndex = 1;
+    customPaneNavigationAndResize = true;
+    historyLimit = 9999999;
+    keyMode = "vi";
+    mouse = true;
+    prefix = "C-q";
+    resizeAmount = 5;
 
-  # Hide the pane border status line when a window has a single pane.
-  borderToggle = ''if -F "#{==:#{window_panes},1}" "setw pane-border-status off" "setw pane-border-status top"'';
-in
-{
-  config = {
-    programs = {
-      tmux = {
+    plugins = {
+      sensible.enable = true;
+      resurrect.enable = true;
+    };
+
+    catppuccin = {
+      enable = true;
+      flavor = "macchiato";
+    };
+
+    status = {
+      paneForegroundCommand.enable = true;
+      windowNotice.enable = true;
+    };
+
+    terminalFeatures = {
+      xterm-256color = [
+        "bpaste"
+        "ccolour"
+        "clipboard"
+        "cstyle"
+        "focus"
+        "RGB"
+        "sixel"
+        "title"
+      ];
+      xterm-ghostty = [
+        "256"
+        "bpaste"
+        "ccolour"
+        "clipboard"
+        "hyperlinks"
+        "cstyle"
+        "extkeys"
+        "focus"
+        "ignorefkeys"
+        "margins"
+        "mouse"
+        "osc7"
+        "overline"
+        "rectfill"
+        "RGB"
+        "sixel"
+        "strikethrough"
+        "sync"
+        "title"
+        "usstyle"
+        "progressbar"
+      ];
+    };
+
+    extendedKeys.enable = true;
+    passthrough.enable = true;
+
+    terminalTitle = {
+      enable = true;
+      format = "#T";
+    };
+
+    popupBindings = {
+      sessionSelector.enable = true;
+      navi.enable = true;
+    };
+    splitBindings.enable = true;
+    viCopyMode.enable = true;
+
+    paneBorder = {
+      enable = true;
+      indicators = "off";
+      lines = "heavy";
+      status = "off";
+      activeStyle = "fg=#ffb86c";
+      title = {
         enable = true;
-
-        terminal = "tmux-256color";
-        shell = "${pkgs.zsh}/bin/zsh";
-
-        baseIndex = 1;
-        customPaneNavigationAndResize = true;
-        historyLimit = 9999999;
-        keyMode = "vi";
-        mouse = true;
-        prefix = "C-q";
-        resizeAmount = 5;
-
-        plugins = with pkgs; [
-          tmuxPlugins.sensible
-          tmuxPlugins.resurrect
-          {
-            plugin = tmuxPlugins.catppuccin;
-            extraConfig = ''
-              set -g @catppuccin_flavor "macchiato" # latte, frappe, macchiato, mocha
-              set -g @catppuccin_status_background "none"
-              set -g @catppuccin_window_status_style "none"
-              set -g @catppuccin_pane_status_enabled "off"
-              set -g @catppuccin_pane_border_status "off"
-
-              set -g window-status-format " #I${windowNotice}#{?#{!=:#{window_name},Window},: #W,} "
-              set -g window-status-style "bg=#{@thm_bg},fg=#{@thm_rosewater}"
-              set -g window-status-last-style "bg=#{@thm_bg},fg=#{@thm_peach}"
-              set -g window-status-activity-style "bg=#{@thm_red},fg=#{@thm_bg}"
-              set -g window-status-bell-style "bg=#{@thm_red},fg=#{@thm_bg},bold"
-              set -gF window-status-separator "#[bg=#{@thm_bg},fg=#{@thm_overlay_0}]│"
-              set -g window-status-current-format " #I${windowNotice}#{?#{!=:#{window_name},Window},: #W,} "
-              set -g window-status-current-style "bg=#{@thm_peach},fg=#{@thm_bg},bold"
-
-              set -g  status-left-length 100
-              set -g status-left ""
-              set -ga status-left "#{?client_prefix,#{#[bg=#{@thm_red},fg=#{@thm_bg},bold]  #S },#{#[bg=#{@thm_bg},fg=#{@thm_green}]  #S }}"
-              # show argv[0] basename (see tmuxPaneCmd) instead of the kernel comm
-              set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_maroon}]  #(${tmuxPaneCmd} #{pane_tty}) "
-
-              set -g status-right-length 100
-              set -g status-right ""
-              set -ga status-right "#[bg=#{@thm_bg},fg=#{@thm_yellow}]#{?window_zoomed_flag,  zoom ,}"
-              set -ga status-right "#[bg=#{@thm_bg},fg=#{@thm_blue}] 󰭦 %Y-%m-%d 󰅐 %H:%M "
-
-              set -g status-justify "absolute-centre"
-            '';
-          }
-        ];
-
-        extraConfig = ''
-          set -as terminal-features ',xterm-256color:bpaste:ccolour:clipboard:cstyle:focus:RGB:sixel:title'
-          set -as terminal-features ',xterm-ghostty:256:bpaste:ccolour:clipboard:hyperlinks:cstyle:extkeys:focus:ignorefkeys:margins:mouse:osc7:overline:rectfill:RGB:sixel:strikethrough:sync:title:usstyle:progressbar'
-          set -g extended-keys on
-          set -g extended-keys-format csi-u
-          set -g default-command "${pkgs.nushell}/bin/nu"
-
-          # bind
-          bind-key -T prefix s display-popup                                             -E "nu --login -i -c 'tm'"
-          bind-key -T prefix g display-popup -w '95%' -h '95%' -d "#{pane_current_path}" -E "nu --login -i -c 'nv'"
-          bind \" split-window -v -c '#{pane_current_path}'
-          bind \' split-window -h -c '#{pane_current_path}'
-
-          # copy
-          set-window-option -g mode-keys vi
-          setw -g mode-keys vi
-          bind -T copy-mode-vi v   send -X begin-selection
-          bind -T copy-mode-vi V   send -X select-line
-          bind -T copy-mode-vi C-v send -X rectangle-toggle
-          bind -T copy-mode-vi y   send -X copy-selection
-          bind -T copy-mode-vi Y   send -X copy-line
-
-          # border
-          set -g pane-border-indicators off
-          set -g pane-border-lines heavy
-          setw -g pane-border-status off
-          setw -g pane-border-format ' #P#{?#{||:#{==:#{pane_title},π},#{==:#{pane_title}, }}, #{pane_title}, #{pane_title}} '
-          set-hook -g after-split-window '${borderToggle}'
-          set-hook -g after-kill-pane '${borderToggle}'
-          set-hook -g pane-exited '${borderToggle}'
-          set-hook -g after-select-window '${borderToggle}'
-          set -g pane-active-border-style 'fg=#ffb86c'
-
-          # disable bell
-          set-option -g bell-action none
-          set-option -g visual-bell off
-
-          # allow apps to pass escapes to the outer terminal
-          set -g allow-passthrough on
-
-          # propagate the running program's title to the outer terminal
-          set -g set-titles on
-          set -g set-titles-string "#T"
-
-          # basic
-          set -g renumber-windows on
-          setw -g automatic-rename on
-          set -g automatic-rename-format "Window"
-        '';
+        format = " #P#{?#{||:#{==:#{pane_title},π},#{==:#{pane_title}, }}, #{pane_title}, #{pane_title}} ";
       };
+      autoHideSinglePane.enable = true;
+    };
 
-      zsh.initContent = ''
-        function tm() {
-          if ! tmux has-session 2>/dev/null; then
-            tmux new-session -s main -c $HOME -d
-          fi
+    bell.disable = true;
+    renumberWindows.enable = true;
+    automaticRename = {
+      enable = true;
+      format = "Window";
+    };
 
-          target=$(
-            tmux list-sessions -F "#S" | ${config.dot.options.fuzzyFinder.command} \
-              --header='Ctrl+C: new | Ctrl-D: delete' \
-              --bind='ctrl-c:reload(zoxide query --list)' \
-              --bind='ctrl-d:execute(tmux kill-session -t {1})+reload(tmux list-sessions -F "#S")'
-          )
-
-          if [ -z "$target" ]; then
-            return
-          fi
-
-          if ! tmux has-session -t "$target" 2>/dev/null; then
-            session_name=$(basename "$target")
-            tmux new-session -s $session_name -c "$target" -d
-            target="$session_name"
-          fi
-
-          if [ -z "$TMUX" ]; then
-            tmux attach-session -t "$target"
-          else
-            tmux switch-client -t "$target"
-          fi
-        }
-      '';
-
-      nushell.extraConfig = ''
-        export def tm [] {
-          if (tmux has-session | complete | get exit_code | $in != 0) {
-            tmux new-session -s main -c $env.HOME -d
-          }
-
-          mut target = (
-            tmux list-sessions -F "#S" | ${config.dot.options.fuzzyFinder.command}
-              --header='Ctrl+C: new | Ctrl-D: delete'
-              --bind='ctrl-c:reload(zoxide query --list)'
-              --bind='ctrl-d:execute(tmux kill-session -t {1})+reload(tmux list-sessions -F "#S")'
-            | complete | get "stdout" | str trim
-          )
-
-          if ($target | is-empty) { return }
-          if (tmux has-session -t $target | complete | get exit_code | $in != 0) {
-            let session_name = $target | path basename
-            tmux new-session -s $session_name -c $target -d
-            $target = $session_name
-          }
-
-          if ($env.TMUX | is-empty) {
-            tmux attach-session -t $target
-          } else {
-            tmux switch-client -t $target
-          }
-        }
-      '';
+    sessionSelector = {
+      enable = true;
+      commandName = "tm";
+      defaultSessionName = "main";
+      zshIntegration.enable = true;
+      nushellIntegration.enable = true;
     };
   };
 }

--- a/modules/recipes/tmux.nix
+++ b/modules/recipes/tmux.nix
@@ -6,13 +6,41 @@
 }:
 
 with lib;
+let
+  # Print a pane's foreground command by argv[0] (kernel comm can be a version-named binary).
+  tmuxPaneCmd = pkgs.writeShellScript "tmux-pane-cmd" ''
+    tty=''${1#/dev/}
+    [ -n "$tty" ] || exit 0
+    # foreground pgid; its leader has pid == pgid == tpgid
+    fpgid=$(ps -t "$tty" -o tpgid= 2>/dev/null | ${pkgs.gawk}/bin/awk 'NR==1{gsub(/ /,"");print;exit}')
+    case "$fpgid" in
+      "" | *[!0-9]*) ;;
+      *)
+        argv0=$(ps -o command= -p "$fpgid" 2>/dev/null | ${pkgs.gawk}/bin/awk '{print $1; exit}')
+        if [ -n "$argv0" ]; then
+          name=''${argv0##*/}
+          printf '%s' "''${name#-}"
+          exit 0
+        fi
+        ;;
+    esac
+    # fallback: kernel comm basename
+    ps -o comm= -p "$fpgid" 2>/dev/null | ${pkgs.gawk}/bin/awk '{sub(/.*\//,"",$1); print $1; exit}'
+  '';
+
+  # Show the pane's window notice (set by the tmux-pane-title extension) before the window name.
+  windowNotice = "#{?@window_notice, #{@window_notice},}";
+
+  # Hide the pane border status line when a window has a single pane.
+  borderToggle = ''if -F "#{==:#{window_panes},1}" "setw pane-border-status off" "setw pane-border-status top"'';
+in
 {
   config = {
     programs = {
       tmux = {
         enable = true;
 
-        terminal = "screen-256color";
+        terminal = "tmux-256color";
         shell = "${pkgs.zsh}/bin/zsh";
 
         baseIndex = 1;
@@ -35,19 +63,20 @@ with lib;
               set -g @catppuccin_pane_status_enabled "off"
               set -g @catppuccin_pane_border_status "off"
 
-              set -g window-status-format " #I#{?#{!=:#{window_name},Window},: #W,} "
+              set -g window-status-format " #I${windowNotice}#{?#{!=:#{window_name},Window},: #W,} "
               set -g window-status-style "bg=#{@thm_bg},fg=#{@thm_rosewater}"
               set -g window-status-last-style "bg=#{@thm_bg},fg=#{@thm_peach}"
               set -g window-status-activity-style "bg=#{@thm_red},fg=#{@thm_bg}"
               set -g window-status-bell-style "bg=#{@thm_red},fg=#{@thm_bg},bold"
               set -gF window-status-separator "#[bg=#{@thm_bg},fg=#{@thm_overlay_0}]│"
-              set -g window-status-current-format " #I#{?#{!=:#{window_name},Window},: #W,} "
+              set -g window-status-current-format " #I${windowNotice}#{?#{!=:#{window_name},Window},: #W,} "
               set -g window-status-current-style "bg=#{@thm_peach},fg=#{@thm_bg},bold"
 
               set -g  status-left-length 100
               set -g status-left ""
               set -ga status-left "#{?client_prefix,#{#[bg=#{@thm_red},fg=#{@thm_bg},bold]  #S },#{#[bg=#{@thm_bg},fg=#{@thm_green}]  #S }}"
-              set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_maroon}]  #{pane_current_command} "
+              # show argv[0] basename (see tmuxPaneCmd) instead of the kernel comm
+              set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_maroon}]  #(${tmuxPaneCmd} #{pane_tty}) "
 
               set -g status-right-length 100
               set -g status-right ""
@@ -60,7 +89,8 @@ with lib;
         ];
 
         extraConfig = ''
-          set -ga terminal-overrides ',xterm-256color:Tc'
+          set -as terminal-features ',xterm-256color:bpaste:ccolour:clipboard:cstyle:focus:RGB:sixel:title'
+          set -as terminal-features ',xterm-ghostty:256:bpaste:ccolour:clipboard:hyperlinks:cstyle:extkeys:focus:ignorefkeys:margins:mouse:osc7:overline:rectfill:RGB:sixel:strikethrough:sync:title:usstyle:progressbar'
           set -g extended-keys on
           set -g extended-keys-format csi-u
           set -g default-command "${pkgs.nushell}/bin/nu"
@@ -83,11 +113,24 @@ with lib;
           # border
           set -g pane-border-indicators off
           set -g pane-border-lines heavy
+          setw -g pane-border-status off
+          setw -g pane-border-format ' #P#{?#{||:#{==:#{pane_title},π},#{==:#{pane_title}, }}, #{pane_title}, #{pane_title}} '
+          set-hook -g after-split-window '${borderToggle}'
+          set-hook -g after-kill-pane '${borderToggle}'
+          set-hook -g pane-exited '${borderToggle}'
+          set-hook -g after-select-window '${borderToggle}'
           set -g pane-active-border-style 'fg=#ffb86c'
 
           # disable bell
           set-option -g bell-action none
           set-option -g visual-bell off
+
+          # allow apps to pass escapes to the outer terminal
+          set -g allow-passthrough on
+
+          # propagate the running program's title to the outer terminal
+          set -g set-titles on
+          set -g set-titles-string "#T"
 
           # basic
           set -g renumber-windows on


### PR DESCRIPTION
## Summary

- add a Pi extension that updates the tmux pane title with token, cost, and elapsed-time metrics
- use tmux pane/window state to signal completed background work without desktop notifications
- hide pane border titles for single-pane windows and show generic window notices via @window_notice

## Background

This makes Pi completion state visible inside tmux while preserving manually named windows. The pane title keeps the normal title plus lightweight metrics, and completed background turns blink only the pane icon until the pane is focused again.