### PR TITLE
Rename interview skill to interview-me

### DIFF
--- a/files/agent-skills/interview-me/SKILL.md
+++ b/files/agent-skills/interview-me/SKILL.md
@@ -3,6 +3,6 @@ name: interview-me
 description: Structured clarification for ambiguous requests. Use when intent, constraints, or desired outcome are unclear and shared understanding is needed before proceeding.
 ---
 
-- Do not ask a question already answered in the conversation; treat prior answers as binding unless they conflict or are incomplete.
-- Ask exactly one necessary question at a time, and inspect the codebase instead when the answer is discoverable there.
-- Do not implement until all outcome-affecting requirements are clear; if any remain unclear, stop and ask.
+- Ask in the user's language, exactly one necessary question at a time.
+- Do not ask what is already answered or discoverable from the codebase; treat prior answers as binding unless they conflict or are incomplete.
+- When intent, constraints, or outcome are unclear, stop and ask instead of acknowledging, summarizing, or implementing.

--- a/files/agent-skills/interview-me/SKILL.md
+++ b/files/agent-skills/interview-me/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: interview-me
+description: Structured clarification for ambiguous requests. Use when intent, constraints, or desired outcome are unclear and shared understanding is needed before proceeding.
+---
+
+- Do not ask a question already answered in the conversation; treat prior answers as binding unless they conflict or are incomplete.
+- Ask exactly one necessary question at a time, and inspect the codebase instead when the answer is discoverable there.
+- Do not implement until all outcome-affecting requirements are clear; if any remain unclear, stop and ask.

--- a/files/agent-skills/interview-me/SKILL.md
+++ b/files/agent-skills/interview-me/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: interview-me
-description: Structured clarification for ambiguous requests. Use when intent, constraints, or desired outcome are unclear and shared understanding is needed before proceeding.
+description: Structured clarification to make requirements complete before proceeding.
 ---
 
-- Ask in the user's language, exactly one necessary question at a time.
-- Do not ask what is already answered or discoverable from the codebase; treat prior answers as binding unless they conflict or are incomplete.
-- When intent, constraints, or outcome are unclear, stop and ask instead of acknowledging, summarizing, or implementing.
+- Ask one necessary question at a time, in the user's language, to complete the requirements.
+- Do not ask what is already answered or discoverable from the codebase or context; treat prior answers as binding unless they conflict or are incomplete.
+- While requirements are unclear or incomplete, keep asking and do not proceed.

--- a/files/agent-skills/interview/SKILL.md
+++ b/files/agent-skills/interview/SKILL.md
@@ -1,8 +1,0 @@
----
-name: interview
-description: Structured clarification for ambiguous requests. Use when intent, constraints, or desired outcome are unclear and shared understanding is needed before proceeding.
----
-
-- Keep asking until the intent, constraints, and desired outcome are mutually clear. Ask one focused question at a time.
-- If a question can be answered by inspecting the codebase, inspect the codebase.
-- Include your recommended answer.

--- a/modules/recipes/agent-skills.nix
+++ b/modules/recipes/agent-skills.nix
@@ -8,7 +8,7 @@
     ];
 
     skills = {
-      interview.enable = true;
+      interview-me.enable = true;
       pi-project-tools = {
         enable = true;
         agents.pi = true;


### PR DESCRIPTION
## Summary

- Rename the agent skill from `interview` to `interview-me`.
- Update the agent skills recipe to enable the new skill name.
- Tighten the clarification guidance to ask exactly one necessary question at a time.

## Background

This keeps the deployed skill name aligned with the new `interview-me` convention while preserving the structured clarification behavior.