### PR TITLE
fix: hide focus tools for user-selected focus

### DIFF
--- a/files/pi/agent/extensions/user/features/focus.ts
+++ b/files/pi/agent/extensions/user/features/focus.ts
@@ -40,13 +40,14 @@ const openFocusQuickAction =
 		);
 		if (!selected) return;
 		runtime.resetFocusAtAgentEndPending = false;
-		runtime.userSelectedFocus = true;
 		runtime.autoContinueFocusName = undefined;
 		if (selected === BASE_FOCUS) {
+			runtime.userSelectedFocus = false;
 			focus.leave(ctx);
 			runtime.focusReminderPending = true;
 			return;
 		}
+		runtime.userSelectedFocus = true;
 		focus.enter(ctx, selected);
 		runtime.focusReminderPending = true;
 	};
@@ -55,9 +56,9 @@ const toggleFocusSelector =
 	(focus: FocusController, runtime: FocusRuntime) =>
 	async (ctx: ExtensionContext): Promise<void> => {
 		runtime.resetFocusAtAgentEndPending = false;
-		runtime.userSelectedFocus = true;
 		runtime.autoContinueFocusName = undefined;
 		if (focus.current !== BASE_FOCUS) {
+			runtime.userSelectedFocus = false;
 			focus.leave(ctx);
 			runtime.focusReminderPending = true;
 			return;

--- a/files/pi/agent/extensions/user/features/focus.ts
+++ b/files/pi/agent/extensions/user/features/focus.ts
@@ -40,6 +40,7 @@ const openFocusQuickAction =
 		);
 		if (!selected) return;
 		runtime.resetFocusAtAgentEndPending = false;
+		runtime.userSelectedFocus = true;
 		runtime.autoContinueFocusName = undefined;
 		if (selected === BASE_FOCUS) {
 			focus.leave(ctx);
@@ -54,6 +55,7 @@ const toggleFocusSelector =
 	(focus: FocusController, runtime: FocusRuntime) =>
 	async (ctx: ExtensionContext): Promise<void> => {
 		runtime.resetFocusAtAgentEndPending = false;
+		runtime.userSelectedFocus = true;
 		runtime.autoContinueFocusName = undefined;
 		if (focus.current !== BASE_FOCUS) {
 			focus.leave(ctx);

--- a/files/pi/agent/extensions/user/lib/focus/prompt.ts
+++ b/files/pi/agent/extensions/user/lib/focus/prompt.ts
@@ -6,7 +6,11 @@ import type {
 	ExtensionHandler,
 } from "@earendil-works/pi-coding-agent";
 import { type FocusController, buildFocusRestorePrompt } from "./controller";
-import { FOCUS_REMINDER_TYPE } from "./definitions";
+import {
+	ENTER_FOCUS_TOOL,
+	EXIT_FOCUS_TOOL,
+	FOCUS_REMINDER_TYPE,
+} from "./definitions";
 import type { FocusRuntime } from "./runtime";
 
 type ContextResult = { messages?: ContextEvent["messages"] };
@@ -82,13 +86,31 @@ function removeSkillsSection(prompt: string): string {
 	);
 }
 
+function focusManagementToolNames(): ReadonlySet<string> {
+	return new Set([ENTER_FOCUS_TOOL, EXIT_FOCUS_TOOL]);
+}
+
+function visiblePromptToolNames(
+	pi: ExtensionAPI,
+	focus: FocusController,
+	runtime: FocusRuntime,
+): ReadonlySet<string> {
+	const allowedToolNames = focus.allowedToolNames(pi);
+	if (!runtime.userSelectedFocus) return allowedToolNames;
+	const managementTools = focusManagementToolNames();
+	return new Set(
+		[...allowedToolNames].filter((name) => !managementTools.has(name)),
+	);
+}
+
 function rewriteSystemPromptForVisibleTools(
 	pi: ExtensionAPI,
 	focus: FocusController,
+	runtime: FocusRuntime,
 	systemPrompt: string,
 	toolSnippets: Record<string, string> | undefined,
 ): string {
-	const allowedToolNames = focus.allowedToolNames(pi);
+	const allowedToolNames = visiblePromptToolNames(pi, focus, runtime);
 	let prompt = rewritePromptSection(
 		systemPrompt,
 		"Available tools:\n",
@@ -107,8 +129,9 @@ function rewriteSystemPromptForVisibleTools(
 function visibleToolDefinitions(
 	pi: ExtensionAPI,
 	focus: FocusController,
+	runtime: FocusRuntime,
 ): ToolInfo[] {
-	const allowedToolNames = focus.allowedToolNames(pi);
+	const allowedToolNames = visiblePromptToolNames(pi, focus, runtime);
 	return pi.getAllTools().filter((tool) => allowedToolNames.has(tool.name));
 }
 
@@ -133,8 +156,9 @@ function buildActiveFocusPrompt(focus: FocusController): string | undefined {
 function buildFocusReminderPayloadWithTools(
 	pi: ExtensionAPI,
 	focus: FocusController,
+	runtime: FocusRuntime,
 ): FocusReminderWithTools {
-	const tools = visibleToolDefinitions(pi, focus);
+	const tools = visibleToolDefinitions(pi, focus, runtime);
 	const activePrompt = buildActiveFocusPrompt(focus);
 	const focusInstructions = activePrompt
 		? `Focus instructions:\n${activePrompt}`
@@ -157,6 +181,7 @@ export const injectFocusRestorePrompt =
 		const systemPrompt = rewriteSystemPromptForVisibleTools(
 			pi,
 			focus,
+			runtime,
 			event.systemPrompt,
 			event.systemPromptOptions.toolSnippets,
 		);
@@ -188,7 +213,7 @@ export const injectFocusReminder =
 	async (event) => {
 		if (!runtime.focusReminderPending) return;
 		runtime.focusReminderPending = false;
-		const reminder = buildFocusReminderPayloadWithTools(pi, focus);
+		const reminder = buildFocusReminderPayloadWithTools(pi, focus, runtime);
 		return {
 			messages: [
 				...event.messages,

--- a/files/pi/agent/extensions/user/lib/focus/runtime.ts
+++ b/files/pi/agent/extensions/user/lib/focus/runtime.ts
@@ -2,6 +2,7 @@ export type FocusRuntime = {
 	restorePromptPending: boolean;
 	focusReminderPending: boolean;
 	resetFocusAtAgentEndPending: boolean;
+	userSelectedFocus: boolean;
 	autoContinueFocusName?: string;
 };
 
@@ -10,5 +11,6 @@ export function createFocusRuntime(): FocusRuntime {
 		restorePromptPending: false,
 		focusReminderPending: false,
 		resetFocusAtAgentEndPending: false,
+		userSelectedFocus: false,
 	};
 }

--- a/files/pi/agent/extensions/user/lib/focus/tool.ts
+++ b/files/pi/agent/extensions/user/lib/focus/tool.ts
@@ -234,6 +234,7 @@ export function registerEnterFocusTool(
 
 			runtime.resetFocusAtAgentEndPending =
 				getFocusExitMode(definition) === "single-turn";
+			runtime.userSelectedFocus = false;
 			const entered = focus.enter(ctx, definition.name);
 			runtime.autoContinueFocusName = entered.name;
 			runtime.focusReminderPending = true;
@@ -398,6 +399,7 @@ export function registerExitFocusTool(
 			runtime.restorePromptPending = false;
 			runtime.focusReminderPending = true;
 			runtime.resetFocusAtAgentEndPending = false;
+			runtime.userSelectedFocus = false;
 			runtime.autoContinueFocusName = BASE_FOCUS;
 			return {
 				content: [


### PR DESCRIPTION

## Summary

- Track when the user selects a focus via the focus quick action or shortcut.
- Hide focus management tool descriptions from prompt/tool-definition reminders for user-selected focuses.
- Keep normal focus tool prompts available for agent-driven focus transitions.
