### PR TITLE
chore: slow github-actions updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,7 +44,7 @@
       "matchManagers": [
         "github-actions"
       ],
-      "minimumReleaseAge": "3 days",
+      "minimumReleaseAge": "1 week",
       "groupName": "github-actions",
       "groupSlug": "github-actions"
     },


### PR DESCRIPTION

## Summary

- Increase Renovate minimum release age for GitHub Actions from 3 days to 1 week.
- Keep GitHub Actions updates grouped under the existing Renovate rule.
