### PR TITLE
Improve tmux session status and notices

### DIFF
--- a/files/pi/agent/extensions/user/features/tmux-notice.ts
+++ b/files/pi/agent/extensions/user/features/tmux-notice.ts
@@ -10,8 +10,13 @@ const execFileAsync = promisify(execFile);
 
 const DONE_ICONS = ["π", " "] as const;
 const DONE_ICON = DONE_ICONS[0];
-const WINDOW_NOTICE_OPTION = "@window_notice";
+const STATUS_NOTICE_ICON_OPTION = "@status_notice_icon";
+const PANE_NOTICE_ICON_OPTION = "@pane_notice_icon";
+const PANE_NOTICE_TITLE_OPTION = "@pane_notice_title";
+const LEGACY_WINDOW_NOTICE_OPTION = "@window_notice";
+const LEGACY_PI_WAITING_OPTION = "@pi_waiting";
 const DONE_TOGGLE_INTERVAL_MS = 500;
+const STATUS_NOTICE_PULSE_INTERVAL_MS = 900;
 
 // Capture the pane at extension load. Using the active pane at completion time
 // would update whichever pane the user is looking at, not the pane running Pi.
@@ -21,6 +26,7 @@ const isInsideTmux = Boolean(process.env.TMUX);
 let originalTitle: string | undefined;
 let doneTitleIndex = 0;
 let cancelDoneBlink: (() => void) | undefined;
+let cancelStatusNoticePulse: (() => void) | undefined;
 
 // Self-rescheduling async interval with a single re-entrancy guard, returning a
 // canceller for the done-blink timer.
