### PR TITLE
Configure tmux pane borders by pane count

### DIFF
--- a/modules/dot/programs/tmux/default.nix
+++ b/modules/dot/programs/tmux/default.nix
@@ -12,6 +12,8 @@ let
   statusCommands = import ./status-commands.nix { inherit config pkgs; };
 
   borderToggle = ''if -F "#{==:#{window_panes},1}" "setw pane-border-status off" "setw pane-border-status ${cfg.paneBorder.title.position}"'';
+  activeBorderToggle = ''if -F "#{==:#{window_panes},1}" "setw pane-active-border-style '${cfg.paneBorder.activeStyleWhenSinglePane}'" "setw pane-active-border-style '${cfg.paneBorder.activeStyle}'"'';
+  activeBorderHookFlag = if cfg.paneBorder.hideWhenSinglePane then "-ag" else "-g";
   paneBorderTitleNotice = "#{?@pane_notice_icon, #{@pane_notice_icon} #{?@pane_notice_title,#{@pane_notice_title},#{pane_title}},#{?@status_notice_icon, #{@status_notice_icon} #{pane_title},#{pane_title}}}";
   paneBorderTitleFormat =
     if cfg.paneBorder.title.format == null then
@@ -151,6 +153,13 @@ let
         ''
     }
     ${mkSetGlobal "pane-active-border-style" "'${cfg.paneBorder.activeStyle}'"}
+    ${lib.optionalString (cfg.paneBorder.activeStyleWhenSinglePane != null) ''
+      ${activeBorderToggle}
+      set-hook ${activeBorderHookFlag} after-split-window '${activeBorderToggle}'
+      set-hook ${activeBorderHookFlag} after-kill-pane '${activeBorderToggle}'
+      set-hook ${activeBorderHookFlag} pane-exited '${activeBorderToggle}'
+      set-hook ${activeBorderHookFlag} after-select-window '${activeBorderToggle}'
+    ''}
   '';
 
   terminalTitleConfig = lib.optionalString cfg.terminalTitle.enable ''
@@ -421,6 +430,11 @@ in
         type = lib.types.str;
         default = "fg=green";
         description = "pane-active-border-style value.";
+      };
+      activeStyleWhenSinglePane = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "pane-active-border-style value used for single-pane windows. When null, activeStyle is always used.";
       };
       title = {
         enable = lib.mkEnableOption "pane border title format";

--- a/modules/recipes/tmux.nix
+++ b/modules/recipes/tmux.nix
@@ -2,7 +2,8 @@
 
 let
   colors = {
-    paneBorder = "#494d64";
+    paneBorder = "#6e738d";
+    activePaneBorder = "#a28a79";
     text = "#cad3f5";
     muted = "#8087a2";
     accent = "#ffb86c";
@@ -111,7 +112,8 @@ in
       indicators = "off";
       lines = "single";
       style = "fg=${colors.paneBorder}";
-      activeStyle = "fg=${colors.paneBorder}";
+      activeStyle = "fg=${colors.activePaneBorder}";
+      activeStyleWhenSinglePane = "fg=${colors.paneBorder}";
       title = {
         enable = true;
         position = "top";


### PR DESCRIPTION
## Summary

- Add a tmux option to use a different active pane border style for single-pane windows.
- Keep single-pane windows visually neutral by matching the inactive border color.
- Use a subtle accent-tinted active border only when a window has multiple panes.

## Background

A highlighted active border is useful for distinguishing panes, but it is distracting when the window only contains one pane.