### PR TITLE
Add mise configuration

### DIFF
--- a/modules/dot/programs/default.nix
+++ b/modules/dot/programs/default.nix
@@ -4,6 +4,7 @@
     ./aws.nix
     ./gcloud.nix
     ./ghq.nix
+    ./mise.nix
     ./navi.nix
     ./tmux
   ];

--- a/modules/dot/programs/mise.nix
+++ b/modules/dot/programs/mise.nix
@@ -1,0 +1,93 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.dot.programs.mise;
+  tomlFormat = pkgs.formats.toml { };
+
+  idiomaticVersionFileTools = {
+    python.files = [ ".python-version" ];
+    node.files = [
+      ".node-version"
+      ".nvmrc"
+    ];
+    ruby.files = [
+      ".ruby-version"
+      "Gemfile"
+    ];
+    java.files = [ ".java-version" ];
+    go.files = [ ".go-version" ];
+    terraform.files = [ ".terraform-version" ];
+    elixir.files = [ ".exenv-version" ];
+  };
+
+  enabledIdiomaticVersionFileTools = lib.attrNames (
+    lib.filterAttrs (tool: _: cfg.idiomaticVersionFiles.${tool}.enable) idiomaticVersionFileTools
+  );
+  idiomaticVersionFileSettings = lib.optionalAttrs (enabledIdiomaticVersionFileTools != [ ]) {
+    idiomatic_version_file_enable_tools = enabledIdiomaticVersionFileTools;
+  };
+  globalConfig = lib.optionalAttrs (cfg.settings != { } || idiomaticVersionFileSettings != { }) {
+    settings = cfg.settings // idiomaticVersionFileSettings;
+  };
+
+  mkIdiomaticVersionFileOptions =
+    tool:
+    { files }:
+    {
+      enable = lib.mkEnableOption "reading ${tool}'s idiomatic version files (${lib.concatStringsSep ", " files})";
+    };
+in
+{
+  options.dot.programs.mise = {
+    enable = lib.mkEnableOption "mise";
+
+    package = lib.mkPackageOption pkgs "mise" { nullable = true; };
+
+    zshIntegration.enable = lib.mkEnableOption "zsh integration";
+
+    nushellIntegration.enable = lib.mkEnableOption "nushell integration";
+
+    idiomaticVersionFiles = lib.mapAttrs mkIdiomaticVersionFileOptions idiomaticVersionFileTools;
+
+    settings = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+      description = "Additional mise settings written under settings in mise/config.toml.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    warnings =
+      lib.optional (cfg.package == null && (cfg.zshIntegration.enable || cfg.nushellIntegration.enable))
+        ''
+          You have enabled shell integration for `dot.programs.mise` but have not set `package`.
+
+          The shell integration will not be added.
+        '';
+
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile."mise/config.toml" = lib.mkIf (globalConfig != { }) {
+      source = tomlFormat.generate "mise-config" globalConfig;
+    };
+
+    programs = {
+      zsh.initContent = lib.mkIf (cfg.zshIntegration.enable && cfg.package != null) ''
+        eval "$(${lib.getExe cfg.package} activate zsh)"
+      '';
+
+      nushell.extraConfig = lib.mkIf (cfg.nushellIntegration.enable && cfg.package != null) ''
+        use ${
+          pkgs.runCommand "mise-nushell-config.nu" { } ''
+            ${lib.getExe cfg.package} activate nu > $out
+          ''
+        }
+      '';
+    };
+  };
+}

--- a/modules/recipes/default.nix
+++ b/modules/recipes/default.nix
@@ -67,6 +67,7 @@
     ./lazydocker.nix
     ./lazygit.nix
     ./make.nix
+    ./mise.nix
     ./navi.nix
     ./neovim
     ./nix.nix

--- a/modules/recipes/mise.nix
+++ b/modules/recipes/mise.nix
@@ -1,0 +1,15 @@
+{
+  dot.programs.mise = {
+    enable = true;
+
+    zshIntegration.enable = false;
+    nushellIntegration.enable = true;
+
+    idiomaticVersionFiles = {
+      python.enable = true;
+      node.enable = true;
+      ruby.enable = true;
+      terraform.enable = true;
+    };
+  };
+}


### PR DESCRIPTION
## Summary

- add a dot.programs.mise module that manages mise without using the Home Manager programs.mise module
- enable mise with Nushell integration and explicit zsh integration disabled
- enable idiomatic version file support for Python, Node.js, Ruby, and Terraform projects

## Background

This lets project-local version files such as .python-version, .node-version, .nvmrc, .ruby-version, Gemfile, and .terraform-version drive mise without configuring global tool versions.