@@ -40,6 +46,11 @@ function startInterval(ms: number, tick: () => Promise<void>): () => void {
 function stopDoneBlink(): void {
 	cancelDoneBlink?.();
 	cancelDoneBlink = undefined;
+}
+
+function stopStatusNoticePulse(): void {
+	cancelStatusNoticePulse?.();
+	cancelStatusNoticePulse = undefined;
 }
 
 async function getTmuxPaneFormat(format: string): Promise<string | undefined> {
@@ -78,25 +89,91 @@ async function setTmuxPaneTitle(title: string): Promise<boolean> {
 	}
 }
 
-async function setTmuxWindowNotice(notice: string | undefined): Promise<void> {
+async function setTmuxOption(
+	scope: "-w" | "-p",
+	option: string,
+	value: string | undefined,
+): Promise<void> {
 	if (!tmuxPane) return;
 
 	try {
 		await execFileAsync("tmux", [
 			"set-option",
-			"-w",
+			scope,
 			"-t",
 			tmuxPane,
-			WINDOW_NOTICE_OPTION,
-			notice ?? "",
+			option,
+			value ?? "",
 		]);
 	} catch {
 		// Ignore: pane title updates are the primary signal.
 	}
 }
 
+function setTmuxWindowOption(
+	option: string,
+	value: string | undefined,
+): Promise<void> {
+	return setTmuxOption("-w", option, value);
+}
+
+function setTmuxPaneOption(
+	option: string,
+	value: string | undefined,
+): Promise<void> {
+	return setTmuxOption("-p", option, value);
+}
+
+function setTmuxPaneNoticeIcon(icon: string | undefined): Promise<void> {
+	return setTmuxPaneOption(PANE_NOTICE_ICON_OPTION, icon);
+}
+
+function setTmuxPaneNoticeTitle(title: string | undefined): Promise<void> {
+	return setTmuxPaneOption(PANE_NOTICE_TITLE_OPTION, title);
+}
+
+async function setTmuxStatusNoticeIcon(
+	icon: string | undefined,
+): Promise<void> {
+	await Promise.all([
+		setTmuxPaneOption(STATUS_NOTICE_ICON_OPTION, icon),
+		// Clear the legacy Pi-specific markers so generic status aggregation
+		// cannot be polluted by an older Pi process/config.
+		setTmuxPaneOption(LEGACY_PI_WAITING_OPTION, undefined),
+		setTmuxWindowOption(LEGACY_WINDOW_NOTICE_OPTION, undefined),
+		setTmuxWindowOption(LEGACY_PI_WAITING_OPTION, undefined),
+	]);
+}
+
+async function refreshTmuxStatus(): Promise<void> {
+	try {
+		await execFileAsync("tmux", ["refresh-client", "-S"]);
+	} catch {
+		// Ignore: tmux will refresh on its regular status interval.
+	}
+}
+
+function startStatusNoticePulse(): void {
+	stopStatusNoticePulse();
+
+	void refreshTmuxStatus();
+	cancelStatusNoticePulse = startInterval(
+		STATUS_NOTICE_PULSE_INTERVAL_MS,
+		refreshTmuxStatus,
+	);
+}
+
+function clearAllTmuxNotices(): Promise<unknown> {
+	return Promise.all([
+		setTmuxStatusNoticeIcon(undefined),
+		setTmuxPaneNoticeIcon(undefined),
+		setTmuxPaneNoticeTitle(undefined),
+	]);
+}
+
 async function restoreOriginalTmuxPaneTitle(): Promise<boolean> {
-	await setTmuxWindowNotice(undefined);
+	stopStatusNoticePulse();
+	await clearAllTmuxNotices();
 	if (originalTitle === undefined) return false;
 	return setTmuxPaneTitle(originalTitle);
 }
@@ -125,6 +202,10 @@ function renderDonePaneTitle(icon: (typeof DONE_ICONS)[number]): string {
 	return `${icon} ${originalTitle}`;
 }
 
+function renderPaneNoticeTitle(): string | undefined {
+	return originalTitle?.replace(/^π\s*/u, "");
+}
+
 function startDoneBlinkUntilActive(): void {
 	stopDoneBlink();
 
@@ -138,10 +219,7 @@ function startDoneBlinkUntilActive(): void {
 
 		doneTitleIndex = (doneTitleIndex + 1) % DONE_ICONS.length;
 		const icon = DONE_ICONS[doneTitleIndex];
-		await Promise.all([
-			setTmuxPaneTitle(renderDonePaneTitle(icon)),
-			setTmuxWindowNotice(icon),
-		]);
+		await setTmuxPaneNoticeIcon(icon);
 	});
 }
 
@@ -156,12 +234,11 @@ function isPiStatusTitle(title: string): boolean {
 function register(pi: ExtensionAPI): void {
 	pi.on("agent_start", async () => {
 		stopDoneBlink();
+		stopStatusNoticePulse();
 
-		// Clearing the stale notice is independent of reading the current title.
-		const [, currentTitle] = await Promise.all([
-			setTmuxWindowNotice(undefined),
-			getTmuxPaneTitle(),
-		]);
+		await clearAllTmuxNotices();
+
+		const currentTitle = await getTmuxPaneTitle();
 		if (currentTitle === undefined) return;
 
 		if (isPiStatusTitle(currentTitle)) {
@@ -178,14 +255,22 @@ function register(pi: ExtensionAPI): void {
 		}
 
 		await Promise.all([
-			setPaneTitle(ctx, renderDonePaneTitle(DONE_ICON)),
-			setTmuxWindowNotice(DONE_ICON),
+			tmuxPane
+				? Promise.resolve()
+				: setPaneTitle(ctx, renderDonePaneTitle(DONE_ICON)),
+			setTmuxStatusNoticeIcon(DONE_ICON),
+			setTmuxPaneNoticeIcon(DONE_ICON),
+			setTmuxPaneNoticeTitle(renderPaneNoticeTitle()),
 		]);
-		if (tmuxPane) startDoneBlinkUntilActive();
+		if (tmuxPane) {
+			startDoneBlinkUntilActive();
+			startStatusNoticePulse();
+		}
 	});
 
 	pi.on("session_shutdown", async () => {
 		stopDoneBlink();
+		stopStatusNoticePulse();
 		await restoreOriginalTmuxPaneTitle();
 	});
 }

--- a/modules/dot/programs/tmux/default.nix
+++ b/modules/dot/programs/tmux/default.nix
@@ -88,6 +88,12 @@ let
   '';
 
   borderToggle = ''if -F "#{==:#{window_panes},1}" "setw pane-border-status off" "setw pane-border-status ${cfg.paneBorder.title.position}"'';
+  paneBorderTitleNotice = "#{?@pane_notice_icon, #{@pane_notice_icon} #{?@pane_notice_title,#{@pane_notice_title},#{pane_title}},#{?@status_notice_icon, #{@status_notice_icon} #{pane_title},#{pane_title}}}";
+  paneBorderTitleFormat =
+    if cfg.paneBorder.title.format == null then
+      "#{?pane_active,#[${cfg.paneBorder.title.activeStyle}],#[${cfg.paneBorder.title.inactiveStyle}]} #P ${paneBorderTitleNotice} "
+    else
+      cfg.paneBorder.title.format;
   resizeRepeatFlag = lib.optionalString cfg.keyBindings.paneResize.repeatable "-r ";
 
   tmuxBoolean = value: if value then "on" else "off";
@@ -200,7 +206,7 @@ let
     ${mkSetGlobal "pane-border-style" "'${cfg.paneBorder.style}'"}
     ${mkSetWindowGlobal "pane-border-status" cfg.paneBorder.title.position}
     ${lib.optionalString cfg.paneBorder.title.enable ''
-      setw -g pane-border-format '${cfg.paneBorder.title.format}'
+      setw -g pane-border-format '${paneBorderTitleFormat}'
     ''}
     ${
       if cfg.paneBorder.autoHideSinglePane.enable then
@@ -503,10 +509,20 @@ in
           default = "off";
           description = "Position of the pane border title/status line.";
         };
-        format = lib.mkOption {
+        activeStyle = lib.mkOption {
           type = lib.types.str;
-          default = " #P #{pane_title} ";
-          description = "pane-border-format value.";
+          default = "fg=green";
+          description = "Active pane title style for the generated pane-border-format.";
+        };
+        inactiveStyle = lib.mkOption {
+          type = lib.types.str;
+          default = "default";
+          description = "Inactive pane title style for the generated pane-border-format.";
+        };
+        format = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = "Optional pane-border-format override. Defaults to a generated pane title with pane notice icons.";
         };
       };
       autoHideSinglePane.enable = lib.mkEnableOption "pane border title/status auto-hide for single-pane windows";

--- a/modules/dot/programs/tmux/default.nix
+++ b/modules/dot/programs/tmux/default.nix
@@ -209,7 +209,7 @@ let
       setw -g pane-border-format '${paneBorderTitleFormat}'
     ''}
     ${
-      if cfg.paneBorder.autoHideSinglePane.enable then
+      if cfg.paneBorder.hideWhenSinglePane then
         ''
           ${borderToggle}
           set-hook -g after-split-window '${borderToggle}'
@@ -525,7 +525,11 @@ in
           description = "Optional pane-border-format override. Defaults to a generated pane title with pane notice icons.";
         };
       };
