### PR TITLE
Avoid clipboard use during PR creation

### DIFF
--- a/files/agent-skills/runbook/create-pull-request.md
+++ b/files/agent-skills/runbook/create-pull-request.md
@@ -27,20 +27,11 @@ Follow the [check-git-branch-diff](check-git-branch-diff.md) runbook to identify
 
 ### 2. Generate Title and Body
 
-Generate the title and body inline for this PR. Do not copy either value to the clipboard unless the user explicitly asks for a standalone title/body or asks to copy it.
+Follow [generate-pull-request-title](generate-pull-request-title.md) and [generate-pull-request-body](generate-pull-request-body.md) as subroutines.
 
 Use the generated text as the source of truth for the PR content. If the user already provided a title or body, reuse it instead of regenerating.
 
-For the title:
-
-- Use one short, descriptive line.
-- Summarize the intent of the change, not the implementation detail.
-
-For the body:
-
-- Check for a PR template and follow it if present.
-- If no template exists, include a concise summary and background.
-- Write for reviewers, focusing on what changed and why.
+Because this workflow passes the title and body directly to `gh pr create`, skip the optional clipboard step in those runbooks unless the user also asked to copy the text.
 
 ### 3. Ensure the Branch Is Published
 

--- a/files/agent-skills/runbook/create-pull-request.md
+++ b/files/agent-skills/runbook/create-pull-request.md
@@ -27,9 +27,20 @@ Follow the [check-git-branch-diff](check-git-branch-diff.md) runbook to identify
 
 ### 2. Generate Title and Body
 
-Follow [generate-pull-request-title](generate-pull-request-title.md) and [generate-pull-request-body](generate-pull-request-body.md).
+Generate the title and body inline for this PR. Do not copy either value to the clipboard unless the user explicitly asks for a standalone title/body or asks to copy it.
 
 Use the generated text as the source of truth for the PR content. If the user already provided a title or body, reuse it instead of regenerating.
+
+For the title:
+
+- Use one short, descriptive line.
+- Summarize the intent of the change, not the implementation detail.
+
+For the body:
+
+- Check for a PR template and follow it if present.
+- If no template exists, include a concise summary and background.
+- Write for reviewers, focusing on what changed and why.
 
 ### 3. Ensure the Branch Is Published
 

--- a/files/agent-skills/runbook/generate-pull-request-body.md
+++ b/files/agent-skills/runbook/generate-pull-request-body.md
@@ -12,10 +12,11 @@ Generate a pull request body from the diff against the base branch and copy it t
 
 - User wants to create the PR itself (use `gh pr create`)
 - User wants to review someone else's PR
+- Another workflow needs a PR body internally and will pass it directly to a command
 
 ## Tips
 
-- **Clipboard is the default destination.** Unless the user says otherwise, copy the result to the clipboard using the [copy-to-clipboard](copy-to-clipboard.md) runbook.
+- **Clipboard is the default destination for standalone PR body requests.** Unless the user says otherwise, copy the result to the clipboard using the [copy-to-clipboard](copy-to-clipboard.md) runbook.
 - **Treat PR overview as reusable PR text.** In this repository, requests like "PR overview" or "summary" mean the user wants copy-ready text, not a chat-only explanation.
 - **Match the repository's language.** If existing PRs, README, or commit messages are in English, write in English. If in Japanese, write in Japanese.
 - **Avoid redundant validation notes.** Do not add Checks, Tests, or Validation sections unless the user asks or the PR template requires them.

--- a/files/agent-skills/runbook/generate-pull-request-body.md
+++ b/files/agent-skills/runbook/generate-pull-request-body.md
@@ -1,23 +1,22 @@
 # Generate Pull Request Body
 
-Generate a pull request body from the diff against the base branch and copy it to the clipboard.
+Generate a pull request body from the diff against the base branch.
 
 ## When to Use
 
 - User asks to create, write, or draft a PR description, body, or summary
 - User asks for a PR overview or summary
 - User asks to copy a PR body to the clipboard
