### PR TITLE
Add array parameters for Pi project tools

### DIFF
--- a/files/agent-skills/pi-project-tools/SKILL.md
+++ b/files/agent-skills/pi-project-tools/SKILL.md
@@ -5,36 +5,42 @@ description: Use only when the user explicitly mentions Pi project tools, .pi/se
 
 # Project Tools
 
-Pi is the coding agent. A Pi project tool is a tool definition written by a repository in `.pi/settings.user.json` under `tools`.
+Pi project tools are repository-defined tools in `.pi/settings.user.json` under `tools`. They become callable Pi tools only for that project.
 
-Use this skill only when the user explicitly asks about one of these things:
+Use this skill only for:
 
 - Pi project tools
 - `.pi/settings.user.json` `tools`
 - adding, editing, renaming, removing, reviewing, or explaining a Pi tool definition
 
-Do not use this skill for general shell commands, ordinary lint/test/format requests, or non-Pi tool configuration.
+Do not use this skill for ordinary shell commands, lint/test/format requests, or non-Pi tool configuration.
 
-Project tools become callable Pi tools for that project only.
+## Workflow
 
-## Safety
+1. Inspect existing `.pi/settings.user.json` before editing.
+2. Preserve unrelated settings and unrelated `tools` entries.
+3. Add, rename, remove, or modify only the requested tool entries.
+4. Validate JSON after editing.
+5. Summarize changed tool names, commands, parameters, execution mode, and allowed modes.
+
+## Safety and style
 
 - Treat project tools as project-controlled command execution.
-- Prefer `allowedModes: ["read"]` for non-mutating checks.
-- Use `allowedModes: ["write"]` only for commands that modify the working tree, such as formatters.
-- Keep `allowedModes` to `read` and/or `write` unless the user explicitly requests otherwise.
-- Keep commands deterministic and scoped to the repository.
+- Prefer `allowedModes: ["read", "write"]` for non-mutating checks so they are available in both read and write modes.
+- Use `allowedModes: ["read"]` only when a read-only tool should be unavailable during write mode.
+- Use `allowedModes: ["write"]` for commands that modify the working tree, such as formatters.
+- Keep `allowedModes` to `read` and/or `write`.
 - Avoid commands that read secrets, access credentials, or modify paths outside the project.
+- Keep commands deterministic and scoped to the repository.
 - Set `timeoutSeconds` for commands that might hang.
-- Use `executionMode: "parallel"` only when the project tool is safe to run concurrently with other tool calls.
+- Use `executionMode: "parallel"` only when safe to run concurrently with other tool calls.
 - Prefer structured `command` + `arguments` over free-form shell strings.
 - Put fixed subcommands in `arguments`, not in `command`.
-- Use parameter placeholders only as whole arguments, e.g. `"{{path}}"`; do not embed them inside larger strings.
-- Parameter values are shell-quoted by the extension and are passed as single arguments. Do not add extra quoting around `"{{param}}"`.
+- Use parameter placeholders only as whole arguments, e.g. `"{{path}}"`.
+- Parameter values are shell-quoted and passed as single arguments; do not add extra quotes.
+- For variable-length inputs, use an `array` parameter with a `values` entry; do not invent fixed `path1`, `path2`, `path3` parameters.
 
 ## Settings shape
-
-Add or update `.pi/settings.user.json`:
 
 ```json
 {
@@ -56,52 +62,75 @@ Add or update `.pi/settings.user.json`:
 }
 ```
 
-Tool config fields:
+## Tool fields
 
 - `description` required; explain what the tool does.
-- `allowedModes` required; non-empty array. Use `read` and/or `write` for normal project tools.
-- `commands` required; non-empty array. Commands run in parallel within one project tool call.
-- `parameters` optional; object of LLM-provided parameters for this tool.
-- `executionMode` optional; `sequential` or `parallel`. Defaults to `sequential`. Use `parallel` only when this project tool is safe to run concurrently with other tool calls.
-- `cwd` optional; relative path inside the project root. Omit `cwd` when running from the project root.
+- `allowedModes` required; non-empty array of `read` and/or `write`.
+- `commands` required; non-empty array. Commands in one project tool run in parallel.
+- `parameters` optional; object of LLM-provided parameters.
+- `executionMode` optional; `sequential` or `parallel`. Defaults to `sequential`.
+- `cwd` optional; relative path inside the project root.
 - `timeoutSeconds` optional; default timeout for commands.
 - `promptSnippet` optional; one-line LLM-facing tool summary.
 - `promptGuidelines` optional; bullets that must name the tool explicitly.
 