-      autoHideSinglePane.enable = lib.mkEnableOption "pane border title/status auto-hide for single-pane windows";
+      hideWhenSinglePane = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Whether to hide pane border title/status for single-pane windows.";
+      };
     };
 
     bell.disable = lib.mkEnableOption "tmux bell and visual-bell disablement";

--- a/modules/dot/programs/tmux/default.nix
+++ b/modules/dot/programs/tmux/default.nix
@@ -9,83 +9,7 @@ let
   cfg = config.dot.programs.tmux;
   paneCommand = import ./pane-command.nix { inherit pkgs; };
   sessionSelector = import ./session-selector.nix { inherit config pkgs; };
-
-  statusSessionsCommand = pkgs.writeShellScript "tmux-status-sessions" ''
-    current_session_id=''${1-}
-    frame=$(( $(${pkgs.coreutils}/bin/date +%s%3N) / ${toString cfg.status.sessionList.blinkIntervalMs} ))
-
-    {
-      ${cfg.package}/bin/tmux list-sessions -F '#{session_id}	#{session_name}' \
-        | ${pkgs.gawk}/bin/awk -F '\t' '{ print "S\t" $1 "\t" $2 }'
-      ${cfg.package}/bin/tmux list-panes -a -F '#{session_id}	#{@status_notice_icon}' \
-        | ${pkgs.gawk}/bin/awk -F '\t' '{ print "P\t" $1 "\t" $2 }'
-    } 2>/dev/null \
-      | ${pkgs.gawk}/bin/awk -F '\t' \
-        -v current_session_id="$current_session_id" \
-        -v frame="$frame" \
-        -v active_color="${cfg.status.sessionList.colors.active}" \
-        -v inactive_color="${cfg.status.sessionList.colors.inactive}" \
-        -v notice_bright_color="${cfg.status.sessionList.colors.noticeBright}" \
-        -v notice_dim_color="${cfg.status.sessionList.colors.noticeDim}" '
-        $1 == "S" {
-          session_ids[++session_count] = $2
-          session_names[session_count] = $3
-          next
-        }
-
-        $1 == "P" && $3 != "" {
-          session_id = $2
-          icon = $3
-          if (!icon_seen[session_id SUBSEP icon]++) {
-            icons[session_id, ++icon_counts[session_id]] = icon
-          }
-          next
-        }
-
-        END {
-          for (i = 1; i <= session_count; i++) {
-            session_id = session_ids[i]
-            icon_count = icon_counts[session_id] + 0
-            name_color = (session_id == current_session_id) ? active_color : inactive_color
-
-            printf "#[range=session|%s]", session_id
-            for (j = 1; j <= icon_count; j++) {
-              icon_bright = (icon_count == 1) ? (frame % 2 == 0) : ((j - 1) == frame % icon_count)
-              icon_color = icon_bright ? notice_bright_color : notice_dim_color
-              printf "#[fg=%s]%s ", icon_color, icons[session_id, j]
-            }
-            printf "#[fg=%s]%s  #[norange]", name_color, session_names[i]
-          }
-        }
-      '
-  '';
-
-  statusWindowNoticesCommand = pkgs.writeShellScript "tmux-status-window-notices" ''
-    target_window=''${1-}
-    [ -n "$target_window" ] || exit 0
-
-    frame=$(( $(${pkgs.coreutils}/bin/date +%s%3N) / ${toString cfg.status.windowNotice.blinkIntervalMs} ))
-
-    ${cfg.package}/bin/tmux list-panes -t "$target_window" -F '#{@status_notice_icon}' 2>/dev/null \
-      | ${pkgs.gawk}/bin/awk \
-        -v frame="$frame" '
-          $0 != "" {
-            icon = $0
-            if (!icon_seen[icon]++) icons[++icon_count] = icon
-          }
-
-          END {
-            if (icon_count == 0) exit
-
-            printf " "
-            active = (icon_count == 1) ? frame % 2 : frame % icon_count
-            for (i = 1; i <= icon_count; i++) {
-              if (i > 1) printf " "
-              printf "%s", ((i - 1) == active) ? icons[i] : " "
-            }
-          }
-        '
-  '';
+  statusCommands = import ./status-commands.nix { inherit config pkgs; };
 
   borderToggle = ''if -F "#{==:#{window_panes},1}" "setw pane-border-status off" "setw pane-border-status ${cfg.paneBorder.title.position}"'';
   paneBorderTitleNotice = "#{?@pane_notice_icon, #{@pane_notice_icon} #{?@pane_notice_title,#{@pane_notice_title},#{pane_title}},#{?@status_notice_icon, #{@status_notice_icon} #{pane_title},#{pane_title}}}";
@@ -154,8 +78,8 @@ let
     else
       "#{pane_current_command}";
 
-  windowNoticeText = lib.optionalString cfg.status.windowNotice.enable "#(${statusWindowNoticesCommand} #{q:window_id})";
-  statusSessions = lib.optionalString cfg.status.sessionList.enable "#(${statusSessionsCommand} #{q:session_id})";
+  windowNoticeText = lib.optionalString cfg.status.windowNotice.enable "#(${statusCommands.windowNotices} #{q:window_id})";
+  statusSessions = lib.optionalString cfg.status.sessionList.enable "#(${statusCommands.sessions} #{q:session_id})";
   statusNeedsRefresh = cfg.status.sessionList.enable || cfg.status.windowNotice.enable;
 
   # Single-window sessions hide the index; multi-window sessions show

