### PR TITLE
Fix stale focus reminder handling

### DIFF
--- a/files/pi/agent/extensions/user/features/focus.ts
+++ b/files/pi/agent/extensions/user/features/focus.ts
@@ -40,39 +40,39 @@ const openFocusQuickAction =
 			focus.current,
 		);
 		if (!selected) return;
-		runtime.resetFocusAtAgentEndPending = false;
-		runtime.autoContinueFocusName = undefined;
+		runtime.setResetFocusAtAgentEndPending(false);
+		runtime.cancelAutoContinue();
 		if (selected === BASE_FOCUS) {
-			runtime.userSelectedFocus = false;
+			runtime.setUserSelectedFocus(false);
 			focus.leave(ctx);
-			runtime.focusReminderPending = true;
+			runtime.recordFocusChange(BASE_FOCUS);
 			return;
 		}
-		runtime.userSelectedFocus = true;
+		runtime.setUserSelectedFocus(true);
 		focus.enter(ctx, selected);
-		runtime.focusReminderPending = true;
+		runtime.recordFocusChange(selected);
 	};
 
 const toggleFocusSelector =
 	(focus: FocusController, runtime: FocusRuntime) =>
 	async (ctx: ExtensionContext): Promise<void> => {
-		runtime.resetFocusAtAgentEndPending = false;
-		runtime.autoContinueFocusName = undefined;
+		runtime.setResetFocusAtAgentEndPending(false);
+		runtime.cancelAutoContinue();
 		if (focus.current !== BASE_FOCUS) {
-			runtime.userSelectedFocus = false;
+			runtime.setUserSelectedFocus(false);
 			focus.leave(ctx);
-			runtime.focusReminderPending = true;
+			runtime.recordFocusChange(BASE_FOCUS);
 			return;
 		}
 		await openFocusQuickAction(focus, runtime)(ctx);
 	};
 
 function register(pi: ExtensionAPI, services: UserExtensionServices): void {
-	registerBuiltInFocusPolicies();
+	registerBuiltInFocusPolicies(services.tools);
 	const focus = createFocusController(pi, services.focus);
 	const runtime = createFocusRuntime();
-	registerEnterFocusTool(focus, runtime);
-	registerExitFocusTool(focus, runtime);
+	registerEnterFocusTool(focus, runtime, services.tools);
+	registerExitFocusTool(focus, runtime, services.tools);
 	registerQuickActionHandler("focus", openFocusQuickAction(focus, runtime));
 	pi.registerShortcut("shift+tab", {
 		description: "Leave focus or open focus selector",
@@ -86,7 +86,7 @@ function register(pi: ExtensionAPI, services: UserExtensionServices): void {
 	pi.on("session_start", restoreFocus(focus, runtime));
 	pi.on("agent_end", resetFocusAtAgentEnd(focus, runtime));
 	pi.on("agent_end", autoContinueAfterFocusTransition(pi, focus, runtime));
-	pi.on("tool_call", guardToolCall(pi, focus));
+	pi.on("tool_call", guardToolCall(pi, focus, services.tools));
 }
 
 export function createFocusFeature(): Feature {

--- a/files/pi/agent/extensions/user/features/tool.ts
+++ b/files/pi/agent/extensions/user/features/tool.ts
@@ -159,7 +159,7 @@ function projectToolGroups(
 }
 
 function register(pi: ExtensionAPI, services: UserExtensionServices): void {
-	registerCoreUserTools();
+	registerCoreUserTools(services.tools);
 
 	for (const { definition } of services.tools.list()) {
 		pi.registerTool(definition);
@@ -167,7 +167,7 @@ function register(pi: ExtensionAPI, services: UserExtensionServices): void {
 
 	pi.on("session_start", async (_event: SessionStartEvent, ctx) => {
 		await ensureProjectUserSettingsTrusted(ctx);
-		const projectTools = registerProjectTools(pi, ctx);
+		const projectTools = registerProjectTools(pi, ctx, services.tools);
 		activateFocusTools(pi, services.focus.activeFocusDefinition);
 		if (ctx.hasUI) {
 			setTimeout(() => {

--- a/files/pi/agent/extensions/user/lib/focus/definitions.ts
+++ b/files/pi/agent/extensions/user/lib/focus/definitions.ts
@@ -51,7 +51,7 @@ export const BASE_FOCUS_DEFINITIONS: readonly FocusDefinition[] = [
 		description:
 			"Use when the user asks for repository file changes, or after investigation establishes that file changes are needed.",
 		prompt:
-			"You are in edit focus. Make focused file changes with read/write/edit/mv/rm. Keep changes minimal.",
+			"You are in edit focus. Make focused file changes with read/write/edit/mv/rm. Keep changes minimal. Once you have enough exact context for a change, use edit/write instead of rereading the same file repeatedly.",
 		tools: [],
 		toolSets: ["file_read", "file_write"],
 		transition: "confirm",

--- a/files/pi/agent/extensions/user/lib/focus/definitions.ts
+++ b/files/pi/agent/extensions/user/lib/focus/definitions.ts
@@ -51,7 +51,7 @@ export const BASE_FOCUS_DEFINITIONS: readonly FocusDefinition[] = [
 		description:
 			"Use when the user asks for repository file changes, or after investigation establishes that file changes are needed.",
 		prompt:
-			"You are in edit focus. Make focused file changes with read/write/edit/mv/rm. Keep changes minimal. Once you have enough exact context for a change, use edit/write instead of rereading the same file repeatedly.",
+			"You are in edit focus. Make focused file changes with read/write/edit/mv/rm. Keep changes minimal.",
 		tools: [],
 		toolSets: ["file_read", "file_write"],
 		transition: "confirm",

--- a/files/pi/agent/extensions/user/lib/focus/guard.ts
+++ b/files/pi/agent/extensions/user/lib/focus/guard.ts
@@ -4,7 +4,7 @@ import type {
 	ToolCallEvent,
 	ToolCallEventResult,
 } from "@earendil-works/pi-coding-agent";
-import { toolCatalog } from "../tool";
+import type { ToolCatalog } from "../tool";
 import type { FocusController } from "./controller";
 
 type BlockedToolCall = { block: true; reason: string };
@@ -17,15 +17,16 @@ export const guardToolCall =
 	(
 		pi: ExtensionAPI,
 		focus: FocusController,
+		catalog: ToolCatalog,
 	): ExtensionHandler<ToolCallEvent, ToolCallEventResult> =>
 	async (event) => {
-		const notAllowed = toolCatalog.checkToolAllowed(
+		const notAllowed = catalog.checkToolAllowed(
 			focus.current,
 			focus.allowedToolNames(pi),
 			event,
 		);
 		if (notAllowed) return block(notAllowed);
 
-		const secret = toolCatalog.checkSecretBlock(focus.current, event);
+		const secret = catalog.checkSecretBlock(focus.current, event);
 		if (secret) return block(secret);
 	};

--- a/files/pi/agent/extensions/user/lib/focus/policies.ts
+++ b/files/pi/agent/extensions/user/lib/focus/policies.ts
@@ -7,34 +7,34 @@ import type {
 	WriteToolInput,
 } from "@earendil-works/pi-coding-agent";
 import { makeSecretActionReason } from "../policy";
-import { toolCatalog } from "../tool";
+import type { ToolCatalog } from "../tool";
 
-export function registerBuiltInFocusPolicies(): void {
-	toolCatalog.registerPolicy({
+export function registerBuiltInFocusPolicies(catalog: ToolCatalog): void {
+	catalog.registerPolicy({
 		name: "bash",
 		notAllowedReason: (focus) =>
 			`Running bash commands is disabled in ${focus} focus.`,
 	});
-	toolCatalog.registerPolicy<ReadToolInput>({
+	catalog.registerPolicy<ReadToolInput>({
 		name: "read",
 		extractSecretPaths: (input) => [input.path],
 		secretBlockReason: makeSecretActionReason("Reading"),
 	});
-	toolCatalog.registerPolicy<WriteToolInput>({
+	catalog.registerPolicy<WriteToolInput>({
 		name: "write",
 		extractSecretPaths: (input) => [input.path],
 		secretBlockReason: makeSecretActionReason("Writing to"),
 	});
-	toolCatalog.registerPolicy<EditToolInput>({
+	catalog.registerPolicy<EditToolInput>({
 		name: "edit",
 		extractSecretPaths: (input) => [input.path],
 		secretBlockReason: makeSecretActionReason("Writing to"),
 	});
-	toolCatalog.registerPolicy<GrepToolInput>({
+	catalog.registerPolicy<GrepToolInput>({
 		name: "grep",
 		extractSecretPaths: (input) => (input.path ? [input.path] : []),
 		secretBlockReason: makeSecretActionReason("Grepping"),
 	});
-	toolCatalog.registerPolicy<FindToolInput>({ name: "find" });
-	toolCatalog.registerPolicy<LsToolInput>({ name: "ls" });
+	catalog.registerPolicy<FindToolInput>({ name: "find" });
+	catalog.registerPolicy<LsToolInput>({ name: "ls" });
 }

--- a/files/pi/agent/extensions/user/lib/focus/prompt.ts
+++ b/files/pi/agent/extensions/user/lib/focus/prompt.ts
@@ -23,7 +23,7 @@ type FocusReminderWithTools = {
 	customType: typeof FOCUS_REMINDER_TYPE;
 	content: string;
 	display: false;
-	details: { focus: string };
+	details: { focus: string; transitionId: number };
 };
 
 function formatFocusList(
@@ -157,6 +157,27 @@ function buildActiveFocusPrompt(focus: FocusController): string | undefined {
 		: undefined;
 }
 
+function buildStaleFocusReminderPayload(
+	focus: FocusController,
+	runtime: FocusRuntime,
+): FocusReminderWithTools {
+	return {
+		customType: FOCUS_REMINDER_TYPE,
+		content: [
+			"<system-reminder>",
+			"An obsolete focus-transition wakeup was removed.",
+			"Do not call tools or continue previous work solely because of that obsolete wakeup.",
+			"If the latest user message contains a separate request, answer that request under the current focus; otherwise respond briefly that there is no pending action.",
+			"</system-reminder>",
+		].join("\n"),
+		display: false,
+		details: {
+			focus: focus.current,
+			transitionId: runtime.latestTransition.id,
+		},
+	};
+}
+
 function buildFocusReminderPayloadWithTools(
 	pi: ExtensionAPI,
 	focus: FocusController,
@@ -171,7 +192,10 @@ function buildFocusReminderPayloadWithTools(
 		customType: FOCUS_REMINDER_TYPE,
 		content: `<system-reminder>\nCurrent focus: ${focus.current}. Follow the focus instructions.\n\n${focusInstructions}\n\nAvailable tool definitions:\n\`\`\`json\n${formatToolDefinitions(tools)}\n\`\`\`\n</system-reminder>`,
 		display: false,
-		details: { focus: focus.current },
+		details: {
+			focus: focus.current,
+			transitionId: runtime.latestTransition.id,
+		},
 	};
 }
 
@@ -195,7 +219,7 @@ export const injectFocusRestorePrompt =
 			};
 		}
 		if (runtime.restorePromptPending) {
-			runtime.restorePromptPending = false;
+			runtime.setRestorePromptPending(false);
 			return {
 				systemPrompt: `${systemPrompt}\n\n${buildFocusRestorePrompt(focus.active)}`,
 			};
@@ -208,6 +232,17 @@ export const injectFocusRestorePrompt =
 				: { systemPrompt };
 	};
 
+function transitionIdFromMessage(message: unknown): number | undefined {
+	if (typeof message !== "object" || message === null) return undefined;
+	if (!("details" in message)) return undefined;
+	const details = message.details;
+	if (typeof details !== "object" || details === null) return undefined;
+	if (!("transitionId" in details)) return undefined;
+	return typeof details.transitionId === "number"
+		? details.transitionId
+		: undefined;
+}
+
 export const injectFocusReminder =
 	(
 		pi: ExtensionAPI,
@@ -215,17 +250,34 @@ export const injectFocusReminder =
 		runtime: FocusRuntime,
 	): ExtensionHandler<ContextEvent, ContextResult> =>
 	async (event) => {
+		const focusReminderMessages = event.messages.filter(isFocusReminderMessage);
 		const messagesWithoutFocusReminders = event.messages.filter(
 			(message) => !isFocusReminderMessage(message),
 		);
-		const removedStoredReminder =
-			messagesWithoutFocusReminders.length !== event.messages.length;
-		if (!runtime.focusReminderPending && !removedStoredReminder) return;
+		const removedStoredReminder = focusReminderMessages.length > 0;
+		const hasCurrentStoredReminder = focusReminderMessages.some((message) =>
+			runtime.isCurrentTransition(transitionIdFromMessage(message)),
+		);
+		const shouldInjectReminder =
+			runtime.consumeFocusReminderPending() || hasCurrentStoredReminder;
+		if (!shouldInjectReminder) {
+			if (!removedStoredReminder) return undefined;
+			const staleReminder = buildStaleFocusReminderPayload(focus, runtime);
+			return {
+				messages: [
+					...messagesWithoutFocusReminders,
+					{
+						role: "custom",
+						...staleReminder,
+						timestamp: Date.now(),
+					},
+				],
+			};
+		}
 
 		// Stored focus reminders can be delivered after a later focus transition.
-		// Treat them as triggers only and regenerate the actual reminder from the
-		// current runtime state so the model never sees stale focus/tool guidance.
-		runtime.focusReminderPending = false;
+		// Treat current reminders as triggers only and regenerate the actual reminder
+		// from runtime state so the model never sees stale focus/tool guidance.
 		const reminder = buildFocusReminderPayloadWithTools(pi, focus, runtime);
 		return {
 			messages: [

--- a/files/pi/agent/extensions/user/lib/focus/runtime.ts
+++ b/files/pi/agent/extensions/user/lib/focus/runtime.ts
@@ -46,7 +46,7 @@ export function createFocusRuntime(): FocusRuntime {
 	let latestTransition: FocusAutoContinue = { id: 0, focusName: BASE_FOCUS };
 	let pendingAutoContinue: FocusAutoContinue | undefined;
 
-	const recordFocusChange = (
+	const bumpTransition = (
 		focusName: FocusName | typeof BASE_FOCUS,
 	): FocusAutoContinue => {
 		latestTransition = { id: nextTransitionId++, focusName };
@@ -93,12 +93,12 @@ export function createFocusRuntime(): FocusRuntime {
 			userSelectedFocus = selected;
 		},
 		recordFocusChange(focusName) {
-			const transition = recordFocusChange(focusName);
+			const transition = bumpTransition(focusName);
 			focusReminderPending = true;
 			return transition;
 		},
 		scheduleAutoContinue(focusName) {
-			const transition = recordFocusChange(focusName);
+			const transition = bumpTransition(focusName);
 			pendingAutoContinue = transition;
 			focusReminderPending = true;
 			return transition;

--- a/files/pi/agent/extensions/user/lib/focus/runtime.ts
+++ b/files/pi/agent/extensions/user/lib/focus/runtime.ts
@@ -1,16 +1,118 @@
+import { BASE_FOCUS, type FocusName } from "./definitions";
+
+/**
+ * In-memory focus lifecycle state for the current extension instance.
+ *
+ * Keep mutations behind these methods so future focus/tool features cannot leave
+ * stale auto-continue wakeups or reminder flags behind by setting fields out of
+ * order. Every focus change gets a monotonically increasing transition id; queued
+ * reminders carry that id and are ignored if a newer focus change wins the race.
+ */
+export type FocusAutoContinue = {
+	readonly id: number;
+	readonly focusName: FocusName | typeof BASE_FOCUS;
+};
+
 export type FocusRuntime = {
-	restorePromptPending: boolean;
-	focusReminderPending: boolean;
-	resetFocusAtAgentEndPending: boolean;
-	userSelectedFocus: boolean;
-	autoContinueFocusName?: string;
+	readonly restorePromptPending: boolean;
+	readonly focusReminderPending: boolean;
+	readonly resetFocusAtAgentEndPending: boolean;
+	readonly userSelectedFocus: boolean;
+	readonly latestTransition: FocusAutoContinue;
+	readonly pendingAutoContinue: FocusAutoContinue | undefined;
+	setRestorePromptPending(pending: boolean): void;
+	setFocusReminderPending(pending: boolean): void;
+	requestFocusReminder(): void;
+	consumeFocusReminderPending(): boolean;
+	setResetFocusAtAgentEndPending(pending: boolean): void;
+	setUserSelectedFocus(selected: boolean): void;
+	recordFocusChange(
+		focusName: FocusName | typeof BASE_FOCUS,
+	): FocusAutoContinue;
+	scheduleAutoContinue(
+		focusName: FocusName | typeof BASE_FOCUS,
+	): FocusAutoContinue;
+	cancelAutoContinue(): void;
+	consumeAutoContinue(): FocusAutoContinue | undefined;
+	isCurrentTransition(transitionId: number | undefined): boolean;
 };
 
 export function createFocusRuntime(): FocusRuntime {
+	let restorePromptPending = false;
+	let focusReminderPending = false;
+	let resetFocusAtAgentEndPending = false;
+	let userSelectedFocus = false;
+	let nextTransitionId = 1;
+	let latestTransition: FocusAutoContinue = { id: 0, focusName: BASE_FOCUS };
+	let pendingAutoContinue: FocusAutoContinue | undefined;
+
+	const recordFocusChange = (
+		focusName: FocusName | typeof BASE_FOCUS,
+	): FocusAutoContinue => {
+		latestTransition = { id: nextTransitionId++, focusName };
+		return latestTransition;
+	};
+
 	return {
-		restorePromptPending: false,
-		focusReminderPending: false,
-		resetFocusAtAgentEndPending: false,
-		userSelectedFocus: false,
+		get restorePromptPending() {
+			return restorePromptPending;
+		},
+		get focusReminderPending() {
+			return focusReminderPending;
+		},
+		get resetFocusAtAgentEndPending() {
+			return resetFocusAtAgentEndPending;
+		},
+		get userSelectedFocus() {
+			return userSelectedFocus;
+		},
+		get latestTransition() {
+			return latestTransition;
+		},
+		get pendingAutoContinue() {
+			return pendingAutoContinue;
+		},
+		setRestorePromptPending(pending) {
+			restorePromptPending = pending;
+		},
+		setFocusReminderPending(pending) {
+			focusReminderPending = pending;
+		},
+		requestFocusReminder() {
+			focusReminderPending = true;
+		},
+		consumeFocusReminderPending() {
+			const pending = focusReminderPending;
+			focusReminderPending = false;
+			return pending;
+		},
+		setResetFocusAtAgentEndPending(pending) {
+			resetFocusAtAgentEndPending = pending;
+		},
+		setUserSelectedFocus(selected) {
+			userSelectedFocus = selected;
+		},
+		recordFocusChange(focusName) {
+			const transition = recordFocusChange(focusName);
+			focusReminderPending = true;
+			return transition;
+		},
+		scheduleAutoContinue(focusName) {
+			const transition = recordFocusChange(focusName);
+			pendingAutoContinue = transition;
+			focusReminderPending = true;
+			return transition;
+		},
+		cancelAutoContinue() {
+			pendingAutoContinue = undefined;
+		},
+		consumeAutoContinue() {
+			const transition = pendingAutoContinue;
+			pendingAutoContinue = undefined;
+			return transition;
+		},
+		isCurrentTransition(transitionId) {
+			return transitionId === undefined || transitionId === latestTransition.id;
+		},
 	};
 }

--- a/files/pi/agent/extensions/user/lib/focus/session.ts
+++ b/files/pi/agent/extensions/user/lib/focus/session.ts
@@ -39,10 +39,12 @@ export const restoreFocus =
 		focus.loadProjectFocuses(ctx);
 		const persisted = findPersistedFocus(ctx);
 		focus.restore(ctx, persisted);
-		runtime.restorePromptPending = focus.active !== undefined;
-		runtime.focusReminderPending = focus.active !== undefined;
-		runtime.resetFocusAtAgentEndPending = false;
-		runtime.autoContinueFocusName = undefined;
+		runtime.recordFocusChange(focus.current);
+		runtime.setRestorePromptPending(focus.active !== undefined);
+		runtime.setFocusReminderPending(focus.active !== undefined);
+		runtime.setResetFocusAtAgentEndPending(false);
+		runtime.setUserSelectedFocus(false);
+		runtime.cancelAutoContinue();
 	};
 
 export const resetFocusAtAgentEnd =
@@ -51,16 +53,16 @@ export const resetFocusAtAgentEnd =
 		runtime: FocusRuntime,
 	): ExtensionHandler<AgentEndEvent> =>
 	async (_event, ctx) => {
-		if (runtime.autoContinueFocusName) return;
+		if (runtime.pendingAutoContinue) return;
 		if (!focus.active || !runtime.resetFocusAtAgentEndPending) return;
 		if (getFocusExitMode(focus.active) !== "single-turn") {
-			runtime.resetFocusAtAgentEndPending = false;
+			runtime.setResetFocusAtAgentEndPending(false);
 			return;
 		}
 		focus.leave(ctx);
-		runtime.restorePromptPending = false;
-		runtime.focusReminderPending = true;
-		runtime.resetFocusAtAgentEndPending = false;
+		runtime.recordFocusChange(BASE_FOCUS);
+		runtime.setRestorePromptPending(false);
+		runtime.setResetFocusAtAgentEndPending(false);
 	};
 
 export const autoContinueAfterFocusTransition =
@@ -70,16 +72,16 @@ export const autoContinueAfterFocusTransition =
 		runtime: FocusRuntime,
 	): ExtensionHandler<AgentEndEvent> =>
 	async () => {
-		const focusName = runtime.autoContinueFocusName;
-		if (!focusName) return;
-		runtime.autoContinueFocusName = undefined;
-		if (focus.current !== focusName) return;
-		if (focusName !== BASE_FOCUS && !focus.active) return;
-		runtime.focusReminderPending = true;
-		const isBase = focusName === BASE_FOCUS;
-		// This message only wakes the agent up. Its delivery can lag behind later
-		// focus changes, so keep focus-specific guidance in the regenerated
-		// context reminder instead of embedding it here.
+		const transition = runtime.consumeAutoContinue();
+		if (!transition) return;
+		if (!runtime.isCurrentTransition(transition.id)) return;
+		if (focus.current !== transition.focusName) return;
+		if (transition.focusName !== BASE_FOCUS && !focus.active) return;
+		runtime.requestFocusReminder();
+		const isBase = transition.focusName === BASE_FOCUS;
+		// This message only wakes the agent up. Focus-specific guidance is rebuilt
+		// from current runtime state in the context hook. The transition id lets us
+		// drop older queued wakeups if a later focus change happens first.
 		pi.sendMessage(
 			{
 				customType: FOCUS_REMINDER_TYPE,
@@ -96,13 +98,14 @@ export const autoContinueAfterFocusTransition =
 				].join("\n"),
 				display: false,
 				details: {
-					queuedFocus: focusName,
+					queuedFocus: transition.focusName,
+					transitionId: transition.id,
 					reason: isBase
 						? "auto-continue-after-exit"
 						: "auto-continue-after-enter",
 				},
 			},
-			{ triggerTurn: true, deliverAs: "followUp" },
+			{ triggerTurn: true, deliverAs: "steer" },
 		);
 	};
 

--- a/files/pi/agent/extensions/user/lib/focus/tool.ts
+++ b/files/pi/agent/extensions/user/lib/focus/tool.ts
@@ -20,7 +20,7 @@ import {
 } from "./definitions";
 import type { FocusController } from "./controller";
 import type { FocusRuntime } from "./runtime";
-import { defineToolContribution, toolCatalog } from "../tool/catalog";
+import { type ToolCatalog, defineToolContribution } from "../tool/catalog";
 
 type FocusToolDetails = Record<string, unknown>;
 
@@ -75,6 +75,7 @@ function renderEnterFocusResult(
 export function registerEnterFocusTool(
 	focus: FocusController,
 	runtime: FocusRuntime,
+	catalog: ToolCatalog,
 ): void {
 	const contribution = defineToolContribution({
 		source: "focus-management",
@@ -235,12 +236,12 @@ export function registerEnterFocusTool(
 					}
 				}
 
-				runtime.resetFocusAtAgentEndPending =
-					getFocusExitMode(definition) === "single-turn";
-				runtime.userSelectedFocus = false;
+				runtime.setResetFocusAtAgentEndPending(
+					getFocusExitMode(definition) === "single-turn",
+				);
+				runtime.setUserSelectedFocus(false);
 				const entered = focus.enter(ctx, definition.name);
-				runtime.autoContinueFocusName = entered.name;
-				runtime.focusReminderPending = true;
+				runtime.scheduleAutoContinue(entered.name);
 				const action =
 					previousFocusName === BASE_FOCUS
 						? `Entered focus '${entered.name}'.`
@@ -263,7 +264,7 @@ export function registerEnterFocusTool(
 			},
 		},
 	});
-	toolCatalog.register(contribution);
+	catalog.register(contribution);
 }
 
 function renderExitFocusCall(_args: { reason: string }, theme: Theme): Text {
@@ -300,6 +301,7 @@ function isFailedFocusToolDetails(details: unknown): boolean {
 export function registerExitFocusTool(
 	focus: FocusController,
 	runtime: FocusRuntime,
+	catalog: ToolCatalog,
 ): void {
 	const contribution = defineToolContribution({
 		source: "focus-management",
@@ -398,11 +400,10 @@ export function registerExitFocusTool(
 				const exitText = previous
 					? `Exited focus '${previous.name}'.`
 					: "Exited focus.";
-				runtime.restorePromptPending = false;
-				runtime.focusReminderPending = true;
-				runtime.resetFocusAtAgentEndPending = false;
-				runtime.userSelectedFocus = false;
-				runtime.autoContinueFocusName = BASE_FOCUS;
+				runtime.setRestorePromptPending(false);
+				runtime.setResetFocusAtAgentEndPending(false);
+				runtime.setUserSelectedFocus(false);
+				runtime.scheduleAutoContinue(BASE_FOCUS);
 				return {
 					content: [
 						{
@@ -420,5 +421,5 @@ export function registerExitFocusTool(
 			},
 		},
 	});
-	toolCatalog.register(contribution);
+	catalog.register(contribution);
 }

--- a/files/pi/agent/extensions/user/lib/services.ts
+++ b/files/pi/agent/extensions/user/lib/services.ts
@@ -1,5 +1,5 @@
 import { type FocusSharedState, createFocusSharedState } from "./focus/state";
-import { type ToolCatalog, toolCatalog } from "./tool";
+import { type ToolCatalog, createToolCatalog } from "./tool";
 
 export type UserExtensionServices = {
 	readonly focus: FocusSharedState;
@@ -9,6 +9,6 @@ export type UserExtensionServices = {
 export function createUserExtensionServices(): UserExtensionServices {
 	return {
 		focus: createFocusSharedState(),
-		tools: toolCatalog,
+		tools: createToolCatalog(),
 	};
 }

--- a/files/pi/agent/extensions/user/lib/tool/builtin.ts
+++ b/files/pi/agent/extensions/user/lib/tool/builtin.ts
@@ -8,25 +8,25 @@ import {
 	rmSchema,
 } from "../file";
 import { makeSecretActionReason } from "../policy";
-import { defineToolContribution, toolCatalog } from "./catalog";
+import { type ToolCatalog, defineToolContribution } from "./catalog";
 import { registerGitTools } from "./git";
 import { registerGithubTools } from "./github";
 import { registerInterviewTools } from "./interview";
 
 /**
- * Register every core user-extension tool into {@link toolCatalog}. Grouped by
+ * Register every core user-extension tool into the provided catalog. Grouped by
  * domain so non-file tools (git, …) can be added here without touching the
  * `tool` feature.
  */
-export function registerCoreUserTools(): void {
-	registerFileTools();
-	registerGitTools();
-	registerGithubTools();
-	registerInterviewTools();
+export function registerCoreUserTools(catalog: ToolCatalog): void {
+	registerFileTools(catalog);
+	registerGitTools(catalog);
+	registerGithubTools(catalog);
+	registerInterviewTools(catalog);
 }
 
-function registerFileTools(): void {
-	toolCatalog.register(
+function registerFileTools(catalog: ToolCatalog): void {
+	catalog.register(
 		defineToolContribution({
 			policy: {
 				name: "mv",
@@ -55,7 +55,7 @@ function registerFileTools(): void {
 		}),
 	);
 
-	toolCatalog.register(
+	catalog.register(
 		defineToolContribution({
 			policy: {
 				name: "rm",

--- a/files/pi/agent/extensions/user/lib/tool/catalog.ts
+++ b/files/pi/agent/extensions/user/lib/tool/catalog.ts
@@ -57,7 +57,7 @@ export type ToolCatalog = {
 	checkSecretBlock(focusName: string, event: ToolCallEvent): string | undefined;
 };
 
-function createToolCatalog(): ToolCatalog {
+export function createToolCatalog(): ToolCatalog {
 	const tools: ToolContribution[] = [];
 	const policies = new Map<string, ToolPolicy>();
 
@@ -109,5 +109,3 @@ function createToolCatalog(): ToolCatalog {
 		},
 	};
 }
-
-export const toolCatalog: ToolCatalog = createToolCatalog();

--- a/files/pi/agent/extensions/user/lib/tool/git.ts
+++ b/files/pi/agent/extensions/user/lib/tool/git.ts
@@ -8,7 +8,7 @@ import {
 	limitToolOutput,
 	renderLimitedTextResult,
 } from "./output";
-import { defineToolContribution, toolCatalog } from "./catalog";
+import { type ToolCatalog, defineToolContribution } from "./catalog";
 
 const GIT_TIMEOUT_MS = 30_000;
 const GIT_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
@@ -328,22 +328,25 @@ function lineLimitFromInput(
 const DIFF_TRUNCATION_HINT =
 	"Narrow large diffs with paths, or use mode=patch with context=0 to locate changed lines before reading surrounding code.";
 
-function registerGitTool<TInput extends object>(config: {
-	readonly name: string;
-	readonly label: string;
-	readonly description: string;
-	readonly parameters: Parameters<
-		typeof toolCatalog.register
-	>[0]["definition"]["parameters"];
-	readonly promptSnippet: string;
-	readonly buildArgs: (params: TInput) => string[];
-	readonly allowedExitCodes?: readonly number[];
-	readonly emptyMessage?: string;
-	readonly hint?: string;
-	readonly outputFileName?: string;
-	readonly extractSecretPaths?: (input: TInput) => readonly string[];
-}): void {
-	toolCatalog.register(
+function registerGitTool<TInput extends object>(
+	catalog: ToolCatalog,
+	config: {
+		readonly name: string;
+		readonly label: string;
+		readonly description: string;
+		readonly parameters: Parameters<
+			ToolCatalog["register"]
+		>[0]["definition"]["parameters"];
+		readonly promptSnippet: string;
+		readonly buildArgs: (params: TInput) => string[];
+		readonly allowedExitCodes?: readonly number[];
+		readonly emptyMessage?: string;
+		readonly hint?: string;
+		readonly outputFileName?: string;
+		readonly extractSecretPaths?: (input: TInput) => readonly string[];
+	},
+): void {
+	catalog.register(
 		defineToolContribution({
 			policy: {
 				name: config.name,
@@ -379,8 +382,8 @@ function registerGitTool<TInput extends object>(config: {
 	);
 }
 
-export function registerGitTools(): void {
-	registerGitTool<GitStatusInput>({
+export function registerGitTools(catalog: ToolCatalog): void {
+	registerGitTool<GitStatusInput>(catalog, {
 		name: "git_status",
 		label: "git status",
 		description: "Inspect repository status with git status --short --branch.",
@@ -391,7 +394,7 @@ export function registerGitTools(): void {
 		},
 	});
 
-	registerGitTool<GitDiffInput>({
+	registerGitTool<GitDiffInput>(catalog, {
 		name: "git_diff",
 		label: "git diff",
 		description:
@@ -420,7 +423,7 @@ export function registerGitTools(): void {
 		},
 	});
 
-	registerGitTool<GitLogInput>({
+	registerGitTool<GitLogInput>(catalog, {
 		name: "git_log",
 		label: "git log",
 		description: "Inspect commit history with bounded git log output.",
@@ -441,7 +444,7 @@ export function registerGitTools(): void {
 		},
 	});
 
-	registerGitTool<GitShowInput>({
+	registerGitTool<GitShowInput>(catalog, {
 		name: "git_show",
 		label: "git show",
 		description:
@@ -466,7 +469,7 @@ export function registerGitTools(): void {
 		},
 	});
 
-	registerGitTool<GitBranchInput>({
+	registerGitTool<GitBranchInput>(catalog, {
 		name: "git_branch",
 		label: "git branch",
 		description: "Inspect local and remote branches.",
@@ -482,7 +485,7 @@ export function registerGitTools(): void {
 		},
 	});
 
-	registerGitTool<GitLsFilesInput>({
+	registerGitTool<GitLsFilesInput>(catalog, {
 		name: "git_ls_files",
 		label: "git ls-files",
 		description: "List tracked or selected untracked files with git ls-files.",
@@ -499,7 +502,7 @@ export function registerGitTools(): void {
 		},
 	});
 
-	registerGitTool<GitGrepInput>({
+	registerGitTool<GitGrepInput>(catalog, {
 		name: "git_grep",
 		label: "git grep",
 		description: "Search tracked content with git grep.",
@@ -522,7 +525,7 @@ export function registerGitTools(): void {
 		},
 	});
 
-	registerGitTool<GitBlameInput>({
+	registerGitTool<GitBlameInput>(catalog, {
 		name: "git_blame",
 		label: "git blame",
 		description: "Inspect per-line history for a file with git blame.",

--- a/files/pi/agent/extensions/user/lib/tool/github.ts
+++ b/files/pi/agent/extensions/user/lib/tool/github.ts
@@ -8,7 +8,7 @@ import {
 	limitToolOutput,
 	renderLimitedTextResult,
 } from "./output";
-import { defineToolContribution, toolCatalog } from "./catalog";
+import { type ToolCatalog, defineToolContribution } from "./catalog";
 
 const GH_TIMEOUT_MS = 30_000;
 const GH_WATCH_TIMEOUT_MS = 30 * 60 * 1000;
@@ -789,22 +789,25 @@ function lineLimitFromInput(
 	);
 }
 
-function registerGithubTool<TInput extends object>(config: {
-	readonly name: string;
-	readonly label: string;
-	readonly description: string;
-	readonly parameters: Parameters<
-		typeof toolCatalog.register
-	>[0]["definition"]["parameters"];
-	readonly promptSnippet: string;
-	readonly execute: (
-		params: TInput,
-		cwd: string,
-		signal: AbortSignal | undefined,
-	) => Promise<GithubToolOutput>;
-	readonly extractSecretPaths?: (input: TInput) => readonly string[];
-}): void {
-	toolCatalog.register(
+function registerGithubTool<TInput extends object>(
+	catalog: ToolCatalog,
+	config: {
+		readonly name: string;
+		readonly label: string;
+		readonly description: string;
+		readonly parameters: Parameters<
+			ToolCatalog["register"]
+		>[0]["definition"]["parameters"];
+		readonly promptSnippet: string;
+		readonly execute: (
+			params: TInput,
+			cwd: string,
+			signal: AbortSignal | undefined,
+		) => Promise<GithubToolOutput>;
+		readonly extractSecretPaths?: (input: TInput) => readonly string[];
+	},
+): void {
+	catalog.register(
 		defineToolContribution({
 			policy: {
 				name: config.name,
@@ -858,8 +861,8 @@ function registerGithubTool<TInput extends object>(config: {
 	);
 }
 
-export function registerGithubTools(): void {
-	registerGithubTool<GithubPrViewInput>({
+export function registerGithubTools(catalog: ToolCatalog): void {
+	registerGithubTool<GithubPrViewInput>(catalog, {
 		name: "github_pr_view",
 		label: "github pr view",
 		description:
@@ -869,7 +872,7 @@ export function registerGithubTools(): void {
 		execute: githubPrView,
 	});
 
-	registerGithubTool<GithubPrFilesInput>({
+	registerGithubTool<GithubPrFilesInput>(catalog, {
 		name: "github_pr_files",
 		label: "github pr files",
 		description:
@@ -880,7 +883,7 @@ export function registerGithubTools(): void {
 		execute: githubPrFiles,
 	});
 
-	registerGithubTool<GithubPrDiffInput>({
+	registerGithubTool<GithubPrDiffInput>(catalog, {
 		name: "github_pr_diff",
 		label: "github pr diff",
 		description: "Inspect GitHub PR diff summaries, names, or bounded patches.",
@@ -890,7 +893,7 @@ export function registerGithubTools(): void {
 		execute: githubPrDiff,
 	});
 
-	registerGithubTool<GithubCompareInput>({
+	registerGithubTool<GithubCompareInput>(catalog, {
 		name: "github_compare",
 		label: "github compare",
 		description: "Inspect a GitHub base...head comparison with bounded output.",
@@ -900,7 +903,7 @@ export function registerGithubTools(): void {
 		execute: githubCompare,
 	});
 
-	registerGithubTool<GithubPrChecksInput>({
+	registerGithubTool<GithubPrChecksInput>(catalog, {
 		name: "github_pr_checks",
 		label: "github pr checks",
 		description: "Inspect GitHub PR CI/check status with optional filters.",

--- a/files/pi/agent/extensions/user/lib/tool/index.ts
+++ b/files/pi/agent/extensions/user/lib/tool/index.ts
@@ -5,6 +5,6 @@ export {
 	type ToolContribution,
 	type ToolContributionSource,
 	type ToolCatalog,
+	createToolCatalog,
 	defineToolContribution,
-	toolCatalog,
 } from "./catalog";

--- a/files/pi/agent/extensions/user/lib/tool/interview.ts
+++ b/files/pi/agent/extensions/user/lib/tool/interview.ts
@@ -14,7 +14,7 @@ import {
 import { type Static, Type } from "typebox";
 import type { ToolPolicy } from "../policy";
 import { decodePrintableInput } from "../ui";
-import { defineToolContribution, toolCatalog } from "./catalog";
+import { type ToolCatalog, defineToolContribution } from "./catalog";
 
 const choiceSchema = Type.Object({
 	label: Type.String({ description: "User-visible choice label." }),
@@ -651,12 +651,12 @@ async function askMultiple(
 	}
 }
 
-export function registerInterviewTools(): void {
+export function registerInterviewTools(catalog: ToolCatalog): void {
 	const policy: ToolPolicy<AskUserQuestionInput> = {
 		name: ASK_USER_QUESTION_TOOL,
 	};
 
-	toolCatalog.register(
+	catalog.register(
 		defineToolContribution({
 			policy,
 			isErrorResult: isErrorInterviewResult,

--- a/files/pi/agent/extensions/user/lib/tool/project/register.ts
+++ b/files/pi/agent/extensions/user/lib/tool/project/register.ts
@@ -7,9 +7,9 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import type { TSchema } from "typebox";
 import {
+	type ToolCatalog,
 	type ToolContribution,
 	defineToolContribution,
-	toolCatalog,
 } from "../catalog";
 import { executeProjectTool } from "./execute";
 import { isProjectToolDetails } from "./details";
@@ -128,6 +128,7 @@ function loadProjectToolSettings(cwd: string): ProjectToolSettings {
 export function registerProjectTools(
 	pi: ExtensionAPI,
 	ctx: ExtensionContext,
+	catalog: ToolCatalog,
 ): readonly ProjectToolSummary[] {
 	enabledProjectToolNames = new Set();
 	if (!isProjectUserSettingsTrusted(ctx)) return [];
@@ -165,7 +166,7 @@ export function registerProjectTools(
 			}
 			const resolved = resolveTool(ctx.cwd, normalizeTool(name, rawConfig));
 			const contribution = createProjectToolContribution(resolved);
-			toolCatalog.register(contribution);
+			catalog.register(contribution);
 			pi.registerTool(contribution.definition);
 			registeredProjectTools.set(name, { projectRoot: resolved.projectRoot });
 			currentEnabledProjectToolNames.add(name);


### PR DESCRIPTION
## Summary

- add transition IDs to focus runtime auto-continue and reminder state
- ignore stale focus wakeups and replace them with a no-op reminder
- make tool catalog state extension-instance scoped instead of global

## Background

Delayed focus wakeups could arrive after a later focus transition and cause the agent to continue under stale guidance. This change centralizes focus runtime mutations and tags reminders with the latest transition so older queued messages cannot restart obsolete work.
