### PR TITLE
Adjust tmux pane border colors

### DIFF
--- a/modules/dot/programs/tmux/default.nix
+++ b/modules/dot/programs/tmux/default.nix
@@ -15,7 +15,7 @@ let
   paneBorderTitleNotice = "#{?@pane_notice_icon, #{@pane_notice_icon} #{?@pane_notice_title,#{@pane_notice_title},#{pane_title}},#{?@status_notice_icon, #{@status_notice_icon} #{pane_title},#{pane_title}}}";
   paneBorderTitleFormat =
     if cfg.paneBorder.title.format == null then
-      "#{?pane_active,#[${cfg.paneBorder.title.activeStyle}],#[${cfg.paneBorder.title.inactiveStyle}]} #P ${paneBorderTitleNotice} "
+      " #{?pane_active,#[${cfg.paneBorder.title.activeStyle}]#P ${paneBorderTitleNotice},#[${cfg.paneBorder.title.inactiveStyle}]#P ${paneBorderTitleNotice}} "
     else
       cfg.paneBorder.title.format;
   resizeRepeatFlag = lib.optionalString cfg.keyBindings.paneResize.repeatable "-r ";

--- a/modules/recipes/tmux.nix
+++ b/modules/recipes/tmux.nix
@@ -111,12 +111,12 @@ in
       indicators = "off";
       lines = "single";
       style = "fg=${colors.paneBorder}";
-      activeStyle = "fg=${colors.accent}";
+      activeStyle = "fg=${colors.paneBorder}";
       title = {
         enable = true;
         position = "top";
         activeStyle = "fg=${colors.accent}";
-        inactiveStyle = "fg=${colors.muted}";
+        inactiveStyle = "fg=${colors.paneBorder}";
       };
     };
 


### PR DESCRIPTION
## Summary

- make active and inactive tmux pane border lines use the same color
- keep the active pane border title accented
- keep inactive pane titles aligned with the border color

## Background

This reduces visual emphasis on the pane border itself while keeping the active pane identifiable through its title.