--- a/modules/dot/programs/tmux/default.nix
+++ b/modules/dot/programs/tmux/default.nix
@@ -8,9 +8,85 @@
 let
   cfg = config.dot.programs.tmux;
   paneCommand = import ./pane-command.nix { inherit pkgs; };
-  sessionSelector = import ./session-selector.nix { inherit config; };
+  sessionSelector = import ./session-selector.nix { inherit config pkgs; };
 
-  windowNotice = "#{?@window_notice, #{@window_notice},}";
+  statusSessionsCommand = pkgs.writeShellScript "tmux-status-sessions" ''
+    current_session_id=''${1-}
+    frame=$(( $(${pkgs.coreutils}/bin/date +%s%3N) / ${toString cfg.status.sessionList.blinkIntervalMs} ))
+
+    {
+      ${cfg.package}/bin/tmux list-sessions -F '#{session_id}	#{session_name}' \
+        | ${pkgs.gawk}/bin/awk -F '\t' '{ print "S\t" $1 "\t" $2 }'
+      ${cfg.package}/bin/tmux list-panes -a -F '#{session_id}	#{@status_notice_icon}' \
+        | ${pkgs.gawk}/bin/awk -F '\t' '{ print "P\t" $1 "\t" $2 }'
+    } 2>/dev/null \
+      | ${pkgs.gawk}/bin/awk -F '\t' \
+        -v current_session_id="$current_session_id" \
+        -v frame="$frame" \
+        -v active_color="${cfg.status.sessionList.colors.active}" \
+        -v inactive_color="${cfg.status.sessionList.colors.inactive}" \
+        -v notice_bright_color="${cfg.status.sessionList.colors.noticeBright}" \
+        -v notice_dim_color="${cfg.status.sessionList.colors.noticeDim}" '
+        $1 == "S" {
+          session_ids[++session_count] = $2
+          session_names[session_count] = $3
+          next
+        }
+
+        $1 == "P" && $3 != "" {
+          session_id = $2
+          icon = $3
+          if (!icon_seen[session_id SUBSEP icon]++) {
+            icons[session_id, ++icon_counts[session_id]] = icon
+          }
+          next
+        }
+
+        END {
+          for (i = 1; i <= session_count; i++) {
+            session_id = session_ids[i]
+            icon_count = icon_counts[session_id] + 0
+            name_color = (session_id == current_session_id) ? active_color : inactive_color
+
+            printf "#[range=session|%s]", session_id
+            for (j = 1; j <= icon_count; j++) {
+              icon_bright = (icon_count == 1) ? (frame % 2 == 0) : ((j - 1) == frame % icon_count)
+              icon_color = icon_bright ? notice_bright_color : notice_dim_color
+              printf "#[fg=%s]%s ", icon_color, icons[session_id, j]
+            }
+            printf "#[fg=%s]%s  #[norange]", name_color, session_names[i]
+          }
+        }
+      '
+  '';
+
+  statusWindowNoticesCommand = pkgs.writeShellScript "tmux-status-window-notices" ''
+    target_window=''${1-}
+    [ -n "$target_window" ] || exit 0
+
+    frame=$(( $(${pkgs.coreutils}/bin/date +%s%3N) / ${toString cfg.status.windowNotice.blinkIntervalMs} ))
+
+    ${cfg.package}/bin/tmux list-panes -t "$target_window" -F '#{@status_notice_icon}' 2>/dev/null \
+      | ${pkgs.gawk}/bin/awk \
+        -v frame="$frame" '
+          $0 != "" {
+            icon = $0
+            if (!icon_seen[icon]++) icons[++icon_count] = icon
+          }
+
+          END {
+            if (icon_count == 0) exit
+
+            printf " "
+            active = (icon_count == 1) ? frame % 2 : frame % icon_count
+            for (i = 1; i <= icon_count; i++) {
+              if (i > 1) printf " "
+              printf "%s", ((i - 1) == active) ? icons[i] : " "
+            }
+          }
+        '
+  '';
+
   borderToggle = ''if -F "#{==:#{window_panes},1}" "setw pane-border-status off" "setw pane-border-status ${cfg.paneBorder.title.position}"'';
   resizeRepeatFlag = lib.optionalString cfg.keyBindings.paneResize.repeatable "-r ";
 
@@ -42,6 +118,7 @@ let
     ${mkSetWindowGlobal "pane-base-index" (toString cfg.baseIndex)}
     ${mkSetGlobal "history-limit" (toString cfg.historyLimit)}
     ${mkSetGlobal "mouse" (tmuxBoolean cfg.mouse)}
+    ${mkSetGlobal "status-position" cfg.status.position}
     ${mkSetWindowGlobal "mode-keys" cfg.keyMode}
     unbind-key C-b
     ${mkSetGlobal "prefix" cfg.prefix}
@@ -65,33 +142,43 @@ let
     '')
   ];
 
-  statusLeftCommand =
+  statusPaneCommand =
     if cfg.status.paneForegroundCommand.enable then
       "#(${paneCommand.command} #{pane_tty})"
     else
       "#{pane_current_command}";
 
