### PR TITLE
Allow explicit exit mode for project focuses

### DIFF
--- a/files/agent-skills/pi-agent-user-settings/SKILL.md
+++ b/files/agent-skills/pi-agent-user-settings/SKILL.md
@@ -121,8 +121,9 @@ Currently supported project user settings include:
 - When extending an existing focus, write `prompt` as a project-specific supplement, not a full replacement such as `You are in ... focus`.
 - `tools` is additive only.
 - `toolSets` is additive only and expands reusable `toolSets.<name>` entries into the focus tool list.
-- Existing focus `transition` cannot be changed by project settings.
+- Existing focus `transition` and `exitMode` cannot be changed by project settings.
 - New focus `transition` defaults to `confirm` when omitted.
+- New focus `exitMode` defaults to `single-turn` when omitted.
 
 Common focus fields:
 
@@ -131,6 +132,7 @@ Common focus fields:
 - `tools` required for new focuses unless `toolSets` supplies at least one tool; additive when merging. It may include project tool names, built-in tool names, and extension tool names.
 - `toolSets` optional; array of top-level `toolSets` names to add to the focus tool list.
 - `transition` optional for new focuses: `auto`, `confirm`, or `manual`.
+- `exitMode` optional for new focuses: `single-turn` or `explicit`.
 - `color` optional: `accent`, `positive`, `caution`, `alert`, or `muted`.
 
 ## Parameter fields

--- a/files/pi/agent/extensions/user/lib/focus/registry.ts
+++ b/files/pi/agent/extensions/user/lib/focus/registry.ts
@@ -9,6 +9,7 @@ import {
 	BASE_FOCUS_DEFINITIONS,
 	BUILT_IN_TOOL_SETS,
 	type FocusDefinition,
+	type FocusExitMode,
 	type FocusName,
 	type FocusTransition,
 	isFocusTransition,
@@ -45,6 +46,7 @@ type ProjectFocusDefinition = {
 	readonly tools?: readonly string[];
 	readonly toolSets?: readonly string[];
 	readonly transition?: FocusTransition;
+	readonly exitMode?: FocusExitMode;
 	readonly color?: ColorRole;
 };
 
@@ -94,6 +96,17 @@ function normalizeTransition(
 	return value;
 }
 
+function normalizeExitMode(
+	value: unknown,
+	path: string,
+): FocusExitMode | undefined {
+	if (value === undefined) return undefined;
+	if (value !== "single-turn" && value !== "explicit") {
+		throw new Error(`${path} must be single-turn or explicit.`);
+	}
+	return value;
+}
+
 function normalizeColor(value: unknown, path: string): ColorRole | undefined {
 	if (value === undefined) return undefined;
 	if (!isColorRole(value)) {
@@ -127,6 +140,7 @@ function normalizeProjectFocus(
 		tools: normalizeTools(value.tools, `${name}.tools`),
 		toolSets: normalizeTools(value.toolSets, `${name}.toolSets`),
 		transition: normalizeTransition(value.transition, `${name}.transition`),
+		exitMode: normalizeExitMode(value.exitMode, `${name}.exitMode`),
 		color: normalizeColor(value.color, `${name}.color`),
 	};
 }
@@ -243,7 +257,7 @@ function mergeFocus(
 			: base.exitPrompt,
 		tools: unique([...(base.tools ?? []), ...projectTools]),
 		settingsTools: unique([...(base.settingsTools ?? []), ...projectTools]),
-		// Existing focus transitions are security-sensitive and cannot be changed by project config.
+		// Existing focus transitions and exit modes are security-sensitive and cannot be changed by project config.
 		transition: base.transition,
 		color: project.color ?? base.color,
 	};
@@ -272,6 +286,7 @@ function createProjectFocus(
 		tools: unique(projectTools),
 		settingsTools: unique(projectTools),
 		transition: project.transition ?? "confirm",
+		exitMode: project.exitMode,
 		color: project.color,
 	};
 }


### PR DESCRIPTION

## Summary

- allow project-defined focuses to opt into `exitMode: "explicit"`
- keep `exitMode` immutable when project settings extend existing built-in focuses
- document the new project focus setting and its default behavior

## Background

Project-local focuses could already configure transition behavior, but could not keep a focus active until an explicit exit. This adds that option for newly created project focuses while preserving the security boundary for built-in focus definitions.