-Parameter fields (`tools.<name>.parameters.<paramName>`):
+## Parameter fields
 
-- `type` required; one of `string`, `number`, or `boolean`.
-- `description` optional but recommended; explain what value the LLM should provide.
-- `required` optional; defaults to `false`. Set `true` for required parameters.
+`tools.<name>.parameters.<paramName>`:
 
-Command fields:
+- `type` required; `string`, `number`, `boolean`, `array`, or shorthand `string[]`, `number[]`, `boolean[]`.
+- `items` required only for `array`; object with `type` of `string`, `number`, or `boolean`.
+- `description` optional but recommended.
+- `required` optional; defaults to `false`.
 
-- `command` required; executable/program name as a single command token, e.g. `"brain"`, `"pnpm"`, or `"nix"`.
-- `arguments` optional; ordered array of fixed arguments, parameter placeholders, flags, and options.
-- `label` optional; display label in tool output.
-- `cwd` optional; relative path inside the project root. Omit `cwd` when running from the project root.
+Example:
+
+```json
+"parameters": {
+  "path": { "type": "string", "description": "Path to check.", "required": true },
+  "paths": { "type": "string[]", "description": "Paths to check." },
+  "detail": { "type": "boolean", "description": "Show detailed output." },
+  "top": { "type": "number", "description": "Number of entries." }
+}
+```
+
+## Command fields
+
+- `command` required; executable as a single token, e.g. `"brain"`, `"pnpm"`, `"nix"`.
+- `arguments` optional; ordered fixed args, placeholders, flags, options, and array expansions.
+- `label` optional; display label in output.
+- `cwd` optional; relative path inside the project root.
 - `timeoutSeconds` optional; overrides the tool default.
 
-Argument entries:
+## Argument entries
 
 - Fixed argument: `"rule"`
-- Parameter argument: `"{{path}}"`
+- Scalar parameter: `"{{path}}"`
   - References a `string`, `number`, or `boolean` parameter.
-  - If the parameter is optional and omitted, this argument is omitted.
-  - Empty string `""` is treated as provided and passed as an empty argument.
+  - Optional omitted values are omitted.
+  - Empty string `""` is passed as an empty argument.
+  - Array parameters cannot use this form; use `values` with `style`.
 - Boolean flag: `{ "flag": "--detail", "when": "detail" }`
   - `when` must reference a `boolean` parameter.
-  - The flag is included only when the parameter is `true`.
+  - Included only when the parameter is `true`.
 - Value option: `{ "option": "--top", "value": "{{top}}" }`
   - `value` must reference a `string` or `number` parameter.
-  - If the parameter is optional and omitted, both option name and value are omitted.
+  - Optional omitted values omit both option and value.
+- Array repeat option: `{ "option": "--path", "values": "{{paths}}", "style": "repeat" }`
+  - Expands to `--path a --path b --path c`.
+- Array positional spread: `{ "values": "{{paths}}", "style": "spread" }`
+  - Expands to `a b c`.
+- Array join: `{ "option": "--paths", "values": "{{paths}}", "style": "join", "separator": "," }`
+  - Expands to `--paths a,b,c`; without `option`, expands to `a,b,c`.
+  - `separator` is required for `join`.
+- For every `values` entry, `style` is required and `values` must reference an `array` parameter.
+- Optional omitted arrays and empty arrays expand to no arguments.
 
 ## Naming
 
 - Tool names must match `^[a-z][a-z0-9_-]*$`.