-  windowNoticeText = lib.optionalString cfg.status.windowNotice.enable windowNotice;
+  windowNoticeText = lib.optionalString cfg.status.windowNotice.enable "#(${statusWindowNoticesCommand} #{q:window_id})";
+  statusSessions = lib.optionalString cfg.status.sessionList.enable "#(${statusSessionsCommand} #{q:session_id})";
+  statusNeedsRefresh = cfg.status.sessionList.enable || cfg.status.windowNotice.enable;
+
+  # Single-window sessions hide the index; multi-window sessions show
+  # "#I[: notice #W]". Shared between the normal and current formats below.
+  windowStatusContent = "#{?#{>:#{session_windows},1}, #I#{?#{!=:#{window_name},Window},:${windowNoticeText} #W,${windowNoticeText}} ,}";
 
   catppuccinStatusConfig = lib.optionalString cfg.plugins.catppuccin.enable ''
-    set -g window-status-format " #I${windowNoticeText}#{?#{!=:#{window_name},Window},: #W,} "
+    set -g window-status-format "${windowStatusContent}"
     set -g window-status-style "bg=#{@thm_bg},fg=#{@thm_rosewater}"
     set -g window-status-last-style "bg=#{@thm_bg},fg=#{@thm_peach}"
     set -g window-status-activity-style "bg=#{@thm_red},fg=#{@thm_bg}"
     set -g window-status-bell-style "bg=#{@thm_red},fg=#{@thm_bg},bold"
     set -gF window-status-separator "#[bg=#{@thm_bg},fg=#{@thm_overlay_0}]│"
-    set -g window-status-current-format " #I${windowNoticeText}#{?#{!=:#{window_name},Window},: #W,} "
+    set -g window-status-current-format "${windowStatusContent}"
     set -g window-status-current-style "bg=#{@thm_peach},fg=#{@thm_bg},bold"
 
-    set -g  status-left-length 100
+    set -g  status-left-length 200
     set -g status-left ""
-    set -ga status-left "#{?client_prefix,#{#[bg=#{@thm_red},fg=#{@thm_bg},bold]  #S },#{#[bg=#{@thm_bg},fg=#{@thm_green}]  #S }}"
-    set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_maroon}]  ${statusLeftCommand} "
+    set -ga status-left "#{?client_prefix,#{#[bg=#{@thm_red},fg=#{@thm_bg},bold]  },#{#[bg=#{@thm_bg},fg=#{@thm_green}]  }}#[bg=#{@thm_bg},fg=#{@thm_overlay_0}]│ "
+    set -ga status-left "${statusSessions}"
 
-    set -g status-right-length 100
+    ${lib.optionalString statusNeedsRefresh "set -g status-interval 1"}
+
+    set -g status-right-length 160
     set -g status-right ""
     set -ga status-right "#[bg=#{@thm_bg},fg=#{@thm_yellow}]#{?window_zoomed_flag,  zoom ,}"
-    set -ga status-right "#[bg=#{@thm_bg},fg=#{@thm_blue}] 󰭦 %Y-%m-%d 󰅐 %H:%M "
+    set -ga status-right "#[bg=#{@thm_bg},fg=#{@thm_maroon}]  ${statusPaneCommand} "
+    set -ga status-right "#[bg=#{@thm_bg},fg=#{@thm_overlay_0}]│ "
+    set -ga status-right "#[bg=#{@thm_bg},fg=#{@thm_blue}]󰭦 %Y-%m-%d %H:%M "
 
     set -g status-justify "absolute-centre"
   '';
@@ -110,6 +197,7 @@ let
   paneBorderConfig = lib.optionalString cfg.paneBorder.enable ''
     ${mkSetGlobal "pane-border-indicators" cfg.paneBorder.indicators}
     ${mkSetGlobal "pane-border-lines" cfg.paneBorder.lines}
+    ${mkSetGlobal "pane-border-style" "'${cfg.paneBorder.style}'"}
     ${mkSetWindowGlobal "pane-border-status" cfg.paneBorder.title.position}
     ${lib.optionalString cfg.paneBorder.title.enable ''
       setw -g pane-border-format '${cfg.paneBorder.title.format}'
@@ -125,7 +213,7 @@ let
         ''
       else
         ''
-          setw pane-border-status ${cfg.paneBorder.title.position}
+          setw -g pane-border-status ${cfg.paneBorder.title.position}
           set-hook -gu after-split-window
           set-hook -gu after-kill-pane
           set-hook -gu pane-exited
@@ -152,6 +240,13 @@ let
       '')
       (lib.optionalString cfg.keyBindings.popups.sessionSelector.enable ''
         bind-key -T prefix s display-popup -E "nu --login -i -c '${cfg.sessionSelector.commandName}'"
+      '')
+      (lib.optionalString cfg.keyBindings.sessionNavigation.enable ''
+        bind-key -T prefix ${cfg.keyBindings.sessionNavigation.nextKey} switch-client -n
+        bind-key -T prefix ${cfg.keyBindings.sessionNavigation.previousKey} switch-client -p
+      '')
+      (lib.optionalString cfg.keyBindings.windowRename.enable ''
+        bind-key -T prefix ${cfg.keyBindings.windowRename.key} command-prompt -I "#W" -p "Window name:" 'if -F "#{==:%1,}" "set-window-option automatic-rename on" "rename-window \"%%%\""'
       '')
       (lib.optionalString cfg.keyBindings.popups.navi.enable ''
         bind-key -T prefix g display-popup -w '95%' -h '95%' -d "#{pane_current_path}" -E "nu --login -i -c 'nv'"
@@ -268,13 +363,79 @@ in
         sessionSelector.enable = lib.mkEnableOption "prefix+s session-selector popup";
         navi.enable = lib.mkEnableOption "prefix+g navi popup";
       };
