### PR TITLE
Fix tmux notice visibility detection

### DIFF
--- a/modules/dot/programs/scripts/tmux-notice/script.nix
+++ b/modules/dot/programs/scripts/tmux-notice/script.nix
@@ -101,8 +101,8 @@
   pane_is_visible_active() {
     local pane="$1"
     local active
-    active=$(tmux display-message -p -t "$pane" '#{pane_active}:#{window_active}' 2>/dev/null || true)
-    [[ "$active" == "1:1" ]]
+    active=$(tmux display-message -p -t "$pane" '#{pane_active}:#{window_active}:#{session_attached}' 2>/dev/null || true)
+    [[ "$active" =~ ^1:1:[1-9][0-9]*$ ]]
   }
 
   clear_target() {


### PR DESCRIPTION

## Summary

- Require the target tmux session to have an attached client before treating a pane as visible.
- Allow tmux notices such as `pi-wait` to appear when the pane is active only in another, detached session.

## Background

Previously, tmux-notice skipped wait notices whenever the target pane and window were active inside their session. That also matched panes in sessions that were not currently being viewed, so wait notices could be missed after switching to another session.