+- Another runbook needs a PR body
 
 ## When NOT to Use
 
-- User wants to create the PR itself (use `gh pr create`)
 - User wants to review someone else's PR
-- Another workflow needs a PR body internally and will pass it directly to a command
 
 ## Tips
 
-- **Clipboard is the default destination for standalone PR body requests.** Unless the user says otherwise, copy the result to the clipboard using the [copy-to-clipboard](copy-to-clipboard.md) runbook.
-- **Treat PR overview as reusable PR text.** In this repository, requests like "PR overview" or "summary" mean the user wants copy-ready text, not a chat-only explanation.
+- **Clipboard copy is optional.** Copy standalone PR body/overview results by default, but skip copying when another runbook only needs the body as an internal value.
+- **Treat PR overview as reusable PR text.** In this repository, requests like "PR overview" or "summary" mean the user wants copy-ready text, so copy them unless the user says not to.
 - **Match the repository's language.** If existing PRs, README, or commit messages are in English, write in English. If in Japanese, write in Japanese.
 - **Avoid redundant validation notes.** Do not add Checks, Tests, or Validation sections unless the user asks or the PR template requires them.
 
@@ -53,6 +52,8 @@ Based on the diff and the template (if any), compose the pull request body.
 - Do not list commands or checks that CI already runs.
 - Do not add `Co-authored-by` or similar trailers.
 
-### 4. Copy to Clipboard
+### 4. Copy to Clipboard (Optional)
 
-Follow the [copy-to-clipboard](copy-to-clipboard.md) runbook to copy the body.
+Follow the [copy-to-clipboard](copy-to-clipboard.md) runbook when the user directly asked for a PR body, description, overview, or summary.
+
+Skip this step when another runbook needs the body only as an internal value, unless the user also asked to copy it.

--- a/files/agent-skills/runbook/generate-pull-request-title.md
+++ b/files/agent-skills/runbook/generate-pull-request-title.md
@@ -9,6 +9,7 @@ Generate a pull request title and copy it to the clipboard.
 ## When NOT to Use
 
 - User asks for a PR body or description (use [generate-pull-request-body](generate-pull-request-body.md))
+- Another workflow needs a PR title internally and will use it directly without showing or copying it
 
 ## Tips
 

--- a/files/agent-skills/runbook/generate-pull-request-title.md
+++ b/files/agent-skills/runbook/generate-pull-request-title.md
@@ -1,15 +1,15 @@
 # Generate Pull Request Title
 
-Generate a pull request title and copy it to the clipboard.
+Generate a pull request title.
 
 ## When to Use
 
 - User asks to create, write, or draft a PR title
+- Another runbook needs a PR title
 
 ## When NOT to Use
 
 - User asks for a PR body or description (use [generate-pull-request-body](generate-pull-request-body.md))
-- Another workflow needs a PR title internally and will use it directly without showing or copying it
 
 ## Tips
 
@@ -27,6 +27,8 @@ Skip if the changes are already well understood in the current session.
 - One line. Keep it short and descriptive.
 - Summarize the intent of the change, not the implementation detail.
 
-### 3. Copy to Clipboard
+### 3. Copy to Clipboard (Optional)
 
-Follow the [copy-to-clipboard](copy-to-clipboard.md) runbook to copy the title.
+Follow the [copy-to-clipboard](copy-to-clipboard.md) runbook when the user directly asked for a PR title, such as "give me a PR title" or "draft a PR title".
+
+Skip this step when another runbook needs the title only as an internal value, unless the user also asked to copy it.


### PR DESCRIPTION
## Summary

- update the PR creation runbook to generate titles and bodies inline
- clarify that clipboard copying is only for standalone PR title/body requests
- prevent parent workflows from invoking clipboard copy steps unnecessarily

## Background

Creating a PR passes the generated title and body directly to `gh pr create`, so copying them to the clipboard is unnecessary unless explicitly requested.