+      sessionNavigation = {
+        enable = lib.mkEnableOption "session next/previous key bindings";
+        nextKey = lib.mkOption {
+          type = lib.types.str;
+          default = "N";
+          description = "Prefix key for switch-client -n.";
+        };
+        previousKey = lib.mkOption {
+          type = lib.types.str;
+          default = "P";
+          description = "Prefix key for switch-client -p.";
+        };
+      };
+      windowRename = {
+        enable = lib.mkEnableOption "window rename prompt that restores automatic rename on empty input";
+        key = lib.mkOption {
+          type = lib.types.str;
+          default = ",";
+          description = "Prefix key for the window rename prompt.";
+        };
+      };
       split.enable = lib.mkEnableOption "split-window bindings that preserve pane_current_path";
       copyModeVi.enable = lib.mkEnableOption "vi copy-mode bindings";
     };
 
     status = {
+      position = lib.mkOption {
+        type = lib.types.enum [
+          "top"
+          "bottom"
+        ];
+        default = "bottom";
+        description = "tmux status-position value.";
+      };
       paneForegroundCommand.enable = lib.mkEnableOption "argv[0]-based pane command in status-left";
-      windowNotice.enable = lib.mkEnableOption "@window_notice marker in window status";
+      windowNotice = {
+        enable = lib.mkEnableOption "pane-scoped notice icons in window status";
+        blinkIntervalMs = lib.mkOption {
+          type = lib.types.ints.positive;
+          default = 900;
+          description = "Notice icon blink interval in the window list.";
+        };
+      };
+      sessionList = {
+        enable = lib.mkEnableOption "clickable tmux session list with pane notices in status-left";
+        blinkIntervalMs = lib.mkOption {
+          type = lib.types.ints.positive;
+          default = 900;
+          description = "Notice icon blink interval in the status session list.";
+        };
+        colors = {
+          active = lib.mkOption {
+            type = lib.types.str;
+            default = "#cad3f5";
+            description = "Active session name color.";
+          };
+          inactive = lib.mkOption {
+            type = lib.types.str;
+            default = "#8087a2";
+            description = "Inactive session name color.";
+          };
+          noticeBright = lib.mkOption {
+            type = lib.types.str;
+            default = "#cad3f5";
+            description = "Bright notice icon color.";
+          };
+          noticeDim = lib.mkOption {
+            type = lib.types.str;
+            default = "#8087a2";
+            description = "Dim notice icon color.";
+          };
+        };
+      };
     };
 
     terminalFeatures = lib.mkOption {
@@ -321,6 +482,11 @@ in
         default = "single";
         description = "pane-border-lines value.";
       };
