### PR TITLE
Tighten oxlint rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -11,7 +11,7 @@
   "categories": {
     "correctness": "error",
     "suspicious": "error",
-    "perf": "warn"
+    "perf": "error"
   },
   "rules": {
     "typescript/no-explicit-any": "error",
@@ -25,10 +25,21 @@
       }
     ],
     "eslint/require-unicode-regexp": "warn",
+    "no-unused-vars": [
+      "error",
+      {
+        "args": "all",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "caughtErrorsIgnorePattern": "^_",
+        "vars": "all",
+        "varsIgnorePattern": "^_"
+      }
+    ],
     "no-duplicate-imports": ["error", { "allowSeparateTypeImports": true }],
     "import/no-cycle": "error",
     "import/extensions": ["error", "never"],
-    "sort-imports": ["warn", { "ignoreDeclarationSort": true }]
+    "sort-imports": ["error", { "ignoreDeclarationSort": true }]
   },
   "env": {
     "builtin": true

--- a/files/pi/agent/extensions/user/lib/tool/interview.ts
+++ b/files/pi/agent/extensions/user/lib/tool/interview.ts
@@ -260,7 +260,6 @@ function sortedChoices(
 }
 
 function otherDescription(
-	text: QuestionLabels,
 	multiple: boolean,
 	otherText: string | undefined,
 ): string {
@@ -295,7 +294,7 @@ function makeRows(
 		{
 			action: { type: "other" },
 			label: text.other,
-			description: otherDescription(text, multiple, otherText),
+			description: otherDescription(multiple, otherText),
 			selected: otherSelected,
 			section: "choice",
 		},
@@ -507,7 +506,6 @@ async function showQuestion(
 async function showOtherInput(
 	ctx: ExtensionContext,
 	params: AskUserQuestionInput,
-	text: QuestionLabels,
 	initialValue: string | undefined,
 ): Promise<string | undefined> {
 	const title = [
@@ -554,7 +552,7 @@ async function askSingle(
 		}
 		if (action.type === "other" || action.type === "other-input") {
 			// oxlint-disable-next-line no-await-in-loop -- Other input is part of the current question flow.
-			const otherText = await showOtherInput(ctx, params, text, undefined);
+			const otherText = await showOtherInput(ctx, params, undefined);
 			if (otherText === undefined || !otherText.trim()) continue;
 			return answeredResult({
 				status: "answered",
@@ -640,7 +638,7 @@ async function askMultiple(
 		}
 		if (action.type === "other-input") {
 			// oxlint-disable-next-line no-await-in-loop -- Other input is part of the current selection loop state.
-			const input = await showOtherInput(ctx, params, text, otherText);
+			const input = await showOtherInput(ctx, params, otherText);
 			if (input !== undefined) {
 				otherText = input.trim() || undefined;
 				otherSelected = Boolean(otherText);


### PR DESCRIPTION

## Summary

- promote oxlint perf checks and import sorting from warnings to errors
- add unused variable enforcement with underscore escape hatches
- remove unused interview tool parameters exposed by the stricter rules
