### PR TITLE
docs(runbook): prevent symlink discovery misses

### DIFF
--- a/files/agent-skills/runbook/SKILL.md
+++ b/files/agent-skills/runbook/SKILL.md
@@ -9,6 +9,8 @@ Guidance for selecting and following task-specific runbooks.
 
 - Use this skill only when a task-specific runbook may apply.
 - List runbook files in this skill directory before planning.
+  - Include symlinked files. Do not rely on filters that exclude symlinks, such as `find ... -type f`.
+  - If the list is unexpectedly empty after loading this file, inspect the directory without type filters before concluding no runbooks exist.
 - Select applicable runbooks by their When to Use / When NOT to Use.
 - Follow selected runbooks directly; do not skip, reorder, or substitute steps.
 - If multiple runbooks apply, use all relevant runbooks in the needed order.


### PR DESCRIPTION
## Summary

- Update the runbook skill instructions to include symlinked runbook files when listing available runbooks.
- Add a guardrail to re-inspect the skill directory without type filters when the list is unexpectedly empty.

## Background

Runbooks can be deployed as symlinks through Home Manager. A file-only discovery command can miss them and incorrectly conclude that no runbooks exist, so the skill now calls out that failure mode explicitly.