### PR TITLE
Improve Pi project tools and mode gating

### DIFF
--- a/.pi/settings.user.json
+++ b/.pi/settings.user.json
@@ -3,6 +3,7 @@
     "lint": {
       "description": "Run all lint and type checks for the project (no files are modified).",
       "allowedModes": ["read", "write"],
+      "executionMode": "parallel",
       "promptSnippet": "Run lint and type checks for the project",
       "promptGuidelines": [
         "Use lint after editing files to verify; it runs the same checks as CI and modifies nothing."
@@ -10,25 +11,30 @@
       "commands": [
         {
           "label": "tsgo",
-          "command": "pnpm lint"
+          "command": "pnpm",
+          "arguments": ["lint"]
         },
         {
           "label": "oxlint",
-          "command": "oxlint --deny-warnings"
+          "command": "oxlint",
+          "arguments": ["--deny-warnings"]
         },
         {
           "label": "deadnix",
-          "command": "deadnix --fail ."
+          "command": "deadnix",
+          "arguments": ["--fail", "."]
         },
         {
           "label": "statix",
-          "command": "statix check ."
+          "command": "statix",
+          "arguments": ["check", "."]
         }
       ]
     },
     "format": {
       "description": "Format the project in place with treefmt.",
       "allowedModes": ["write"],
+      "executionMode": "sequential",
       "promptSnippet": "Format the project in place",
       "promptGuidelines": [
         "Use format to auto-fix formatting, then run lint to verify."
@@ -43,10 +49,12 @@
     "homemanager_switch": {
       "description": "Run Home Manager switch for the current host via the flake.",
       "allowedModes": ["write"],
+      "executionMode": "sequential",
       "commands": [
         {
           "label": "home-manager switch",
-          "command": "nix run .#switch",
+          "command": "nix",
+          "arguments": ["run", ".#switch"],
           "timeoutSeconds": 600
         }
       ]

--- a/files/agent-skills/pi-project-tools/SKILL.md
+++ b/files/agent-skills/pi-project-tools/SKILL.md
@@ -26,6 +26,11 @@ Project tools become callable Pi tools for that project only.
 - Keep commands deterministic and scoped to the repository.
 - Avoid commands that read secrets, access credentials, or modify paths outside the project.
 - Set `timeoutSeconds` for commands that might hang.
+- Use `executionMode: "parallel"` only when the project tool is safe to run concurrently with other tool calls.
+- Prefer structured `command` + `arguments` over free-form shell strings.
+- Put fixed subcommands in `arguments`, not in `command`.
+- Use parameter placeholders only as whole arguments, e.g. `"{{path}}"`; do not embed them inside larger strings.
+- Parameter values are shell-quoted by the extension and are passed as single arguments. Do not add extra quoting around `"{{param}}"`.
 
 ## Settings shape
 
@@ -37,8 +42,14 @@ Add or update `.pi/settings.user.json`:
     "lint": {
       "description": "Run project lint and type checks.",
       "allowedModes": ["read", "write"],
+      "executionMode": "parallel",
       "commands": [
-        { "label": "lint", "command": "pnpm lint", "timeoutSeconds": 120 }
+        {
+          "label": "lint",
+          "command": "pnpm",
+          "arguments": ["lint"],
+          "timeoutSeconds": 120
+        }
       ]
     }
   }
@@ -49,23 +60,47 @@ Tool config fields:
 
 - `description` required; explain what the tool does.
 - `allowedModes` required; non-empty array. Use `read` and/or `write` for normal project tools.
-- `commands` required; non-empty array. Commands run in parallel.
+- `commands` required; non-empty array. Commands run in parallel within one project tool call.
+- `parameters` optional; object of LLM-provided parameters for this tool.
+- `executionMode` optional; `sequential` or `parallel`. Defaults to `sequential`. Use `parallel` only when this project tool is safe to run concurrently with other tool calls.
 - `cwd` optional; relative path inside the project root. Omit `cwd` when running from the project root.
 - `timeoutSeconds` optional; default timeout for commands.
 - `promptSnippet` optional; one-line LLM-facing tool summary.
 - `promptGuidelines` optional; bullets that must name the tool explicitly.
 
+Parameter fields (`tools.<name>.parameters.<paramName>`):
+
+- `type` required; one of `string`, `number`, or `boolean`.
+- `description` optional but recommended; explain what value the LLM should provide.
+- `required` optional; defaults to `false`. Set `true` for required parameters.
+
 Command fields:
 
-- `command` required; shell command to run.
+- `command` required; executable/program name as a single command token, e.g. `"brain"`, `"pnpm"`, or `"nix"`.
+- `arguments` optional; ordered array of fixed arguments, parameter placeholders, flags, and options.
 - `label` optional; display label in tool output.
 - `cwd` optional; relative path inside the project root. Omit `cwd` when running from the project root.
 - `timeoutSeconds` optional; overrides the tool default.
 
+Argument entries:
+
+- Fixed argument: `"rule"`
+- Parameter argument: `"{{path}}"`
+  - References a `string`, `number`, or `boolean` parameter.
+  - If the parameter is optional and omitted, this argument is omitted.
+  - Empty string `""` is treated as provided and passed as an empty argument.
+- Boolean flag: `{ "flag": "--detail", "when": "detail" }`
+  - `when` must reference a `boolean` parameter.
+  - The flag is included only when the parameter is `true`.
+- Value option: `{ "option": "--top", "value": "{{top}}" }`
+  - `value` must reference a `string` or `number` parameter.
+  - If the parameter is optional and omitted, both option name and value are omitted.
+
 ## Naming
 
 - Tool names must match `^[a-z][a-z0-9_-]*$`.
-- Use concise names like `lint`, `test`, `format`, `check_types`, `homemanager_switch`.
+- Parameter names must start with a letter or `_` and then use letters, numbers, `_`, or `-`.
+- Use concise names like `lint`, `test`, `format`, `check_types`, `homemanager_switch`, `brain_rule_match`.
 - Do not conflict with built-in or extension tools.
 
 ## Examples
@@ -78,8 +113,14 @@ Read-only check:
     "lint": {
       "description": "Run lint and type checks.",
       "allowedModes": ["read", "write"],
+      "executionMode": "parallel",
       "commands": [
-        { "label": "lint", "command": "pnpm lint", "timeoutSeconds": 120 }
+        {
+          "label": "lint",
+          "command": "pnpm",
+          "arguments": ["lint"],
+          "timeoutSeconds": 120
+        }
       ]
     }
   }
@@ -110,9 +151,72 @@ Multiple parallel checks:
     "check": {
       "description": "Run project checks in parallel.",
       "allowedModes": ["read", "write"],
+      "executionMode": "parallel",
       "commands": [
-        { "label": "types", "command": "pnpm lint", "timeoutSeconds": 120 },
-        { "label": "nix", "command": "nix flake check", "timeoutSeconds": 600 }
+        { "label": "types", "command": "pnpm", "arguments": ["lint"], "timeoutSeconds": 120 },
+        { "label": "nix", "command": "nix", "arguments": ["flake", "check"], "timeoutSeconds": 600 }
+      ]
+    }
+  }
+}
+```
+
+Parameterized path command:
+
+```json
+{
+  "tools": {
+    "brain_rule_match": {
+      "description": "Show brain rules that apply to a path.",
+      "allowedModes": ["read"],
+      "parameters": {
+        "path": {
+          "type": "string",
+          "description": "Path to check.",
+          "required": true
+        }
+      },
+      "commands": [
+        {
+          "label": "brain rule match",
+          "command": "brain",
+          "arguments": ["rule", "match", "{{path}}"]
+        }
+      ]
+    }
+  }
+}
+```
+
+Flags and value options in a specific order:
+
+```json
+{
+  "tools": {
+    "brain_token_stats_count": {
+      "description": "Count approximate brain tokens.",
+      "allowedModes": ["read"],
+      "parameters": {
+        "detail": {
+          "type": "boolean",
+          "description": "Show detailed output."
+        },
+        "top": {
+          "type": "number",
+          "description": "Number of top entries to show."
+        }
+      },
+      "commands": [
+        {
+          "label": "brain token-stats count",
+          "command": "brain",
+          "arguments": [
+            "token-stats",
+            "count",
+            { "flag": "--detail", "when": "detail" },
+            { "option": "--top", "value": "{{top}}" }
+          ]
+        }
       ]
     }
   }
@@ -124,6 +228,6 @@ Multiple parallel checks:
 1. Inspect existing `.pi/settings.user.json` before editing.
 2. Preserve unrelated settings and unrelated `tools` entries.
 3. Add, rename, remove, or modify only the requested `tools` entries.
-4. Keep each tool's `description`, `allowedModes`, and `commands` consistent with the command behavior.
+4. Keep each tool's `description`, `allowedModes`, `executionMode`, `parameters`, and `commands` consistent with the command behavior.
 5. Validate that `.pi/settings.user.json` remains valid JSON.
-6. Summarize the changed tool names, commands, and allowed modes.
+6. Summarize the changed tool names, commands, parameters, execution mode, and allowed modes.

--- a/files/pi/agent/extensions/user/features/mode.ts
+++ b/files/pi/agent/extensions/user/features/mode.ts
@@ -22,8 +22,6 @@ import {
 	createModeController,
 	findPersistedMode,
 	findPersistedModeInSessionFile,
-	formatAllowedTools,
-	getAllowedModeTools,
 	getMode,
 	getNextMode,
 	getStartupMode,
@@ -124,10 +122,8 @@ const injectSystemPrompt =
 		const prompt = getMode(mode.current).systemPrompt;
 		if (!prompt) return;
 
-		const allowedTools = getAllowedModeTools(pi, mode.current);
-		const tools = formatAllowedTools(allowedTools);
 		return {
-			systemPrompt: `${event.systemPrompt}\n\n[${mode.current.toUpperCase()} MODE]\nAllowed tools in this mode: ${tools}\n${prompt}\n\nTool schemas may include tools that are blocked in the current mode; do not call tools that are not listed in "Allowed tools in this mode". If the user asks for a listed tool, call that tool rather than saying it is unavailable.`,
+			systemPrompt: `${event.systemPrompt}\n\n[${mode.current.toUpperCase()} MODE]\n${prompt}`,
 		};
 	};
 
@@ -185,13 +181,12 @@ const injectTransientModeReminder =
 		const messages = event.messages.filter(
 			(message) => !isModeReminderMessage(message),
 		);
-		const allowedTools = getAllowedModeTools(pi, mode.current);
 		return {
 			messages: [
 				...messages,
 				{
 					role: "custom",
-					...buildModeReminderPayload(mode.current, allowedTools),
+					...buildModeReminderPayload(mode.current),
 					timestamp: Date.now(),
 				},
 			],

--- a/files/pi/agent/extensions/user/features/tool.ts
+++ b/files/pi/agent/extensions/user/features/tool.ts
@@ -4,6 +4,7 @@ import type {
 	Theme,
 } from "@earendil-works/pi-coding-agent";
 import type { Feature } from "../feature";
+import { activateModeTools, getCurrentModeName } from "../lib/mode";
 import { policyRegistry } from "../lib/policy";
 import {
 	type ProjectToolSummary,
@@ -48,6 +49,7 @@ function register(pi: ExtensionAPI): void {
 	const projectToolNames = new Set<string>();
 	pi.on("session_start", async (_event: SessionStartEvent, ctx) => {
 		const projectTools = registerProjectTools(pi, ctx, projectToolNames);
+		if (projectTools.length > 0) activateModeTools(pi, getCurrentModeName());
 		if (ctx.hasUI && projectTools.length > 0) {
 			setTimeout(() => {
 				ctx.ui.notify(

--- a/files/pi/agent/extensions/user/lib/mode/controller.ts
+++ b/files/pi/agent/extensions/user/lib/mode/controller.ts
@@ -12,55 +12,49 @@ import { activateModeTools, applyModeStatus } from "./ui";
 
 export const MODE_REMINDER_TYPE = "system-reminder";
 
-/** Render an allowed-tool list for prompts, or "none" when empty. */
-export function formatAllowedTools(allowedTools: readonly string[]): string {
-	return allowedTools.length > 0 ? allowedTools.join(", ") : "none";
+let activeModeName: ModeName = DEFAULT_MODE;
+
+export function getCurrentModeName(): ModeName {
+	return activeModeName;
 }
 
-export function getModeReminder(
-	modeName: ModeName,
-	allowedTools: readonly string[],
-): string {
+export function getModeReminder(modeName: ModeName): string {
 	const mode = getMode(modeName);
 	const modeInstruction = mode.systemPrompt;
-	const tools = formatAllowedTools(allowedTools);
 
 	return `<system-reminder>
 Permission mode changed while you were working.
 
 Current mode: ${modeName}
-Allowed tools now: ${tools}
 
 ${modeInstruction}
 
-The tool names above are the complete current allowed tool set. If the user asks for a listed tool, call that tool rather than saying it is unavailable. Tool schemas may include tools that are blocked in the current mode; do not call tools that are not listed above.
-Follow the current mode and current allowed tools. Do not rely on any earlier mode reminder.
+Follow the current mode. Do not rely on any earlier mode reminder.
 </system-reminder>`;
 }
 
 /**
  * The shared shape of a mode-reminder custom message. Construction and
- * detection stay in one place; detection also accepts the previous
- * `details.activeTools` field so stale reminders from older sessions are
- * stripped from context. Callers add their own delivery-specific fields
+ * detection stay in one place; detection also accepts previous
+ * `details.allowedTools`/`details.activeTools` fields so stale reminders from
+ * older sessions are stripped from context. Callers add their own delivery-specific fields
  * (e.g. `role`/`timestamp` for context injection).
  */
 export type ModeReminderPayload = {
 	customType: string;
 	content: string;
 	display: boolean;
-	details: { mode: ModeName; allowedTools: readonly string[] };
+	details: { mode: ModeName };
 };
 
 export function buildModeReminderPayload(
 	modeName: ModeName,
-	allowedTools: readonly string[],
 ): ModeReminderPayload {
 	return {
 		customType: MODE_REMINDER_TYPE,
-		content: getModeReminder(modeName, allowedTools),
+		content: getModeReminder(modeName),
 		display: false,
-		details: { mode: modeName, allowedTools },
+		details: { mode: modeName },
 	};
 }
 
@@ -76,8 +70,7 @@ export function isModeReminderMessage(message: {
 	return (
 		typeof message.details === "object" &&
 		message.details !== null &&
-		"mode" in message.details &&
-		("allowedTools" in message.details || "activeTools" in message.details)
+		"mode" in message.details
 	);
 }
 
@@ -85,11 +78,10 @@ function steerModeReminder(
 	pi: ExtensionAPI,
 	ctx: ExtensionContext,
 	modeName: ModeName,
-	allowedTools: readonly string[],
 ): void {
 	if (ctx.isIdle()) return;
 
-	pi.sendMessage(buildModeReminderPayload(modeName, allowedTools), {
+	pi.sendMessage(buildModeReminderPayload(modeName), {
 		deliverAs: "steer",
 		triggerTurn: true,
 	});
@@ -117,7 +109,7 @@ export type ModeController = {
 };
 
 export function createModeController(pi: ExtensionAPI): ModeController {
-	let currentMode: ModeName = DEFAULT_MODE;
+	let currentMode: ModeName = activeModeName;
 
 	return {
 		get current() {
@@ -131,9 +123,10 @@ export function createModeController(pi: ExtensionAPI): ModeController {
 				pi.appendEntry(MODE_STATE_TYPE, { mode: modeName });
 			}
 			currentMode = modeName;
-			const allowedTools = activateModeTools(pi, modeName);
+			activeModeName = modeName;
+			activateModeTools(pi, modeName);
 			applyModeStatus(ctx, getMode(modeName));
-			if (changed) steerModeReminder(pi, ctx, modeName, allowedTools);
+			if (changed) steerModeReminder(pi, ctx, modeName);
 		},
 	};
 }

--- a/files/pi/agent/extensions/user/lib/mode/index.ts
+++ b/files/pi/agent/extensions/user/lib/mode/index.ts
@@ -4,7 +4,7 @@ export {
 	type SetModeOptions,
 	buildModeReminderPayload,
 	createModeController,
-	formatAllowedTools,
+	getCurrentModeName,
 	getModeReminder,
 	isModeReminderMessage,
 } from "./controller";

--- a/files/pi/agent/extensions/user/lib/mode/ui.ts
+++ b/files/pi/agent/extensions/user/lib/mode/ui.ts
@@ -60,18 +60,10 @@ export function activateModeTools(
 	pi: ExtensionAPI,
 	modeName: ModeName,
 ): string[] {
-	// Tool schemas are captured for the duration of an agent run. Keep every
-	// policy-managed tool callable at the provider layer so mode changes made
-	// while the agent is working can take effect on the next LLM call in that
-	// same run. Preserve unmanaged active tools from core/other extensions
-	// instead of clobbering them; the policy guard remains the source of truth
-	// for whether policy-managed tools are actually allowed in the current mode.
-	pi.setActiveTools(
-		unique([
-			...ALWAYS_ALLOWED_TOOL_NAMES,
-			...getUnmanagedActiveTools(pi),
-			...policyRegistry.getKnownToolNames(),
-		]),
-	);
-	return getAllowedModeTools(pi, modeName);
+	// Expose only the tools that are currently allowed. Otherwise providers see
+	// inactive tool schemas, and the agent can unnecessarily reveal that those
+	// tools exist when asked to list tools.
+	const allowedTools = getAllowedModeTools(pi, modeName);
+	pi.setActiveTools(allowedTools);
+	return allowedTools;
 }

--- a/files/pi/agent/extensions/user/lib/tool/project.ts
+++ b/files/pi/agent/extensions/user/lib/tool/project.ts
@@ -22,9 +22,10 @@ import {
 	type ToolResultEvent,
 	createLocalBashOperations,
 	formatSize,
+	keyHint,
 } from "@earendil-works/pi-coding-agent";
 import { type Component, Text } from "@earendil-works/pi-tui";
-import { Type } from "typebox";
+import { type TSchema, Type } from "typebox";
 import { type ModeName, policyRegistry } from "../policy";
 
 const PROJECT_TOOL_SETTINGS_RELATIVE_PATH = ".pi/settings.user.json";
@@ -38,15 +39,34 @@ const RUNNING_TAIL_LINES = 3;
 const EXPANDED_TAIL_LINES = 200;
 const UPDATE_THROTTLE_MS = 100;
 
-const emptyParams = Type.Object({}, { additionalProperties: false });
+const PARAMETER_NAME_RE = /^[A-Za-z_][A-Za-z0-9_-]*$/u;
+const PARAMETER_PLACEHOLDER_RE = /^\{\{([A-Za-z_][A-Za-z0-9_-]*)\}\}$/u;
 
 type ProjectToolSettings = {
 	tools?: unknown;
 };
 
+type ProjectParameterType = "string" | "number" | "boolean";
+type ProjectToolExecutionMode = "sequential" | "parallel";
+
+type ProjectParameterConfig = {
+	readonly type: ProjectParameterType;
+	readonly description?: string;
+	readonly required: boolean;
+};
+
+type ProjectToolInput = Record<string, string | number | boolean | undefined>;
+
+type ProjectToolCommandArgument =
+	| { readonly kind: "literal"; readonly value: string }
+	| { readonly kind: "param"; readonly name: string }
+	| { readonly kind: "flag"; readonly flag: string; readonly when: string }
+	| { readonly kind: "option"; readonly option: string; readonly name: string };
+
 type ProjectToolCommandConfig = {
 	readonly label?: string;
 	readonly command: string;
+	readonly arguments: readonly ProjectToolCommandArgument[];
 	readonly cwd?: string;
 	readonly timeoutSeconds?: number;
 };
@@ -55,6 +75,8 @@ type ProjectToolConfig = {
 	readonly name: string;
 	readonly description: string;
 	readonly allowedModes: readonly ModeName[];
+	readonly parameters: Readonly<Record<string, ProjectParameterConfig>>;
+	readonly executionMode?: ProjectToolExecutionMode;
 	readonly cwd?: string;
 	readonly timeoutSeconds?: number;
 	readonly promptSnippet?: string;
@@ -65,12 +87,14 @@ type ProjectToolConfig = {
 type ResolvedProjectToolCommand = ProjectToolCommandConfig & {
 	readonly index: number;
 	readonly displayLabel: string;
+	readonly displayCommand: string;
 	readonly absoluteCwd: string;
 	readonly displayCwd: string;
 	readonly timeoutSeconds?: number;
 };
 
 type ResolvedProjectTool = Omit<ProjectToolConfig, "commands"> & {
+	readonly parametersSchema: TSchema;
 	readonly commands: readonly ResolvedProjectToolCommand[];
 };
 
@@ -109,6 +133,7 @@ type MutableCommandState = {
 	readonly config: ResolvedProjectToolCommand;
 	readonly output: StreamingOutput;
 	status: ProjectCommandStatus;
+	executedCommand?: string;
 	exitCode?: number | null;
 	error?: string;
 	startedAt?: number;
@@ -121,6 +146,15 @@ function isObject(value: unknown): value is Record<string, unknown> {
 
 function isModeName(value: unknown): value is ModeName {
 	return typeof value === "string" && MODE_NAMES.includes(value as ModeName);
+}
+
+function normalizeExecutionMode(
+	value: unknown,
+	path: string,
+): ProjectToolExecutionMode | undefined {
+	if (value === undefined) return undefined;
+	if (value === "sequential" || value === "parallel") return value;
+	throw new Error(`${path} must be sequential or parallel.`);
 }
 
 function notifyWarning(ctx: ExtensionContext, message: string): void {
@@ -171,15 +205,167 @@ function resolveProjectCwd(
 	return { absolute, display: rel };
 }
 
+function normalizeParameter(
+	name: string,
+	value: unknown,
+	path: string,
+): ProjectParameterConfig {
+	if (!PARAMETER_NAME_RE.test(name)) {
+		throw new Error(
+			`${path} has invalid parameter name '${name}'. Use letters, numbers, '_' and '-'.`,
+		);
+	}
+	if (!isObject(value)) throw new Error(`${path}.${name} must be an object.`);
+	if (
+		value.type !== "string" &&
+		value.type !== "number" &&
+		value.type !== "boolean"
+	) {
+		throw new Error(`${path}.${name}.type must be string, number, or boolean.`);
+	}
+	if (value.required !== undefined && typeof value.required !== "boolean") {
+		throw new Error(`${path}.${name}.required must be a boolean.`);
+	}
+	return {
+		type: value.type,
+		description: normalizeOptionalString(
+			value.description,
+			`${path}.${name}.description`,
+		),
+		required: value.required ?? false,
+	};
+}
+
+function normalizeParameters(
+	value: unknown,
+	path: string,
+): Record<string, ProjectParameterConfig> {
+	if (value === undefined) return {};
+	if (!isObject(value)) throw new Error(`${path} must be an object.`);
+
+	const parameters: Record<string, ProjectParameterConfig> = {};
+	for (const [name, config] of Object.entries(value)) {
+		parameters[name] = normalizeParameter(name, config, path);
+	}
+	return parameters;
+}
+
+function getParameter(
+	parameters: Readonly<Record<string, ProjectParameterConfig>>,
+	name: string,
+	path: string,
+): ProjectParameterConfig {
+	const parameter = parameters[name];
+	if (!parameter)
+		throw new Error(`${path} references unknown parameter '${name}'.`);
+	return parameter;
+}
+
+function parseOptionalParameterPlaceholder(
+	value: string,
+	path: string,
+): string | undefined {
+	const match = PARAMETER_PLACEHOLDER_RE.exec(value);
+	if (match) return match[1];
+	if (value.includes("{{") || value.includes("}}")) {
+		throw new Error(
+			`${path} parameter references must be the whole argument, like "{{name}}".`,
+		);
+	}
+	return undefined;
+}
+
+function parseRequiredParameterPlaceholder(
+	value: string,
+	path: string,
+): string {
+	const name = parseOptionalParameterPlaceholder(value, path);
+	if (!name)
+		throw new Error(`${path} must be a parameter reference like "{{name}}".`);
+	return name;
+}
+
+function normalizeArgument(
+	value: unknown,
+	path: string,
+	parameters: Readonly<Record<string, ProjectParameterConfig>>,
+): ProjectToolCommandArgument {
+	if (typeof value === "string") {
+		const name = parseOptionalParameterPlaceholder(value, path);
+		if (!name) return { kind: "literal", value };
+		getParameter(parameters, name, path);
+		return { kind: "param", name };
+	}
+
+	if (!isObject(value)) {
+		throw new Error(
+			`${path} must be a string, a flag object, or an option object.`,
+		);
+	}
+
+	const hasFlag = "flag" in value;
+	const hasOption = "option" in value;
+	if (hasFlag && hasOption) {
+		throw new Error(`${path} cannot contain both flag and option.`);
+	}
+
+	if (hasFlag) {
+		const flag = normalizeOptionalString(value.flag, `${path}.flag`);
+		if (!flag) throw new Error(`${path}.flag is required.`);
+		const when = normalizeOptionalString(value.when, `${path}.when`);
+		if (!when) throw new Error(`${path}.when is required.`);
+		const parameter = getParameter(parameters, when, `${path}.when`);
+		if (parameter.type !== "boolean") {
+			throw new Error(`${path}.when must reference a boolean parameter.`);
+		}
+		return { kind: "flag", flag, when };
+	}
+
+	if (hasOption) {
+		const option = normalizeOptionalString(value.option, `${path}.option`);
+		if (!option) throw new Error(`${path}.option is required.`);
+		const valueReference = normalizeOptionalString(
+			value.value,
+			`${path}.value`,
+		);
+		if (!valueReference) throw new Error(`${path}.value is required.`);
+		const name = parseRequiredParameterPlaceholder(
+			valueReference,
+			`${path}.value`,
+		);
+		const parameter = getParameter(parameters, name, `${path}.value`);
+		if (parameter.type === "boolean") {
+			throw new Error(
+				`${path}.value must reference a string or number parameter.`,
+			);
+		}
+		return { kind: "option", option, name };
+	}
+
+	throw new Error(`${path} must contain either flag or option.`);
+}
+
 function normalizeCommand(
 	value: unknown,
 	path: string,
+	parameters: Readonly<Record<string, ProjectParameterConfig>>,
 ): ProjectToolCommandConfig {
 	if (!isObject(value)) throw new Error(`${path} must be an object.`);
 	const command = normalizeOptionalString(value.command, `${path}.command`);
 	if (!command) throw new Error(`${path}.command is required.`);
+	if (/\s/u.test(command)) {
+		throw new Error(
+			`${path}.command must be a single executable token. Put subcommands and flags in arguments.`,
+		);
+	}
+	if (value.arguments !== undefined && !Array.isArray(value.arguments)) {
+		throw new Error(`${path}.arguments must be an array.`);
+	}
 	return {
 		command,
+		arguments: (value.arguments ?? []).map((argument, index) =>
+			normalizeArgument(argument, `${path}.arguments[${index}]`, parameters),
+		),
 		label: normalizeOptionalString(value.label, `${path}.label`),
 		cwd: normalizeOptionalString(value.cwd, `${path}.cwd`),
 		timeoutSeconds: normalizeTimeout(
@@ -187,6 +373,42 @@ function normalizeCommand(
 			`${path}.timeoutSeconds`,
 		),
 	};
+}
+
+function createParameterSchema(parameter: ProjectParameterConfig): TSchema {
+	const options = parameter.description
+		? { description: parameter.description }
+		: undefined;
+	if (parameter.type === "string") return Type.String(options);
+	if (parameter.type === "number") return Type.Number(options);
+	return Type.Boolean(options);
+}
+
+function buildParameterSchema(
+	parameters: Readonly<Record<string, ProjectParameterConfig>>,
+): TSchema {
+	const properties: Record<string, TSchema> = {};
+	for (const [name, parameter] of Object.entries(parameters)) {
+		const schema = createParameterSchema(parameter);
+		properties[name] = parameter.required ? schema : Type.Optional(schema);
+	}
+	return Type.Object(properties, { additionalProperties: false });
+}
+
+function formatArgumentForDisplay(
+	argument: ProjectToolCommandArgument,
+): string {
+	if (argument.kind === "literal") return argument.value;
+	if (argument.kind === "param") return `{{${argument.name}}}`;
+	if (argument.kind === "flag") return `${argument.flag} when ${argument.when}`;
+	return `${argument.option} {{${argument.name}}}`;
+}
+
+function formatConfiguredCommand(command: ProjectToolCommandConfig): string {
+	return [
+		command.command,
+		...command.arguments.map(formatArgumentForDisplay),
+	].join(" ");
 }
 
 function normalizeTool(name: string, value: unknown): ProjectToolConfig {
@@ -223,6 +445,11 @@ function normalizeTool(name: string, value: unknown): ProjectToolConfig {
 		);
 	}
 
+	const parameters = normalizeParameters(
+		value.parameters,
+		`${name}.parameters`,
+	);
+
 	const promptGuidelines = value.promptGuidelines;
 	if (promptGuidelines !== undefined) {
 		if (
@@ -241,6 +468,11 @@ function normalizeTool(name: string, value: unknown): ProjectToolConfig {
 		name,
 		description,
 		allowedModes,
+		parameters,
+		executionMode: normalizeExecutionMode(
+			value.executionMode,
+			`${name}.executionMode`,
+		),
 		cwd: normalizeOptionalString(value.cwd, `${name}.cwd`),
 		timeoutSeconds: normalizeTimeout(
 			value.timeoutSeconds,
@@ -252,7 +484,7 @@ function normalizeTool(name: string, value: unknown): ProjectToolConfig {
 		),
 		promptGuidelines,
 		commands: value.commands.map((command, index) =>
-			normalizeCommand(command, `${name}.commands[${index}]`),
+			normalizeCommand(command, `${name}.commands[${index}]`, parameters),
 		),
 	};
 }
@@ -264,6 +496,7 @@ function resolveTool(
 	const toolCwd = resolveProjectCwd(root, config.cwd, `${config.name}.cwd`);
 	return {
 		...config,
+		parametersSchema: buildParameterSchema(config.parameters),
 		commands: config.commands.map((command, index) => {
 			const cwd = resolveProjectCwd(
 				root,
@@ -274,6 +507,7 @@ function resolveTool(
 				...command,
 				index,
 				displayLabel: command.label ?? String(index + 1),
+				displayCommand: formatConfiguredCommand(command),
 				absoluteCwd: cwd.absolute,
 				displayCwd: cwd.display,
 				timeoutSeconds: command.timeoutSeconds ?? config.timeoutSeconds,
@@ -390,13 +624,68 @@ class StreamingOutput {
 	}
 }
 
+function shellQuote(value: string): string {
+	if (value === "") return "''";
+	return `'${value.replace(/'/gu, `'\\''`)}'`;
+}
+
+function hasParameterValue(
+	value: string | number | boolean | undefined,
+): value is string | number | boolean {
+	return value !== undefined;
+}
+
+function stringifyParameterValue(value: string | number | boolean): string {
+	if (typeof value === "number" && !Number.isFinite(value)) {
+		throw new Error("Parameter values must be finite numbers.");
+	}
+	return String(value);
+}
+
+function renderCommandArguments(
+	argumentsConfig: readonly ProjectToolCommandArgument[],
+	params: ProjectToolInput,
+): string[] {
+	const args: string[] = [];
+	for (const argument of argumentsConfig) {
+		if (argument.kind === "literal") {
+			args.push(argument.value);
+			continue;
+		}
+		if (argument.kind === "param") {
+			const value = params[argument.name];
+			if (hasParameterValue(value)) args.push(stringifyParameterValue(value));
+			continue;
+		}
+		if (argument.kind === "flag") {
+			if (params[argument.when] === true) args.push(argument.flag);
+			continue;
+		}
+
+		const value = params[argument.name];
+		if (hasParameterValue(value)) {
+			args.push(argument.option, stringifyParameterValue(value));
+		}
+	}
+	return args;
+}
+
+function buildShellCommand(
+	command: ResolvedProjectToolCommand,
+	params: ProjectToolInput,
+): string {
+	return [command.command, ...renderCommandArguments(command.arguments, params)]
+		.map(shellQuote)
+		.join(" ");
+}
+
 function commandDetailsFromState(
 	state: MutableCommandState,
 ): ProjectCommandDetails {
 	const snapshot = state.output.snapshot();
 	return {
 		label: state.config.displayLabel,
-		command: state.config.command,
+		command: state.executedCommand ?? state.config.displayCommand,
 		cwd: state.config.displayCwd,
 		timeoutSeconds: state.config.timeoutSeconds,
 		status: state.status,
@@ -477,6 +766,7 @@ function formatLlmOutput(details: ProjectToolDetails): string {
 
 async function runCommand(
 	state: MutableCommandState,
+	params: ProjectToolInput,
 	ops: ReturnType<typeof createLocalBashOperations>,
 	commandPrefix: string | undefined,
 	signal: AbortSignal | undefined,
@@ -486,9 +776,10 @@ async function runCommand(
 	state.startedAt = Date.now();
 	onChange();
 
+	state.executedCommand = buildShellCommand(state.config, params);
 	const executedCommand = commandPrefix
-		? `${commandPrefix}\n${state.config.command}`
-		: state.config.command;
+		? `${commandPrefix}\n${state.executedCommand}`
+		: state.executedCommand;
 	try {
 		const result = await ops.exec(executedCommand, state.config.absoluteCwd, {
 			onData: (data) => {
@@ -522,6 +813,7 @@ async function runCommand(
 
 async function executeProjectTool(
 	tool: ResolvedProjectTool,
+	params: ProjectToolInput,
 	ctx: ExtensionContext,
 	signal: AbortSignal | undefined,
 	onUpdate: AgentToolUpdateCallback<ProjectToolDetails> | undefined,
@@ -568,7 +860,7 @@ async function executeProjectTool(
 		scheduleUpdate();
 		await Promise.all(
 			states.map((state) =>
-				runCommand(state, ops, commandPrefix, signal, scheduleUpdate),
+				runCommand(state, params, ops, commandPrefix, signal, scheduleUpdate),
 			),
 		);
 	} finally {
@@ -590,15 +882,91 @@ function isProjectToolDetails(value: unknown): value is ProjectToolDetails {
 	);
 }
 
-function renderCallTitle(tool: ResolvedProjectTool, theme: Theme): Component {
+function formatParameterValueForDisplay(
+	value: string | number | boolean,
+): string {
+	let text: string;
+	if (typeof value === "string") {
+		text = value === "" ? '""' : value.replace(/[\r\n\t]/gu, " ");
+	} else {
+		text = String(value);
+	}
+	return text.length > 80 ? `${text.slice(0, 77)}...` : text;
+}
+
+function formatParameterRecordForDisplay(
+	parameters: Readonly<Record<string, string | number | boolean>>,
+	theme: Theme,
+): string {
+	const parts = Object.entries(parameters).map(
+		([name, value]) =>
+			`${theme.fg("muted", name)} ${theme.fg(
+				"accent",
+				formatParameterValueForDisplay(value),
+			)}`,
+	);
+	if (parts.length === 0) return "";
+	return `${theme.fg("dim", " (")}${parts.join(theme.fg("dim", ", "))}${theme.fg("dim", ")")}`;
+}
+
+function formatParametersForDisplay(
+	tool: ResolvedProjectTool,
+	params: ProjectToolInput,
+	theme: Theme,
+): string {
+	const parameters: Record<string, string | number | boolean> = {};
+	for (const name of Object.keys(tool.parameters)) {
+		const value = params[name];
+		if (hasParameterValue(value)) parameters[name] = value;
+	}
+	return formatParameterRecordForDisplay(parameters, theme);
+}
+
+function renderCallTitle(
+	tool: ResolvedProjectTool,
+	args: ProjectToolInput,
+	theme: Theme,
+): Component {
 	let text = theme.fg("toolTitle", theme.bold(tool.name));
+	text += formatParametersForDisplay(tool, args, theme);
 	if (tool.commands.length > 1) {
 		text += theme.fg("dim", ` · ${tool.commands.length} parallel commands`);
 	}
 	return new Text(text, 0, 0);
 }
 
-function renderRunning(details: ProjectToolDetails, theme: Theme): Component {
+function renderRunningOutput(
+	output: string,
+	expanded: boolean,
+	theme: Theme,
+): string[] {
+	const trimmed = output.trimEnd();
+	if (!trimmed) return [];
+
+	const outputLines = trimmed.split("\n");
+	const maxLines = expanded ? EXPANDED_TAIL_LINES : RUNNING_TAIL_LINES;
+	const skipped = Math.max(0, outputLines.length - maxLines);
+	const visibleLines = skipped > 0 ? outputLines.slice(skipped) : outputLines;
+	const lines: string[] = [];
+
+	if (skipped > 0) {
+		lines.push(
+			theme.fg(
+				"muted",
+				`... (${skipped} earlier lines, ${keyHint("app.tools.expand", "to expand")})`,
+			),
+		);
+	}
+	lines.push(...visibleLines.map((line) => theme.fg("toolOutput", line)));
+	return lines;
+}
+
+function renderRunning(
+	details: ProjectToolDetails,
+	theme: Theme,
+	elapsedMs: number | undefined,
+	expanded: boolean,
+): Component {
 	const lines: string[] = [];
 	const showCommandHeaders = details.commandCount > 1;
 	for (const command of details.commands) {
@@ -610,16 +978,17 @@ function renderRunning(details: ProjectToolDetails, theme: Theme): Component {
 			if (command.status === "failed") header += ` ${theme.fg("error", "✗")}`;
 			lines.push(header);
 		}
-		const output = truncateLines(command.output.trimEnd(), RUNNING_TAIL_LINES);
-		if (output) {
-			lines.push(
-				...output.split("\n").map((line) => theme.fg("toolOutput", line)),
-			);
+		const output = renderRunningOutput(command.output, expanded, theme);
+		if (output.length > 0) {
+			lines.push(...output);
 		} else if (command.status === "running" || command.status === "pending") {
 			lines.push(theme.fg("muted", "(running...)"));
 		} else {
 			lines.push(theme.fg("muted", "(no output)"));
 		}
+	}
+	if (elapsedMs !== undefined) {
+		lines.push("", theme.fg("dim", `Elapsed ${formatDuration(elapsedMs)}`));
 	}
 	return new Text(lines.join("\n"), 0, 0);
 }
@@ -638,9 +1007,8 @@ function renderSummary(details: ProjectToolDetails, theme: Theme): Component {
 	);
 	const success = failed.length === 0;
 	const duration = formatTotalDuration(details);
-	const lines: string[] = [
-		`${theme.fg("toolTitle", theme.bold(details.toolName))} ${success ? theme.fg("success", "✓") : theme.fg("error", "✗")}${duration ? theme.fg("dim", ` · ${duration}`) : ""}`,
-	];
+	const status = `${success ? theme.fg("success", "✓") : theme.fg("error", "✗")}${duration ? theme.fg("dim", ` ${duration}`) : ""}`;
+	const lines: string[] = [];
 	if (details.commandCount > 1) {
 		lines.push(
 			success
@@ -653,16 +1021,16 @@ function renderSummary(details: ProjectToolDetails, theme: Theme): Component {
 						`${failed.length}/${details.commandCount} commands failed`,
 					),
 		);
+		for (const command of failed) {
+			lines.push(theme.fg("dim", `[${command.label}] ${statusLine(command)}`));
+		}
+		lines.push(status);
+		return new Text(lines.join("\n"), 0, 0);
 	}
+
+	lines.push(status);
 	for (const command of failed) {
-		lines.push(
-			theme.fg(
-				"error",
-				details.commandCount > 1
-					? `[${command.label}] ${statusLine(command)}`
-					: statusLine(command),
-			),
-		);
+		lines.push(theme.fg("error", statusLine(command)));
 	}
 	return new Text(lines.join("\n"), 0, 0);
 }
@@ -700,6 +1068,10 @@ function renderResult(
 	result: AgentToolResult<ProjectToolDetails>,
 	options: { expanded: boolean; isPartial: boolean },
 	theme: Theme,
+	context: {
+		state: { startedAt?: number; interval?: ReturnType<typeof setInterval> };
+		invalidate(): void;
+	},
 ): Component {
 	const details = result.details;
 	if (!isProjectToolDetails(details)) {
@@ -707,8 +1079,22 @@ function renderResult(
 			result.content.find((content) => content.type === "text")?.text ?? "";
 		return new Text(text, 0, 0);
 	}
-	if (options.isPartial || details.status === "running")
-		return renderRunning(details, theme);
+	const running = options.isPartial || details.status === "running";
+	if (running) {
+		context.state.startedAt ??= Date.now();
+		context.state.interval ??= setInterval(() => context.invalidate(), 1000);
+		return renderRunning(
+			details,
+			theme,
+			Date.now() - context.state.startedAt,
+			options.expanded,
+		);
+	}
+	if (context.state.interval) {
+		clearInterval(context.state.interval);
+		context.state.interval = undefined;
+	}
+	context.state.startedAt = undefined;
 	return options.expanded
 		? renderExpanded(details, theme)
 		: renderSummary(details, theme);
@@ -716,7 +1102,7 @@ function renderResult(
 
 function createProjectToolDefinition(
 	tool: ResolvedProjectTool,
-): ToolDefinition<typeof emptyParams, ProjectToolDetails> {
+): ToolDefinition<TSchema, ProjectToolDetails> {
 	return {
 		name: tool.name,
 		label: tool.name,
@@ -725,18 +1111,25 @@ function createProjectToolDefinition(
 		promptGuidelines: tool.promptGuidelines
 			? [...tool.promptGuidelines]
 			: undefined,
-		parameters: emptyParams,
-		executionMode: "sequential" as const,
-		renderCall: (_args, theme, context) =>
-			context.isPartial ? renderCallTitle(tool, theme) : new Text("", 0, 0),
+		parameters: tool.parametersSchema,
+		executionMode: tool.executionMode ?? "sequential",
+		renderCall: (args, theme) =>
+			renderCallTitle(tool, args as ProjectToolInput, theme),
 		renderResult,
 		execute: (
 			_toolCallId: string,
-			_params: object,
+			params,
 			signal: AbortSignal | undefined,
 			onUpdate: AgentToolUpdateCallback<ProjectToolDetails> | undefined,
 			ctx: ExtensionContext,
-		) => executeProjectTool(tool, ctx, signal, onUpdate),
+		) =>
+			executeProjectTool(
+				tool,
+				params as ProjectToolInput,
+				ctx,
+				signal,
+				onUpdate,
+			),
 	};
 }
 
@@ -778,7 +1171,6 @@ export function registerProjectTools(
 	}
 
 	const existingToolNames = new Set(pi.getAllTools().map((tool) => tool.name));
-	const newlyRegistered: string[] = [];
 	const summaries: ProjectToolSummary[] = [];
 	for (const [name, rawConfig] of Object.entries(projectSettings.tools)) {
 		try {
@@ -793,7 +1185,6 @@ export function registerProjectTools(
 			pi.registerTool(createProjectToolDefinition(resolved));
 			policyRegistry.register({ name, allowedModes: resolved.allowedModes });
 			registeredNames.add(name);
-			newlyRegistered.push(name);
 			summaries.push({
 				name,
 				allowedModes: resolved.allowedModes,
@@ -807,11 +1198,6 @@ export function registerProjectTools(
 		}
 	}
 
-	if (newlyRegistered.length > 0) {
-		pi.setActiveTools([
-			...new Set([...pi.getActiveTools(), ...newlyRegistered]),
-		]);
-	}
 	return summaries;
 }
 


### PR DESCRIPTION

## Summary

- add parameterized Pi project tools with structured command arguments
- improve project tool rendering for parameters, parallel command summaries, and running output
- restrict active tool schemas to the current permission mode to avoid exposing unavailable tools

## Background

Project tools now encode safe command paths and arguments instead of relying on free-form shell strings. The permission mode integration also reapplies active tools after project tools are registered so only mode-allowed tools are exposed to the provider.