+      style = lib.mkOption {
+        type = lib.types.str;
+        default = "default";
+        description = "pane-border-style value.";
+      };
       activeStyle = lib.mkOption {
         type = lib.types.str;
         default = "fg=green";
@@ -365,11 +531,6 @@ in
         type = lib.types.str;
         default = "tm";
         description = "Shell function name for selecting tmux sessions.";
-      };
-      defaultSessionName = lib.mkOption {
-        type = lib.types.str;
-        default = "main";
-        description = "Session created when no tmux sessions exist.";
       };
       zshIntegration.enable = lib.mkOption {
         type = lib.types.bool;

--- a/modules/dot/programs/tmux/session-selector.nix
+++ b/modules/dot/programs/tmux/session-selector.nix
@@ -1,70 +1,62 @@
 {
   config,
+  pkgs,
   ...
 }:
 
 let
   cfg = config.dot.programs.tmux;
   fuzzyFinderCommand = config.dot.options.fuzzyFinder.command;
+  ghqCommand = "${config.dot.programs.ghq.package}/bin/ghq";
+  selectorCommand = pkgs.writeShellScript "tmux-session-selector" ''
+    set -u
+
+    if ${cfg.package}/bin/tmux has-session 2>/dev/null; then
+      target=$(
+        ${cfg.package}/bin/tmux list-sessions -F '#S' 2>/dev/null \
+          | ${fuzzyFinderCommand} \
+            --header='Ctrl-C: repos  Ctrl-D: delete' \
+            --bind="ctrl-c:reload(${ghqCommand} list -p 2>/dev/null || true)+change-header(Repos)" \
+            --bind="ctrl-d:execute(${cfg.package}/bin/tmux kill-session -t {1})+reload(${cfg.package}/bin/tmux list-sessions -F '#S' 2>/dev/null || true)"
+      )
+    else
+      target=$(
+        ${ghqCommand} list -p 2>/dev/null \
+          | ${fuzzyFinderCommand} --header='Repos'
+      )
+    fi
+
+    if [ -z "$target" ]; then
+      exit 0
+    fi
+
+    if ! ${cfg.package}/bin/tmux has-session -t "$target" 2>/dev/null; then
+      session_name=$(basename "$target")
+      if ${cfg.package}/bin/tmux has-session -t "$session_name" 2>/dev/null; then
+        target="$session_name"
+      else
+        ${cfg.package}/bin/tmux new-session -s "$session_name" -c "$target" -d
+        target="$session_name"
+      fi
+    fi
+
+    if [ -z "''${TMUX-}" ]; then
+      ${cfg.package}/bin/tmux attach-session -t "$target"
+    else
+      ${cfg.package}/bin/tmux switch-client -t "$target"
+    fi
+  '';
 in
 {
   zsh = ''
     function ${cfg.sessionSelector.commandName}() {
-      if ! ${cfg.package}/bin/tmux has-session 2>/dev/null; then
-        ${cfg.package}/bin/tmux new-session -s ${cfg.sessionSelector.defaultSessionName} -c $HOME -d
-      fi
-
-      target=$(
-        ${cfg.package}/bin/tmux list-sessions -F "#S" | ${fuzzyFinderCommand} \
-          --header='Ctrl+C: new | Ctrl-D: delete' \
-          --bind='ctrl-c:reload(zoxide query --list)' \
-          --bind='ctrl-d:execute(${cfg.package}/bin/tmux kill-session -t {1})+reload(${cfg.package}/bin/tmux list-sessions -F "#S")'
-      )
-
-      if [ -z "$target" ]; then
-        return
-      fi
-
-      if ! ${cfg.package}/bin/tmux has-session -t "$target" 2>/dev/null; then
-        session_name=$(basename "$target")
-        ${cfg.package}/bin/tmux new-session -s $session_name -c "$target" -d
-        target="$session_name"
-      fi
-
-      if [ -z "$TMUX" ]; then
-        ${cfg.package}/bin/tmux attach-session -t "$target"
-      else
-        ${cfg.package}/bin/tmux switch-client -t "$target"
-      fi
+      ${selectorCommand}
     }
   '';
 
   nushell = ''
     export def ${cfg.sessionSelector.commandName} [] {
-      if (${cfg.package}/bin/tmux has-session | complete | get exit_code | $in != 0) {
-        ${cfg.package}/bin/tmux new-session -s ${cfg.sessionSelector.defaultSessionName} -c $env.HOME -d
-      }
-
-      mut target = (
-        ${cfg.package}/bin/tmux list-sessions -F "#S" | ${fuzzyFinderCommand}
-          --header='Ctrl+C: new | Ctrl-D: delete'
-          --bind='ctrl-c:reload(zoxide query --list)'
-          --bind='ctrl-d:execute(${cfg.package}/bin/tmux kill-session -t {1})+reload(${cfg.package}/bin/tmux list-sessions -F "#S")'
-        | complete | get "stdout" | str trim
-      )
-
-      if ($target | is-empty) { return }
-      if (${cfg.package}/bin/tmux has-session -t $target | complete | get exit_code | $in != 0) {
-        let session_name = $target | path basename
-        ${cfg.package}/bin/tmux new-session -s $session_name -c $target -d
-        $target = $session_name
-      }
-
-      if ($env.TMUX | is-empty) {
-        ${cfg.package}/bin/tmux attach-session -t $target
-      } else {
-        ${cfg.package}/bin/tmux switch-client -t $target
-      }
+      ^${selectorCommand}
     }
   '';
 }

--- a/modules/dot/programs/tmux/status-commands.nix
+++ b/modules/dot/programs/tmux/status-commands.nix
@@ -1,0 +1,83 @@
+{ config, pkgs, ... }:
+
+let
+  cfg = config.dot.programs.tmux;
+in
+{
+  sessions = pkgs.writeShellScript "tmux-status-sessions" ''
+    current_session_id=''${1-}
+    frame=$(( $(${pkgs.coreutils}/bin/date +%s%3N) / ${toString cfg.status.sessionList.blinkIntervalMs} ))
+
+    {
+      ${cfg.package}/bin/tmux list-sessions -F '#{session_id}	#{session_name}' \
+        | ${pkgs.gawk}/bin/awk -F '\t' '{ print "S\t" $1 "\t" $2 }'
+      ${cfg.package}/bin/tmux list-panes -a -F '#{session_id}	#{@status_notice_icon}' \
+        | ${pkgs.gawk}/bin/awk -F '\t' '{ print "P\t" $1 "\t" $2 }'
+    } 2>/dev/null \
+      | ${pkgs.gawk}/bin/awk -F '\t' \
+        -v current_session_id="$current_session_id" \
+        -v frame="$frame" \
+        -v active_color="${cfg.status.sessionList.colors.active}" \
+        -v inactive_color="${cfg.status.sessionList.colors.inactive}" \
+        -v notice_bright_color="${cfg.status.sessionList.colors.noticeBright}" \
+        -v notice_dim_color="${cfg.status.sessionList.colors.noticeDim}" '
+        $1 == "S" {
+          session_ids[++session_count] = $2
+          session_names[session_count] = $3
+          next
+        }
+
+        $1 == "P" && $3 != "" {
+          session_id = $2
+          icon = $3
+          if (!icon_seen[session_id SUBSEP icon]++) {
+            icons[session_id, ++icon_counts[session_id]] = icon
+          }
+          next
+        }
+
+        END {
+          for (i = 1; i <= session_count; i++) {
+            session_id = session_ids[i]
+            icon_count = icon_counts[session_id] + 0
+            name_color = (session_id == current_session_id) ? active_color : inactive_color
+
+            printf "#[range=session|%s]", session_id
+            for (j = 1; j <= icon_count; j++) {
+              icon_bright = (icon_count == 1) ? (frame % 2 == 0) : ((j - 1) == frame % icon_count)
+              icon_color = icon_bright ? notice_bright_color : notice_dim_color
+              printf "#[fg=%s]%s ", icon_color, icons[session_id, j]
+            }
+            printf "#[fg=%s]%s  #[norange]", name_color, session_names[i]
+          }
+        }
+      '
+  '';
+
+  windowNotices = pkgs.writeShellScript "tmux-status-window-notices" ''
+    target_window=''${1-}
+    [ -n "$target_window" ] || exit 0
+
+    frame=$(( $(${pkgs.coreutils}/bin/date +%s%3N) / ${toString cfg.status.windowNotice.blinkIntervalMs} ))
+
+    ${cfg.package}/bin/tmux list-panes -t "$target_window" -F '#{@status_notice_icon}' 2>/dev/null \
+      | ${pkgs.gawk}/bin/awk \
+        -v frame="$frame" '
+          $0 != "" {
+            icon = $0
+            if (!icon_seen[icon]++) icons[++icon_count] = icon
+          }
+
+          END {
+            if (icon_count == 0) exit
+
+            printf " "
+            active = (icon_count == 1) ? frame % 2 : frame % icon_count
+            for (i = 1; i <= icon_count; i++) {
+              if (i > 1) printf " "
+              printf "%s", ((i - 1) == active) ? icons[i] : " "
+            }
+          }
+        '
+  '';
+}

--- a/modules/recipes/tmux.nix
+++ b/modules/recipes/tmux.nix
@@ -133,6 +133,5 @@ in
       enable = true;
       commandName = "tm";
     };
