### PR TITLE
Use stable tsc for TypeScript checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -135,8 +135,8 @@ jobs:
           restore-prefixes-first-match: nix-oxlint-${{ runner.os }}-
       - run: nix build .#checks.x86_64-linux.oxlint
 
-  tsgo:
-    name: tsgo
+  tsc:
+    name: tsc
     runs-on: ubuntu-latest
     needs:
       - changes
@@ -151,7 +151,7 @@ jobs:
           node-version: lts/*
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm exec tsgo --noEmit
+      - run: pnpm lint
 
   actionlint:
     name: actionlint
@@ -203,7 +203,7 @@ jobs:
       - deadnix
       - statix
       - oxlint
-      - tsgo
+      - tsc
       - actionlint
       - zizmor
     if: ${{ always() }}

--- a/.pi/settings.user.json
+++ b/.pi/settings.user.json
@@ -9,7 +9,7 @@
       ],
       "commands": [
         {
-          "label": "tsgo",
+          "label": "tsc",
           "command": "pnpm",
           "arguments": [
             "lint"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "lint": "tsgo --noEmit"
+    "lint": "tsc --noEmit"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.9.2",
-    "@typescript/native-preview": "7.0.0-dev.20260614.1"
+    "typescript": "^6.0.3"
   },
   "packageManager": "pnpm@11.6.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,9 +24,9 @@ importers:
       '@types/node':
         specifier: ^25.9.2
         version: 25.9.3
-      '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260614.1
-        version: 7.0.0-dev.20260614.1
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
 packages:
 
@@ -321,53 +321,6 @@ packages:
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-2JHbdJ00FKTKDR1+NL4zhQBDlFZfZHEXaAarV6kbEjV0P47qKnSrAzzKHuponG0B9FqkPEMHOgu7WGJTBW2rHw==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-/8enyEb1tDsVvUp4rDeA5DernrvWgD6cQ4rY6O6PH6BQK8fqwY+CcHEHmw2xgwfqoswHNYjznLvmQmHBOjHqLw==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-jqhqAXqyEUxJpno/wRfWGa72R3VTt7p2LRTOFJ0C1bx5dEKrVosQSOdr2m9+2VhjXFXNvorXsGZPIWqxLOo28Q==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-zYrUKq5oC6fUoHpOmT3B65hFMhbdIlLp7T9RW1/6a+wSYoq9xTRAeFufQ2XZ9cpTJ1tfIvlUmtgJJ5CGE/cOrg==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm]
-    os: [linux]
-
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-K2c/DN7Q3a6Z+KIl7bq45xByuuGjacqWO/UPCa/iTBA/m6GDzoMJ/Q/DBLtLRHyROBRiy5kjgEZfyLy3Tp8ygw==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [linux]
-
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-C+C25Grr4sCbQIYPT5WfKYIL613ZIN9aGcUwDGMSTmIQ3azIR5MtdkSF4l4vsOC4lF8HwFV83MDa28JuQYhQFg==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-nJBR61NGiCMBJOpdzJ4ZgA/HEd+fqIb99ur39UljSH9xvFKFlRwDosyAQFD8UEwrZsUbXN0VPLJY5MDknug3GA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [win32]
-
-  '@typescript/native-preview@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-4N1ZBHJUcsjKJQnUCxKUemV3jnm0PKZIZ4xh7dXN/3/AfmckE8Z1llyqOFfDwGOf8oQpdgkwQ6JUm7pqI3bGPg==}
-    engines: {node: '>=16.20.0'}
-    hasBin: true
-
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -613,6 +566,11 @@ packages:
 
   typebox@1.2.9:
     resolution: {integrity: sha512-lsZLOj4acd0WSuwUqF7CTvvgkCZphs5+qbzFwxcccmeBiUMBIhytf6WQORmj90qQk1N9tlRax7BMIMy1POFZAA==}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
@@ -1108,37 +1066,6 @@ snapshots:
 
   '@types/retry@0.12.0': {}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260614.1':
-    optional: true
-
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260614.1':
-    optional: true
-
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260614.1':
-    optional: true
-
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260614.1':
-    optional: true
-
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260614.1':
-    optional: true
-
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260614.1':
-    optional: true
-
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260614.1':
-    optional: true
-
-  '@typescript/native-preview@7.0.0-dev.20260614.1':
-    optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260614.1
-
   agent-base@7.1.4: {}
 
   anynum@1.0.0: {}
@@ -1373,6 +1300,8 @@ snapshots:
   typebox@1.1.38: {}
 
   typebox@1.2.9: {}
+
+  typescript@6.0.3: {}
 
   undici-types@7.24.6: {}
 


### PR DESCRIPTION

## Summary

- Replace the TypeScript lint command from tsgo to stable tsc.
- Swap @typescript/native-preview for the standard typescript package.
- Update CI and Pi project lint settings to use the tsc-based lint command.

## Background

The native preview compiler is not required here, so this keeps local and CI
TypeScript checks on the stable compiler path.
