### PR TITLE
Fix project tool reload updates

### DIFF
--- a/files/pi/agent/extensions/user/lib/tool/project.ts
+++ b/files/pi/agent/extensions/user/lib/tool/project.ts
@@ -1369,6 +1369,7 @@ export function registerProjectTools(
 	ctx: ExtensionContext,
 	registeredNames: Set<string>,
 ): readonly ProjectToolSummary[] {
+	const previouslyRegisteredNames = new Set(registeredNames);
 	registeredNames.clear();
 	let projectSettings: ProjectToolSettings;
 	try {
@@ -1392,7 +1393,8 @@ export function registerProjectTools(
 	const summaries: ProjectToolSummary[] = [];
 	for (const [name, rawConfig] of Object.entries(projectSettings.tools)) {
 		try {
-			if (existingToolNames.has(name) || registeredNames.has(name)) {
+			const isProjectToolUpdate = previouslyRegisteredNames.has(name);
+			if (existingToolNames.has(name) && !isProjectToolUpdate) {
 				notifyWarning(
 					ctx,
 					`Project tool '${name}' conflicts with an existing tool and was ignored.`,


### PR DESCRIPTION
## Summary

- Allow existing project tools to be re-registered on Pi reload.
- Keep conflict protection for built-in and other extension tools.

## Background

Project tool definitions from `.pi/settings.user.json` were ignored on `/reload` when the tool name already existed from the previous load. That prevented parameter schema changes from reaching Pi until a full restart.