-
   };
 }

--- a/modules/recipes/tmux.nix
+++ b/modules/recipes/tmux.nix
@@ -115,6 +115,7 @@ in
       lines = "single";
       style = "fg=${colors.paneBorder}";
       activeStyle = "fg=${colors.accent}";
+      autoHideSinglePane.enable = true;
       title = {
         enable = true;
         position = "top";

--- a/modules/recipes/tmux.nix
+++ b/modules/recipes/tmux.nix
@@ -112,7 +112,6 @@ in
       lines = "single";
       style = "fg=${colors.paneBorder}";
       activeStyle = "fg=${colors.accent}";
-      autoHideSinglePane.enable = true;
       title = {
         enable = true;
         position = "top";

--- a/modules/recipes/tmux.nix
+++ b/modules/recipes/tmux.nix
@@ -7,9 +7,6 @@ let
     muted = "#8087a2";
     accent = "#ffb86c";
   };
-
-  paneTitleColor = "#{?pane_active,#[fg=${colors.accent}],#[fg=${colors.muted}]}";
-  paneNotice = "#{?@pane_notice_icon, #{@pane_notice_icon} #{?@pane_notice_title,#{@pane_notice_title},#{pane_title}},#{?@status_notice_icon, #{@status_notice_icon} #{pane_title},#{pane_title}}}";
 in
 {
   config.dot.programs.tmux = {
@@ -119,7 +116,8 @@ in
       title = {
         enable = true;
         position = "top";
-        format = "${paneTitleColor} #P ${paneNotice} ";
+        activeStyle = "fg=${colors.accent}";
+        inactiveStyle = "fg=${colors.muted}";
       };
     };
 

--- a/modules/recipes/tmux.nix
+++ b/modules/recipes/tmux.nix
@@ -1,5 +1,16 @@
 { pkgs, ... }:
 
+let
+  colors = {
+    paneBorder = "#494d64";
+    text = "#cad3f5";
+    muted = "#8087a2";
+    accent = "#ffb86c";
+  };
+
+  paneTitleColor = "#{?pane_active,#[fg=${colors.accent}],#[fg=${colors.muted}]}";
+  paneNotice = "#{?@pane_notice_icon, #{@pane_notice_icon} #{?@pane_notice_title,#{@pane_notice_title},#{pane_title}},#{?@status_notice_icon, #{@status_notice_icon} #{pane_title},#{pane_title}}}";
+in
 {
   config.dot.programs.tmux = {
     enable = true;
@@ -33,13 +44,25 @@
         sessionSelector.enable = true;
         navi.enable = true;
       };
+      sessionNavigation.enable = true;
+      windowRename.enable = true;
       split.enable = true;
       copyModeVi.enable = true;
     };
 
     status = {
+      position = "top";
       paneForegroundCommand.enable = true;
       windowNotice.enable = true;
+      sessionList = {
+        enable = true;
+        colors = {
+          active = colors.text;
+          inactive = colors.muted;
+          noticeBright = colors.text;
+          noticeDim = colors.muted;
+        };
+      };
     };
 
     terminalFeatures = {
@@ -89,12 +112,13 @@
     paneBorder = {
       enable = true;
       indicators = "off";
-      lines = "heavy";
-      activeStyle = "fg=#ffb86c";
+      lines = "single";
+      style = "fg=${colors.paneBorder}";
+      activeStyle = "fg=${colors.accent}";
       title = {
         enable = true;
         position = "top";
-        format = " #P#{?#{||:#{==:#{pane_title},π},#{==:#{pane_title}, }}, #{pane_title}, #{pane_title}} ";
+        format = "${paneTitleColor} #P ${paneNotice} ";
       };
     };
 
@@ -108,7 +132,7 @@
     sessionSelector = {
       enable = true;
       commandName = "tm";
-      defaultSessionName = "main";
     };
+
   };
 }


### PR DESCRIPTION

## Summary

- Show clickable tmux sessions in status-left with pane-scoped notice icons.
- Move the foreground process indicator to status-right and simplify window status behavior.
- Update Pi tmux notices to use generic pane/status notice options.
- Refine the tmux session selector to choose existing sessions first and ghq repos for new sessions.

## Background

This makes tmux status information more consistent across sessions, windows, and panes while keeping repo-based session creation available without creating a default main session first.
