### PR TITLE
Refactor tmux option layout

### DIFF
--- a/modules/dot/programs/tmux/default.nix
+++ b/modules/dot/programs/tmux/default.nix
@@ -11,7 +11,8 @@ let
   sessionSelector = import ./session-selector.nix { inherit config; };
 
   windowNotice = "#{?@window_notice, #{@window_notice},}";
-  borderToggle = ''if -F "#{==:#{window_panes},1}" "setw pane-border-status off" "setw pane-border-status top"'';
+  borderToggle = ''if -F "#{==:#{window_panes},1}" "setw pane-border-status off" "setw pane-border-status ${cfg.paneBorder.title.position}"'';
+  resizeRepeatFlag = lib.optionalString cfg.keyBindings.paneResize.repeatable "-r ";
 
   tmuxBoolean = value: if value then "on" else "off";
 
@@ -54,8 +55,8 @@ let
   pluginConfig = lib.concatStringsSep "\n" [
     (lib.optionalString cfg.plugins.sensible.enable (runPlugin "sensible" pkgs.tmuxPlugins.sensible))
     (lib.optionalString cfg.plugins.resurrect.enable (runPlugin "resurrect" pkgs.tmuxPlugins.resurrect))
-    (lib.optionalString cfg.catppuccin.enable ''
-      set -g @catppuccin_flavor "${cfg.catppuccin.flavor}" # latte, frappe, macchiato, mocha
+    (lib.optionalString cfg.plugins.catppuccin.enable ''
+      set -g @catppuccin_flavor "${cfg.plugins.catppuccin.flavor}" # latte, frappe, macchiato, mocha
       set -g @catppuccin_status_background "none"
       set -g @catppuccin_window_status_style "none"
       set -g @catppuccin_pane_status_enabled "off"
@@ -72,7 +73,7 @@ let
 
   windowNoticeText = lib.optionalString cfg.status.windowNotice.enable windowNotice;
 
-  catppuccinStatusConfig = lib.optionalString cfg.catppuccin.enable ''
+  catppuccinStatusConfig = lib.optionalString cfg.plugins.catppuccin.enable ''
     set -g window-status-format " #I${windowNoticeText}#{?#{!=:#{window_name},Window},: #W,} "
     set -g window-status-style "bg=#{@thm_bg},fg=#{@thm_rosewater}"
     set -g window-status-last-style "bg=#{@thm_bg},fg=#{@thm_peach}"
@@ -95,30 +96,42 @@ let
     set -g status-justify "absolute-centre"
   '';
 
-  customPaneNavigationAndResizeConfig = lib.optionalString cfg.customPaneNavigationAndResize ''
+  paneNavigationAndResizeBindingsConfig = lib.optionalString cfg.keyBindings.paneNavigationAndResize.enable ''
     bind-key h select-pane -L
     bind-key j select-pane -D
     bind-key k select-pane -U
     bind-key l select-pane -R
-    bind-key H resize-pane -L ${toString cfg.resizeAmount}
-    bind-key J resize-pane -D ${toString cfg.resizeAmount}
-    bind-key K resize-pane -U ${toString cfg.resizeAmount}
-    bind-key L resize-pane -R ${toString cfg.resizeAmount}
+    bind-key ${resizeRepeatFlag}H resize-pane -L ${toString cfg.keyBindings.paneResize.amount}
+    bind-key ${resizeRepeatFlag}J resize-pane -D ${toString cfg.keyBindings.paneResize.amount}
+    bind-key ${resizeRepeatFlag}K resize-pane -U ${toString cfg.keyBindings.paneResize.amount}
+    bind-key ${resizeRepeatFlag}L resize-pane -R ${toString cfg.keyBindings.paneResize.amount}
   '';
 
   paneBorderConfig = lib.optionalString cfg.paneBorder.enable ''
     ${mkSetGlobal "pane-border-indicators" cfg.paneBorder.indicators}
     ${mkSetGlobal "pane-border-lines" cfg.paneBorder.lines}
-    ${mkSetWindowGlobal "pane-border-status" cfg.paneBorder.status}
+    ${mkSetWindowGlobal "pane-border-status" cfg.paneBorder.title.position}
     ${lib.optionalString cfg.paneBorder.title.enable ''
       setw -g pane-border-format '${cfg.paneBorder.title.format}'
     ''}
-    ${lib.optionalString cfg.paneBorder.autoHideSinglePane.enable ''
-      set-hook -g after-split-window '${borderToggle}'
-      set-hook -g after-kill-pane '${borderToggle}'
-      set-hook -g pane-exited '${borderToggle}'
-      set-hook -g after-select-window '${borderToggle}'
-    ''}
+    ${
+      if cfg.paneBorder.autoHideSinglePane.enable then
+        ''
+          ${borderToggle}
+          set-hook -g after-split-window '${borderToggle}'
+          set-hook -g after-kill-pane '${borderToggle}'
+          set-hook -g pane-exited '${borderToggle}'
+          set-hook -g after-select-window '${borderToggle}'
+        ''
+      else
+        ''
+          setw pane-border-status ${cfg.paneBorder.title.position}
+          set-hook -gu after-split-window
+          set-hook -gu after-kill-pane
+          set-hook -gu pane-exited
+          set-hook -gu after-select-window
+        ''
+    }
     ${mkSetGlobal "pane-active-border-style" "'${cfg.paneBorder.activeStyle}'"}
   '';
 
@@ -137,18 +150,18 @@ let
         set -g extended-keys on
         set -g extended-keys-format csi-u
       '')
-      (lib.optionalString cfg.popupBindings.sessionSelector.enable ''
+      (lib.optionalString cfg.keyBindings.popups.sessionSelector.enable ''
         bind-key -T prefix s display-popup -E "nu --login -i -c '${cfg.sessionSelector.commandName}'"
       '')
-      (lib.optionalString cfg.popupBindings.navi.enable ''
+      (lib.optionalString cfg.keyBindings.popups.navi.enable ''
         bind-key -T prefix g display-popup -w '95%' -h '95%' -d "#{pane_current_path}" -E "nu --login -i -c 'nv'"
       '')
-      (lib.optionalString cfg.splitBindings.enable ''
+      (lib.optionalString cfg.keyBindings.split.enable ''
         bind \" split-window -v -c '#{pane_current_path}'
         bind \' split-window -h -c '#{pane_current_path}'
       '')
-      customPaneNavigationAndResizeConfig
-      (lib.optionalString cfg.viCopyMode.enable ''
+      paneNavigationAndResizeBindingsConfig
+      (lib.optionalString cfg.keyBindings.copyModeVi.enable ''
         bind -T copy-mode-vi v   send -X begin-selection
         bind -T copy-mode-vi V   send -X select-line
         bind -T copy-mode-vi C-v send -X rectangle-toggle
@@ -211,12 +224,6 @@ in
       description = "tmux prefix key.";
     };
 
-    resizeAmount = lib.mkOption {
-      type = lib.types.int;
-      default = 5;
-      description = "Pane resize amount for custom pane resize bindings.";
-    };
-
     historyLimit = lib.mkOption {
       type = lib.types.int;
       default = 50000;
@@ -233,20 +240,36 @@ in
     };
 
     mouse = lib.mkEnableOption "tmux mouse support";
-    customPaneNavigationAndResize = lib.mkEnableOption "custom pane navigation and resize bindings";
 
     plugins = {
       sensible.enable = lib.mkEnableOption "tmux sensible plugin";
       resurrect.enable = lib.mkEnableOption "tmux resurrect plugin";
+      catppuccin = {
+        enable = lib.mkEnableOption "catppuccin tmux plugin and status configuration";
+        flavor = lib.mkOption {
+          type = lib.types.str;
+          default = "macchiato";
+          description = "Catppuccin flavor.";
+        };
+      };
     };
 
-    catppuccin = {
-      enable = lib.mkEnableOption "catppuccin tmux status configuration";
-      flavor = lib.mkOption {
-        type = lib.types.str;
-        default = "macchiato";
-        description = "Catppuccin flavor.";
+    keyBindings = {
+      paneNavigationAndResize.enable = lib.mkEnableOption "custom pane navigation and resize bindings";
+      paneResize = {
+        amount = lib.mkOption {
+          type = lib.types.int;
+          default = 5;
+          description = "Pane resize amount for custom pane resize bindings.";
+        };
+        repeatable = lib.mkEnableOption "repeatable pane resize bindings";
       };
+      popups = {
+        sessionSelector.enable = lib.mkEnableOption "prefix+s session-selector popup";
+        navi.enable = lib.mkEnableOption "prefix+g navi popup";
+      };
+      split.enable = lib.mkEnableOption "split-window bindings that preserve pane_current_path";
+      copyModeVi.enable = lib.mkEnableOption "vi copy-mode bindings";
     };
 
     status = {
@@ -263,6 +286,20 @@ in
     extendedKeys.enable = lib.mkEnableOption "tmux extended keys";
     passthrough.enable = lib.mkEnableOption "tmux allow-passthrough";
 
+    zshIntegration.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = config.programs.zsh.enable;
+      defaultText = lib.literalExpression "config.programs.zsh.enable";
+      description = "Whether to enable zsh integration for tmux features by default.";
+    };
+
+    nushellIntegration.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = config.programs.nushell.enable;
+      defaultText = lib.literalExpression "config.programs.nushell.enable";
+      description = "Whether to enable nushell integration for tmux features by default.";
+    };
+
     terminalTitle = {
       enable = lib.mkEnableOption "tmux set-titles";
       format = lib.mkOption {
@@ -271,14 +308,6 @@ in
         description = "tmux set-titles-string value.";
       };
     };
-
-    popupBindings = {
-      sessionSelector.enable = lib.mkEnableOption "prefix+s session-selector popup";
-      navi.enable = lib.mkEnableOption "prefix+g navi popup";
-    };
-
-    splitBindings.enable = lib.mkEnableOption "split-window bindings that preserve pane_current_path";
-    viCopyMode.enable = lib.mkEnableOption "vi copy-mode bindings";
 
     paneBorder = {
       enable = lib.mkEnableOption "pane border configuration";
@@ -292,11 +321,6 @@ in
         default = "single";
         description = "pane-border-lines value.";
       };
-      status = lib.mkOption {
-        type = lib.types.str;
-        default = "off";
-        description = "pane-border-status value.";
-      };
       activeStyle = lib.mkOption {
         type = lib.types.str;
         default = "fg=green";
@@ -304,13 +328,22 @@ in
       };
       title = {
         enable = lib.mkEnableOption "pane border title format";
+        position = lib.mkOption {
+          type = lib.types.enum [
+            "off"
+            "top"
+            "bottom"
+          ];
+          default = "off";
+          description = "Position of the pane border title/status line.";
+        };
         format = lib.mkOption {
           type = lib.types.str;
           default = " #P #{pane_title} ";
           description = "pane-border-format value.";
         };
       };
-      autoHideSinglePane.enable = lib.mkEnableOption "pane border status auto-hide for single-pane windows";
+      autoHideSinglePane.enable = lib.mkEnableOption "pane border title/status auto-hide for single-pane windows";
     };
 
     bell.disable = lib.mkEnableOption "tmux bell and visual-bell disablement";
@@ -338,8 +371,18 @@ in
         default = "main";
         description = "Session created when no tmux sessions exist.";
       };
-      zshIntegration.enable = lib.mkEnableOption "zsh integration";
-      nushellIntegration.enable = lib.mkEnableOption "nushell integration";
+      zshIntegration.enable = lib.mkOption {
+        type = lib.types.bool;
+        default = cfg.zshIntegration.enable;
+        defaultText = lib.literalExpression "config.dot.programs.tmux.zshIntegration.enable";
+        description = "Whether to install the session selector zsh integration.";
+      };
+      nushellIntegration.enable = lib.mkOption {
+        type = lib.types.bool;
+        default = cfg.nushellIntegration.enable;
+        defaultText = lib.literalExpression "config.dot.programs.tmux.nushellIntegration.enable";
+        description = "Whether to install the session selector nushell integration.";
+      };
     };
 
     extraConfig = lib.mkOption {

--- a/modules/recipes/tmux.nix
+++ b/modules/recipes/tmux.nix
@@ -9,21 +9,32 @@
     defaultCommand = "${pkgs.nushell}/bin/nu";
 
     baseIndex = 1;
-    customPaneNavigationAndResize = true;
     historyLimit = 9999999;
     keyMode = "vi";
     mouse = true;
     prefix = "C-q";
-    resizeAmount = 5;
 
     plugins = {
       sensible.enable = true;
       resurrect.enable = true;
+      catppuccin = {
+        enable = true;
+        flavor = "macchiato";
+      };
     };
 
-    catppuccin = {
-      enable = true;
-      flavor = "macchiato";
+    keyBindings = {
+      paneNavigationAndResize.enable = true;
+      paneResize = {
+        amount = 5;
+        repeatable = true;
+      };
+      popups = {
+        sessionSelector.enable = true;
+        navi.enable = true;
+      };
+      split.enable = true;
+      copyModeVi.enable = true;
     };
 
     status = {
@@ -75,24 +86,16 @@
       format = "#T";
     };
 
-    popupBindings = {
-      sessionSelector.enable = true;
-      navi.enable = true;
-    };
-    splitBindings.enable = true;
-    viCopyMode.enable = true;
-
     paneBorder = {
       enable = true;
       indicators = "off";
       lines = "heavy";
-      status = "off";
       activeStyle = "fg=#ffb86c";
       title = {
         enable = true;
+        position = "top";
         format = " #P#{?#{||:#{==:#{pane_title},π},#{==:#{pane_title}, }}, #{pane_title}, #{pane_title}} ";
       };
-      autoHideSinglePane.enable = true;
     };
 
     bell.disable = true;
@@ -106,8 +109,6 @@
       enable = true;
       commandName = "tm";
       defaultSessionName = "main";
-      zshIntegration.enable = true;
-      nushellIntegration.enable = true;
     };
   };
 }


### PR DESCRIPTION
## Summary

- reorganize tmux options so plugin and key binding settings are grouped by purpose
- move Catppuccin configuration under `plugins.catppuccin`
- keep the generated tmux behavior intact while enabling repeatable pane resize bindings and single-pane border titles
- add top-level shell integration defaults for tmux features, with session selector overrides

## Background

The tmux module had related settings spread across top-level options. This groups
those settings more naturally while preserving the current recipe behavior.
