### PR TITLE
Remove interview skill

### DIFF
--- a/files/agent-skills/interview-me/SKILL.md
+++ b/files/agent-skills/interview-me/SKILL.md
@@ -1,8 +1,0 @@
----
-name: interview-me
-description: Structured clarification to make requirements complete before proceeding.
----
-
-- Ask one necessary question at a time, in the user's language, to complete the requirements.
-- Do not ask what is already answered or discoverable from the codebase or context; treat prior answers as binding unless they conflict or are incomplete.
-- While requirements are unclear or incomplete, keep asking and do not proceed.

--- a/modules/recipes/agent-skills.nix
+++ b/modules/recipes/agent-skills.nix
@@ -8,7 +8,6 @@
     ];
 
     skills = {
-      interview-me.enable = true;
       pi-agent-user-settings = {
         enable = true;
         agents.pi = true;


### PR DESCRIPTION
## Summary

- Remove the interview-me agent skill from the managed skill files.
- Stop enabling the interview skill in the agent-skills recipe.

## Background

Pi now provides an interview focus, so this standalone interview-me skill is no longer needed in the dotfiles-managed agent skills.