-- Parameter names must start with a letter or `_` and then use letters, numbers, `_`, or `-`.
-- Use concise names like `lint`, `test`, `format`, `check_types`, `homemanager_switch`, `brain_rule_match`.
-- Do not conflict with built-in or extension tools.
+- Parameter names must start with a letter or `_`, then use letters, numbers, `_`, or `-`.
+- Do not conflict with built-in tools (`read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`, `mv`, `rm`) or extension tools.
 
 ## Examples
 
@@ -115,80 +144,14 @@ Read-only check:
       "allowedModes": ["read", "write"],
       "executionMode": "parallel",
       "commands": [
-        {
-          "label": "lint",
-          "command": "pnpm",
-          "arguments": ["lint"],
-          "timeoutSeconds": 120
-        }
+        { "label": "lint", "command": "pnpm", "arguments": ["lint"], "timeoutSeconds": 120 }
       ]
     }
   }
 }
 ```
 
-Formatter:
-
-```json
-{
-  "tools": {
-    "format": {
-      "description": "Format the project in place.",
-      "allowedModes": ["write"],
-      "commands": [
-        { "label": "treefmt", "command": "treefmt", "timeoutSeconds": 120 }
-      ]
-    }
-  }
-}
-```
-
-Multiple parallel checks:
-
-```json
-{
-  "tools": {
-    "check": {
-      "description": "Run project checks in parallel.",
-      "allowedModes": ["read", "write"],
-      "executionMode": "parallel",
-      "commands": [
-        { "label": "types", "command": "pnpm", "arguments": ["lint"], "timeoutSeconds": 120 },
-        { "label": "nix", "command": "nix", "arguments": ["flake", "check"], "timeoutSeconds": 600 }
-      ]
-    }
-  }
-}
-```
-
-Parameterized path command:
-
-```json
-{
-  "tools": {
-    "brain_rule_match": {
-      "description": "Show brain rules that apply to a path.",
-      "allowedModes": ["read"],
-      "parameters": {
-        "path": {
-          "type": "string",
-          "description": "Path to check.",
-          "required": true
-        }
-      },
-      "commands": [
-        {
-          "label": "brain rule match",
-          "command": "brain",
-          "arguments": ["rule", "match", "{{path}}"]
-        }
-      ]
-    }
-  }
-}
-```
-
-Flags and value options in a specific order:
+Parameterized command with flag and option:
 
 ```json
 {
@@ -197,14 +160,8 @@ Flags and value options in a specific order:
       "description": "Count approximate brain tokens.",
       "allowedModes": ["read"],
       "parameters": {
-        "detail": {
-          "type": "boolean",
-          "description": "Show detailed output."
-        },
-        "top": {
-          "type": "number",
-          "description": "Number of top entries to show."
-        }
+        "detail": { "type": "boolean", "description": "Show detailed output." },
+        "top": { "type": "number", "description": "Number of top entries." }
       },
       "commands": [
         {
@@ -223,11 +180,32 @@ Flags and value options in a specific order:
 }
 ```
 
-## Workflow
+Variable-length repeat option:
 
-1. Inspect existing `.pi/settings.user.json` before editing.
-2. Preserve unrelated settings and unrelated `tools` entries.
-3. Add, rename, remove, or modify only the requested `tools` entries.
-4. Keep each tool's `description`, `allowedModes`, `executionMode`, `parameters`, and `commands` consistent with the command behavior.
-5. Validate that `.pi/settings.user.json` remains valid JSON.
-6. Summarize the changed tool names, commands, parameters, execution mode, and allowed modes.
+```json
+{
+  "tools": {
+    "brain_context_suggest": {
+      "description": "Suggest applicable brain context files.",
+      "allowedModes": ["read"],
+      "parameters": {
+        "paths": { "type": "string[]", "description": "Paths to consider." },
+        "query": { "type": "string", "description": "Optional query to guide suggestions." }
+      },
+      "commands": [
+        {
+          "label": "brain context suggest",
+          "command": "brain",
+          "arguments": [
+            "context",
+            "suggest",
+            { "option": "--path", "values": "{{paths}}", "style": "repeat" },
+            { "option": "--query", "value": "{{query}}" }
+          ],
+          "timeoutSeconds": 60
+        }
+      ]
+    }
+  }
+}
+```

--- a/files/pi/agent/extensions/user/lib/tool/project.ts
+++ b/files/pi/agent/extensions/user/lib/tool/project.ts
@@ -46,22 +46,55 @@ type ProjectToolSettings = {
 	tools?: unknown;
 };
 
-type ProjectParameterType = "string" | "number" | "boolean";
+type ProjectScalarParameterType = "string" | "number" | "boolean";
+type ProjectArrayItemType = ProjectScalarParameterType;
 type ProjectToolExecutionMode = "sequential" | "parallel";
+type ProjectArrayArgumentStyle = "repeat" | "spread" | "join";
 
-type ProjectParameterConfig = {
-	readonly type: ProjectParameterType;
+type ProjectScalarParameterConfig = {
+	readonly type: ProjectScalarParameterType;
 	readonly description?: string;
 	readonly required: boolean;
 };
 
-type ProjectToolInput = Record<string, string | number | boolean | undefined>;
+type ProjectArrayParameterConfig = {
+	readonly type: "array";
+	readonly items: { readonly type: ProjectArrayItemType };
+	readonly description?: string;
+	readonly required: boolean;
+};
+
+type ProjectParameterConfig =
+	| ProjectScalarParameterConfig
+	| ProjectArrayParameterConfig;
+
+type ProjectScalarParameterValue = string | number | boolean;
+type ProjectArrayParameterValue = readonly ProjectScalarParameterValue[];
+type ProjectParameterValue =
+	| ProjectScalarParameterValue
+	| ProjectArrayParameterValue;
+
+type ProjectToolInput = Record<string, ProjectParameterValue | undefined>;
 
 type ProjectToolCommandArgument =
 	| { readonly kind: "literal"; readonly value: string }
 	| { readonly kind: "param"; readonly name: string }
 	| { readonly kind: "flag"; readonly flag: string; readonly when: string }
-	| { readonly kind: "option"; readonly option: string; readonly name: string };
+	| { readonly kind: "option"; readonly option: string; readonly name: string }
+	| {
+			readonly kind: "array";
+			readonly style: "repeat";
+			readonly option: string;
+			readonly name: string;
+	  }
+	| { readonly kind: "array"; readonly style: "spread"; readonly name: string }
+	| {
+			readonly kind: "array";
+			readonly style: "join";
+			readonly option?: string;
+			readonly name: string;
+			readonly separator: string;
+	  };
 
 type ProjectToolCommandConfig = {
 	readonly label?: string;
@@ -205,6 +238,21 @@ function resolveProjectCwd(
 	return { absolute, display: rel };
 }
 
+function isScalarParameterType(
+	value: unknown,
+): value is ProjectScalarParameterType {
+	return value === "string" || value === "number" || value === "boolean";
+}
+
+function parseArrayParameterType(
+	value: unknown,
+): ProjectArrayItemType | undefined {
+	if (value === "string[]") return "string";
+	if (value === "number[]") return "number";
+	if (value === "boolean[]") return "boolean";
+	return undefined;
+}
+
 function normalizeParameter(
 	name: string,
 	value: unknown,
@@ -216,23 +264,47 @@ function normalizeParameter(
 		);
 	}
 	if (!isObject(value)) throw new Error(`${path}.${name} must be an object.`);
+	const shorthandArrayItemType = parseArrayParameterType(value.type);
 	if (
-		value.type !== "string" &&
-		value.type !== "number" &&
-		value.type !== "boolean"
+		!isScalarParameterType(value.type) &&
+		value.type !== "array" &&
+		shorthandArrayItemType === undefined
 	) {
-		throw new Error(`${path}.${name}.type must be string, number, or boolean.`);
+		throw new Error(
+			`${path}.${name}.type must be string, number, boolean, array, string[], number[], or boolean[].`,
+		);
 	}
 	if (value.required !== undefined && typeof value.required !== "boolean") {
 		throw new Error(`${path}.${name}.required must be a boolean.`);
 	}
-	return {
-		type: value.type,
+	const common = {
 		description: normalizeOptionalString(
 			value.description,
 			`${path}.${name}.description`,
 		),
 		required: value.required ?? false,
+	};
+	if (isScalarParameterType(value.type)) return { type: value.type, ...common };
+	if (shorthandArrayItemType !== undefined) {
+		return {
+			type: "array",
+			items: { type: shorthandArrayItemType },
+			...common,
+		};
+	}
+
+	if (!isObject(value.items)) {
+		throw new Error(`${path}.${name}.items must be an object.`);
+	}
+	if (!isScalarParameterType(value.items.type)) {
+		throw new Error(
+			`${path}.${name}.items.type must be string, number, or boolean.`,
+		);
+	}
+	return {
+		type: "array",
+		items: { type: value.items.type },
+		...common,
 	};
 }
 
@@ -285,6 +357,16 @@ function parseRequiredParameterPlaceholder(
 	return name;
 }
 
+function normalizeArrayArgumentStyle(
+	value: unknown,
+	path: string,
+): ProjectArrayArgumentStyle {
+	if (value === "repeat" || value === "spread" || value === "join") {
+		return value;
+	}
+	throw new Error(`${path} must be repeat, spread, or join.`);
+}
+
 function normalizeArgument(
 	value: unknown,
 	path: string,
@@ -293,20 +375,32 @@ function normalizeArgument(
 	if (typeof value === "string") {
 		const name = parseOptionalParameterPlaceholder(value, path);
 		if (!name) return { kind: "literal", value };
-		getParameter(parameters, name, path);
+		const parameter = getParameter(parameters, name, path);
+		if (parameter.type === "array") {
+			throw new Error(
+				`${path} references array parameter '${name}'. Use an object with values and style.`,
+			);
+		}
 		return { kind: "param", name };
 	}
 
 	if (!isObject(value)) {
 		throw new Error(
-			`${path} must be a string, a flag object, or an option object.`,
+			`${path} must be a string, a flag object, an option object, or an array values object.`,
 		);
 	}
 
 	const hasFlag = "flag" in value;
 	const hasOption = "option" in value;
-	if (hasFlag && hasOption) {
-		throw new Error(`${path} cannot contain both flag and option.`);
+	const hasValue = "value" in value;
+	const hasValues = "values" in value;
+	if (hasFlag && (hasOption || hasValue || hasValues)) {
+		throw new Error(
+			`${path} flag arguments cannot contain option, value, or values.`,
+		);
+	}
+	if (hasValue && hasValues) {
+		throw new Error(`${path} cannot contain both value and values.`);
 	}
 
 	if (hasFlag) {
@@ -319,6 +413,48 @@ function normalizeArgument(
 			throw new Error(`${path}.when must reference a boolean parameter.`);
 		}
 		return { kind: "flag", flag, when };
+	}
+
+	if (hasValues) {
+		const valuesReference = normalizeOptionalString(
+			value.values,
+			`${path}.values`,
+		);
+		if (!valuesReference) throw new Error(`${path}.values is required.`);
+		const name = parseRequiredParameterPlaceholder(
+			valuesReference,
+			`${path}.values`,
+		);
+		const parameter = getParameter(parameters, name, `${path}.values`);
+		if (parameter.type !== "array") {
+			throw new Error(`${path}.values must reference an array parameter.`);
+		}
+		const style = normalizeArrayArgumentStyle(value.style, `${path}.style`);
+		const option = hasOption
+			? normalizeOptionalString(value.option, `${path}.option`)
+			: undefined;
+		if (hasOption && !option) throw new Error(`${path}.option is required.`);
+
+		if (style === "repeat") {
+			if (!option)
+				throw new Error(`${path}.option is required for repeat style.`);
+			return { kind: "array", style, option, name };
+		}
+		if (style === "spread") {
+			if (option)
+				throw new Error(`${path}.option is not allowed for spread style.`);
+			return { kind: "array", style, name };
+		}
+
+		const separator = normalizeOptionalString(
+			value.separator,
+			`${path}.separator`,
+		);
+		if (!separator)
+			throw new Error(`${path}.separator is required for join style.`);
+		return option
+			? { kind: "array", style, option, name, separator }
+			: { kind: "array", style, name, separator };
 	}
 
 	if (hasOption) {
@@ -334,7 +470,7 @@ function normalizeArgument(
 			`${path}.value`,
 		);
 		const parameter = getParameter(parameters, name, `${path}.value`);
-		if (parameter.type === "boolean") {
+		if (parameter.type === "boolean" || parameter.type === "array") {
 			throw new Error(
 				`${path}.value must reference a string or number parameter.`,
 			);
@@ -342,7 +478,7 @@ function normalizeArgument(
 		return { kind: "option", option, name };
 	}
 
-	throw new Error(`${path} must contain either flag or option.`);
+	throw new Error(`${path} must contain flag, option, or values.`);
 }
 
 function normalizeCommand(
@@ -375,13 +511,26 @@ function normalizeCommand(
 	};
 }
 
+function createScalarParameterSchema(
+	type: ProjectScalarParameterType,
+	options: { description: string } | undefined,
+): TSchema {
+	if (type === "string") return Type.String(options);
+	if (type === "number") return Type.Number(options);
+	return Type.Boolean(options);
+}
+
 function createParameterSchema(parameter: ProjectParameterConfig): TSchema {
 	const options = parameter.description
 		? { description: parameter.description }
 		: undefined;
-	if (parameter.type === "string") return Type.String(options);
-	if (parameter.type === "number") return Type.Number(options);
-	return Type.Boolean(options);
+	if (parameter.type === "array") {
+		return Type.Array(
+			createScalarParameterSchema(parameter.items.type, undefined),
+			options,
+		);
+	}
+	return createScalarParameterSchema(parameter.type, options);
 }
 
 function buildParameterSchema(
@@ -401,7 +550,13 @@ function formatArgumentForDisplay(
 	if (argument.kind === "literal") return argument.value;
 	if (argument.kind === "param") return `{{${argument.name}}}`;
 	if (argument.kind === "flag") return `${argument.flag} when ${argument.when}`;
-	return `${argument.option} {{${argument.name}}}`;
+	if (argument.kind === "option")
+		return `${argument.option} {{${argument.name}}}`;
+	if (argument.style === "repeat")
+		return `${argument.option} {{${argument.name}}}...`;
+	if (argument.style === "spread") return `{{${argument.name}}}...`;
+	const joined = `join({{${argument.name}}}, ${JSON.stringify(argument.separator)})`;
+	return argument.option ? `${argument.option} ${joined}` : joined;
 }
 
 function formatConfiguredCommand(command: ProjectToolCommandConfig): string {
@@ -630,16 +785,58 @@ function shellQuote(value: string): string {
 }
 
 function hasParameterValue(
-	value: string | number | boolean | undefined,
-): value is string | number | boolean {
+	value: ProjectParameterValue | undefined,
+): value is ProjectParameterValue {
 	return value !== undefined;
 }
 
-function stringifyParameterValue(value: string | number | boolean): string {
+function stringifyParameterValue(value: ProjectScalarParameterValue): string {
 	if (typeof value === "number" && !Number.isFinite(value)) {
 		throw new Error("Parameter values must be finite numbers.");
 	}
 	return String(value);
+}
+
+function isProjectArrayParameterValue(
+	value: ProjectParameterValue,
+): value is ProjectArrayParameterValue {
+	return Array.isArray(value);
+}
+
+function getScalarParameterValue(
+	value: ProjectParameterValue | undefined,
+	name: string,
+): ProjectScalarParameterValue | undefined {
+	if (!hasParameterValue(value)) return undefined;
+	if (isProjectArrayParameterValue(value)) {
+		throw new Error(`Parameter '${name}' must be a scalar value.`);
+	}
+	return value;
+}
+
+function getArrayParameterValue(
+	value: ProjectParameterValue | undefined,
+	name: string,
+): ProjectArrayParameterValue | undefined {
+	if (!hasParameterValue(value)) return undefined;
+	if (!isProjectArrayParameterValue(value)) {
+		throw new Error(`Parameter '${name}' must be an array value.`);
+	}
+	return value;
+}
+
+function renderArrayArgument(
+	argument: Extract<ProjectToolCommandArgument, { readonly kind: "array" }>,
+	value: ProjectArrayParameterValue,
+): string[] {
+	if (value.length === 0) return [];
+	const values = value.map(stringifyParameterValue);
+	if (argument.style === "spread") return values;
+	if (argument.style === "repeat") {
+		return values.flatMap((item) => [argument.option, item]);
+	}
+	const joined = values.join(argument.separator);
+	return argument.option ? [argument.option, joined] : [joined];
 }
 
 function renderCommandArguments(
@@ -653,19 +850,30 @@ function renderCommandArguments(
 			continue;
 		}
 		if (argument.kind === "param") {
-			const value = params[argument.name];
-			if (hasParameterValue(value)) args.push(stringifyParameterValue(value));
+			const value = getScalarParameterValue(
+				params[argument.name],
+				argument.name,
+			);
+			if (value !== undefined) args.push(stringifyParameterValue(value));
 			continue;
 		}
 		if (argument.kind === "flag") {
 			if (params[argument.when] === true) args.push(argument.flag);
 			continue;
 		}
-
-		const value = params[argument.name];
-		if (hasParameterValue(value)) {
-			args.push(argument.option, stringifyParameterValue(value));
+		if (argument.kind === "option") {
+			const value = getScalarParameterValue(
+				params[argument.name],
+				argument.name,
+			);
+			if (value !== undefined) {
+				args.push(argument.option, stringifyParameterValue(value));
+			}
+			continue;
 		}
+
+		const value = getArrayParameterValue(params[argument.name], argument.name);
+		if (value !== undefined) args.push(...renderArrayArgument(argument, value));
 	}
 	return args;
 }
@@ -882,20 +1090,30 @@ function isProjectToolDetails(value: unknown): value is ProjectToolDetails {
 	);
 }
 
-function formatParameterValueForDisplay(
-	value: string | number | boolean,
+function formatScalarParameterValueForDisplay(
+	value: ProjectScalarParameterValue,
 ): string {
-	let text: string;
 	if (typeof value === "string") {
-		text = value === "" ? '""' : value.replace(/[\r\n\t]/gu, " ");
+		return value === "" ? '""' : value.replace(/[\r\n\t]/gu, " ");
+	}
+	return String(value);
+}
+
+function formatParameterValueForDisplay(value: ProjectParameterValue): string {
+	let text: string;
+	if (isProjectArrayParameterValue(value)) {
+		text =
+			value.length === 1
+				? formatScalarParameterValueForDisplay(value[0])
+				: `[${value.map(formatScalarParameterValueForDisplay).join(", ")}]`;
 	} else {
-		text = String(value);
+		text = formatScalarParameterValueForDisplay(value);
 	}
 	return text.length > 80 ? `${text.slice(0, 77)}...` : text;
 }
 
 function formatParameterRecordForDisplay(
-	parameters: Readonly<Record<string, string | number | boolean>>,
+	parameters: Readonly<Record<string, ProjectParameterValue>>,
 	theme: Theme,
 ): string {
 	const parts = Object.entries(parameters).map(
@@ -914,7 +1132,7 @@ function formatParametersForDisplay(
 	params: ProjectToolInput,
 	theme: Theme,
 ): string {
-	const parameters: Record<string, string | number | boolean> = {};
+	const parameters: Record<string, ProjectParameterValue> = {};
 	for (const name of Object.keys(tool.parameters)) {
 		const value = params[name];
 		if (hasParameterValue(value)) parameters[name] = value;


### PR DESCRIPTION

## Summary

- Add array parameter support to Pi project tool definitions.
- Support repeat, spread, and join expansion styles for variable-length CLI arguments.
- Document the project tool schema with string[] shorthand and updated guidance.

## Background

This lets project tools accept repeated values such as paths or tags without fixed numbered parameters like path1/path2/path3.
