### PR TITLE
Fix navi managed cheat loading

### DIFF
--- a/modules/dot/programs/navi.nix
+++ b/modules/dot/programs/navi.nix
@@ -19,6 +19,9 @@ let
 
   mkVariable = name: command: "$ ${name}: ${command}";
 
+  generatedCheatsDir = "navi/dotfiles/cheats";
+  generatedCheatsPath = "${config.xdg.dataHome}/${generatedCheatsDir}";
+
   mkSection =
     cheatName: section:
     let
@@ -39,12 +42,12 @@ let
 
   mkCheatFile =
     cheatName: cheat:
-    lib.nameValuePair "navi/cheats/${cheatName}.cheat" {
+    lib.nameValuePair "${generatedCheatsDir}/${cheatName}.cheat" {
       text = mkCheatText cheatName cheat;
     };
 
   shellAliasesFile = lib.optionalAttrs (cfg.enableShellAliases && config.home.shellAliases != { }) {
-    "navi/cheats/aliases.cheat".text = ''
+    "${generatedCheatsDir}/aliases.cheat".text = ''
       % aliases
 
       ${lib.concatStringsSep "\n\n" (lib.mapAttrsToList mkShellAliasEntry config.home.shellAliases)}
@@ -130,7 +133,7 @@ in
         }
       );
       default = { };
-      description = "Navi cheats to generate under the default navi cheats path.";
+      description = "Navi cheats to generate under the dotfiles-managed navi cheats path.";
       example.git.sections = [
         {
           tags = [ "git" ];
@@ -150,9 +153,13 @@ in
     let
       package = if cfg.package == null then pkgs.navi else cfg.package;
       yamlFormat = pkgs.formats.yaml { };
+      settings = lib.recursiveUpdate {
+        cheats.paths = [ generatedCheatsPath ];
+      } cfg.settings;
     in
     {
       home.packages = [ package ];
+      home.sessionVariables.NAVI_PATH = generatedCheatsPath;
 
       programs.zsh.initContent = lib.mkIf cfg.zshIntegration.enable ''
         eval "$(${package}/bin/navi widget zsh)"
@@ -206,8 +213,8 @@ in
         $env.config.keybindings = ($env.config.keybindings | append $nav_keybinding)
       '';
 
-      xdg.configFile."navi/config.yaml" = lib.mkIf (cfg.settings != { }) {
-        source = yamlFormat.generate "navi-config" cfg.settings;
+      xdg.configFile."navi/config.yaml" = {
+        source = yamlFormat.generate "navi-config" settings;
       };
 
       xdg.dataFile = shellAliasesFile // builtins.listToAttrs (lib.mapAttrsToList mkCheatFile cfg.cheats);

--- a/modules/dot/programs/navi.nix
+++ b/modules/dot/programs/navi.nix
@@ -19,8 +19,8 @@ let
 
   mkVariable = name: command: "$ ${name}: ${command}";
 
-  generatedCheatsDir = "navi/dotfiles/cheats";
-  generatedCheatsPath = "${config.xdg.dataHome}/${generatedCheatsDir}";
+  managedCheatsDir = "navi/dotfiles/cheats";
+  managedCheatsPath = "${config.xdg.dataHome}/${managedCheatsDir}";
 
   mkSection =
     cheatName: section:
@@ -42,12 +42,12 @@ let
 
   mkCheatFile =
     cheatName: cheat:
-    lib.nameValuePair "${generatedCheatsDir}/${cheatName}.cheat" {
+    lib.nameValuePair "${managedCheatsDir}/${cheatName}.cheat" {
       text = mkCheatText cheatName cheat;
     };
 
   shellAliasesFile = lib.optionalAttrs (cfg.enableShellAliases && config.home.shellAliases != { }) {
-    "${generatedCheatsDir}/aliases.cheat".text = ''
+    "${managedCheatsDir}/aliases.cheat".text = ''
       % aliases
 
       ${lib.concatStringsSep "\n\n" (lib.mapAttrsToList mkShellAliasEntry config.home.shellAliases)}
@@ -154,12 +154,12 @@ in
       package = if cfg.package == null then pkgs.navi else cfg.package;
       yamlFormat = pkgs.formats.yaml { };
       settings = lib.recursiveUpdate {
-        cheats.paths = [ generatedCheatsPath ];
+        cheats.paths = [ managedCheatsPath ];
       } cfg.settings;
     in
     {
       home.packages = [ package ];
-      home.sessionVariables.NAVI_PATH = generatedCheatsPath;
+      home.sessionVariables.NAVI_PATH = managedCheatsPath;
 
       programs.zsh.initContent = lib.mkIf cfg.zshIntegration.enable ''
         eval "$(${package}/bin/navi widget zsh)"

--- a/modules/recipes/gh.nix
+++ b/modules/recipes/gh.nix
@@ -26,11 +26,11 @@
           "github"
         ];
         variables = {
-          subcommand = ''${pkgs.coreutils}/bin/echo 'auth browse codespace gitst issue org pr project release repo' | ${pkgs.coreutils}/bin/tr ' ' '\n'';
+          subcommand = "${pkgs.coreutils}/bin/printf '%s\\n' auth browse codespace gist issue org pr project release repo";
           base_branch = "${pkgs.git}/bin/git branch --format='%(refname:short)'";
           branch = "${pkgs.git}/bin/git branch --format='%(refname:short)'";
-          pull_number = ''${pkgs.gh}/bin/gh pr list --- --column 1 --delimiter '\t'';
-          pull_numbers = ''${pkgs.gh}/bin/gh pr list  --- --column 1 --delimiter '\t' --multi'';
+          pull_number = "${pkgs.gh}/bin/gh pr list --- --column 1 --delimiter '\\t'";
+          pull_numbers = "${pkgs.gh}/bin/gh pr list --- --column 1 --delimiter '\\t' --multi";
         };
         entries = [
           {


### PR DESCRIPTION

## Summary

- Point navi at the dotfiles-managed cheat directory explicitly.
- Generate managed cheats under `navi/dotfiles/cheats` instead of the default `navi/cheats` path.
- Set `NAVI_PATH` so default cheats are not included.
- Fix broken `gh` cheat variables so the generated `gh.cheat` is parsed correctly.

## Background

The previous configuration could rely on navi default paths, which made managed cheats fail to load consistently and could include default cheats unexpectedly.

The `gh` cheat also had variable definitions whose quoting was broken in the generated cheat file, so `gh` entries could be missing from navi candidates.
