### PR TITLE
Centralize system reminder handling

### DIFF
--- a/files/pi/agent/extensions/user/features/focus.ts
+++ b/files/pi/agent/extensions/user/features/focus.ts
@@ -15,8 +15,8 @@ import { registerQuickActionHandler } from "../lib/quick-actions";
 import { guardToolCall } from "../lib/focus/guard";
 import { filterProviderTools } from "../lib/focus/provider-filter";
 import {
-	injectFocusReminder,
 	injectFocusRestorePrompt,
+	registerFocusReminderSource,
 } from "../lib/focus/prompt";
 import { type FocusRuntime, createFocusRuntime } from "../lib/focus/runtime";
 import {
@@ -71,6 +71,12 @@ function register(pi: ExtensionAPI, services: UserExtensionServices): void {
 	registerBuiltInFocusPolicies(services.tools);
 	const focus = createFocusController(pi, services.focus);
 	const runtime = createFocusRuntime();
+	const focusReminder = registerFocusReminderSource(
+		pi,
+		focus,
+		runtime,
+		services.reminders,
+	);
 	registerEnterFocusTool(focus, runtime, services.tools);
 	registerExitFocusTool(focus, runtime, services.tools);
 	registerQuickActionHandler("focus", openFocusQuickAction(focus, runtime));
@@ -79,18 +85,20 @@ function register(pi: ExtensionAPI, services: UserExtensionServices): void {
 		handler: toggleFocusSelector(focus, runtime),
 	});
 	pi.on("before_agent_start", injectFocusRestorePrompt(pi, focus, runtime));
-	pi.on("context", injectFocusReminder(pi, focus, runtime));
 	pi.on("before_provider_request", filterProviderTools(pi, focus));
 	pi.on("session_before_switch", persistFocusBeforeNew(pi, focus));
 	pi.on("session_start", resetConfirmDecisions());
 	pi.on("session_start", restoreFocus(focus, runtime));
 	pi.on("agent_end", resetFocusAtAgentEnd(focus, runtime));
-	pi.on("agent_end", autoContinueAfterFocusTransition(pi, focus, runtime));
+	pi.on(
+		"agent_end",
+		autoContinueAfterFocusTransition(pi, focus, runtime, focusReminder),
+	);
 	pi.on("tool_call", guardToolCall(pi, focus, services.tools));
 }
 
 export function createFocusFeature(): Feature {
-	return { name: "focus", register };
+	return { name: "focus", dependsOn: ["system-reminders"], register };
 }
 
 export default createFocusFeature();

--- a/files/pi/agent/extensions/user/features/system-reminders.ts
+++ b/files/pi/agent/extensions/user/features/system-reminders.ts
@@ -1,0 +1,13 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { Feature } from "../feature";
+import type { UserExtensionServices } from "../lib/services";
+
+function register(pi: ExtensionAPI, services: UserExtensionServices): void {
+	pi.on("context", services.reminders.inject);
+}
+
+export function createSystemRemindersFeature(): Feature {
+	return { name: "system-reminders", register };
+}
+
+export default createSystemRemindersFeature();

--- a/files/pi/agent/extensions/user/lib/focus/controller.ts
+++ b/files/pi/agent/extensions/user/lib/focus/controller.ts
@@ -5,7 +5,6 @@ import type {
 import { isProjectUserSettingsTrusted } from "../project-settings";
 import {
 	BASE_FOCUS,
-	FOCUS_REMINDER_TYPE,
 	FOCUS_STATE_TYPE,
 	type FocusDefinition,
 	type FocusName,
@@ -47,15 +46,6 @@ export type FocusController = {
 
 export function buildFocusRestorePrompt(focus: FocusDefinition): string {
 	return `[FOCUS RESTORED: ${focus.name}]\n${focus.prompt}`;
-}
-
-export function isFocusReminderMessage(message: {
-	role: string;
-	customType?: string;
-}): boolean {
-	return (
-		message.role === "custom" && message.customType === FOCUS_REMINDER_TYPE
-	);
 }
 
 export function createFocusController(

--- a/files/pi/agent/extensions/user/lib/focus/index.ts
+++ b/files/pi/agent/extensions/user/lib/focus/index.ts
@@ -10,7 +10,6 @@ export {
 export {
 	buildFocusRestorePrompt,
 	createFocusController,
-	isFocusReminderMessage,
 	type FocusController,
 	type FocusStateEntry,
 } from "./controller";

--- a/files/pi/agent/extensions/user/lib/focus/prompt.ts
+++ b/files/pi/agent/extensions/user/lib/focus/prompt.ts
@@ -1,29 +1,28 @@
 import type {
 	BeforeAgentStartEvent,
 	BeforeAgentStartEventResult,
-	ContextEvent,
 	ExtensionAPI,
 	ExtensionHandler,
 } from "@earendil-works/pi-coding-agent";
-import {
-	type FocusController,
-	buildFocusRestorePrompt,
-	isFocusReminderMessage,
-} from "./controller";
+import { type FocusController, buildFocusRestorePrompt } from "./controller";
 import {
 	ENTER_FOCUS_TOOL,
 	EXIT_FOCUS_TOOL,
 	FOCUS_REMINDER_TYPE,
 } from "./definitions";
 import type { FocusRuntime } from "./runtime";
+import type {
+	RegisteredSystemReminder,
+	SystemReminderPayload,
+	SystemReminderRegistry,
+} from "../system-reminder";
 
-type ContextResult = { messages?: ContextEvent["messages"] };
 type ToolInfo = ReturnType<ExtensionAPI["getAllTools"]>[number];
-type FocusReminderWithTools = {
-	customType: typeof FOCUS_REMINDER_TYPE;
-	content: string;
-	display: false;
-	details: { focus: string; transitionId: number };
+export type FocusReminderDetails = {
+	readonly focus?: string;
+	readonly queuedFocus?: string;
+	readonly transitionId: number;
+	readonly reason?: string;
 };
 
 function formatFocusList(
@@ -157,41 +156,27 @@ function buildActiveFocusPrompt(focus: FocusController): string | undefined {
 		: undefined;
 }
 
-function buildStaleFocusReminderPayload(
-	focus: FocusController,
-	runtime: FocusRuntime,
-): FocusReminderWithTools {
-	return {
-		customType: FOCUS_REMINDER_TYPE,
-		content: [
-			"<system-reminder>",
-			"An obsolete focus-transition wakeup was removed.",
-			"Do not call tools or continue previous work solely because of that obsolete wakeup.",
-			"If the latest user message contains a separate request, answer that request under the current focus; otherwise respond briefly that there is no pending action.",
-			"</system-reminder>",
-		].join("\n"),
-		display: false,
-		details: {
-			focus: focus.current,
-			transitionId: runtime.latestTransition.id,
-		},
-	};
-}
-
 function buildFocusReminderPayloadWithTools(
 	pi: ExtensionAPI,
 	focus: FocusController,
 	runtime: FocusRuntime,
-): FocusReminderWithTools {
+): SystemReminderPayload<FocusReminderDetails> {
 	const tools = visibleToolDefinitions(pi, focus, runtime);
 	const activePrompt = buildActiveFocusPrompt(focus);
 	const focusInstructions = activePrompt
 		? `Focus instructions:\n${activePrompt}`
 		: `Focus routing instructions:\n${buildFocusSystemPrompt(focus)}`;
 	return {
-		customType: FOCUS_REMINDER_TYPE,
-		content: `<system-reminder>\nCurrent focus: ${focus.current}. Follow the focus instructions.\n\n${focusInstructions}\n\nAvailable tool definitions:\n\`\`\`json\n${formatToolDefinitions(tools)}\n\`\`\`\n</system-reminder>`,
-		display: false,
+		content: [
+			`Current focus: ${focus.current}. Follow the focus instructions.`,
+			"",
+			focusInstructions,
+			"",
+			"Available tool definitions:",
+			"```json",
+			formatToolDefinitions(tools),
+			"```",
+		].join("\n"),
 		details: {
 			focus: focus.current,
 			transitionId: runtime.latestTransition.id,
@@ -232,10 +217,7 @@ export const injectFocusRestorePrompt =
 				: { systemPrompt };
 	};
 
-function transitionIdFromMessage(message: unknown): number | undefined {
-	if (typeof message !== "object" || message === null) return undefined;
-	if (!("details" in message)) return undefined;
-	const details = message.details;
+function transitionIdFromDetails(details: unknown): number | undefined {
 	if (typeof details !== "object" || details === null) return undefined;
 	if (!("transitionId" in details)) return undefined;
 	return typeof details.transitionId === "number"
@@ -243,50 +225,17 @@ function transitionIdFromMessage(message: unknown): number | undefined {
 		: undefined;
 }
 
-export const injectFocusReminder =
-	(
-		pi: ExtensionAPI,
-		focus: FocusController,
-		runtime: FocusRuntime,
-	): ExtensionHandler<ContextEvent, ContextResult> =>
-	async (event) => {
-		const focusReminderMessages = event.messages.filter(isFocusReminderMessage);
-		const messagesWithoutFocusReminders = event.messages.filter(
-			(message) => !isFocusReminderMessage(message),
-		);
-		const removedStoredReminder = focusReminderMessages.length > 0;
-		const hasCurrentStoredReminder = focusReminderMessages.some((message) =>
-			runtime.isCurrentTransition(transitionIdFromMessage(message)),
-		);
-		const shouldInjectReminder =
-			runtime.consumeFocusReminderPending() || hasCurrentStoredReminder;
-		if (!shouldInjectReminder) {
-			if (!removedStoredReminder) return undefined;
-			const staleReminder = buildStaleFocusReminderPayload(focus, runtime);
-			return {
-				messages: [
-					...messagesWithoutFocusReminders,
-					{
-						role: "custom",
-						...staleReminder,
-						timestamp: Date.now(),
-					},
-				],
-			};
-		}
-
-		// Stored focus reminders can be delivered after a later focus transition.
-		// Treat current reminders as triggers only and regenerate the actual reminder
-		// from runtime state so the model never sees stale focus/tool guidance.
-		const reminder = buildFocusReminderPayloadWithTools(pi, focus, runtime);
-		return {
-			messages: [
-				...messagesWithoutFocusReminders,
-				{
-					role: "custom",
-					...reminder,
-					timestamp: Date.now(),
-				},
-			],
-		};
-	};
+export function registerFocusReminderSource(
+	pi: ExtensionAPI,
+	focus: FocusController,
+	runtime: FocusRuntime,
+	reminders: SystemReminderRegistry,
+): RegisteredSystemReminder<FocusReminderDetails> {
+	return reminders.register<FocusReminderDetails>({
+		customType: FOCUS_REMINDER_TYPE,
+		consumePending: () => runtime.consumeFocusReminderPending(),
+		isCurrent: (details) =>
+			runtime.isCurrentTransition(transitionIdFromDetails(details)),
+		buildReminder: () => buildFocusReminderPayloadWithTools(pi, focus, runtime),
+	});
+}

--- a/files/pi/agent/extensions/user/lib/focus/session.ts
+++ b/files/pi/agent/extensions/user/lib/focus/session.ts
@@ -6,14 +6,11 @@ import type {
 	SessionStartEvent,
 } from "@earendil-works/pi-coding-agent";
 import { ensureProjectUserSettingsTrusted } from "../project-settings";
+import type { RegisteredSystemReminder } from "../system-reminder";
 import { clearFocusTransitionDecisions } from "./confirmation";
 import type { FocusController } from "./controller";
-import {
-	BASE_FOCUS,
-	FOCUS_REMINDER_TYPE,
-	FOCUS_STATE_TYPE,
-	getFocusExitMode,
-} from "./definitions";
+import { BASE_FOCUS, FOCUS_STATE_TYPE, getFocusExitMode } from "./definitions";
+import type { FocusReminderDetails } from "./prompt";
 import type { FocusRuntime } from "./runtime";
 import { findPersistedFocus } from "./startup";
 
@@ -70,6 +67,7 @@ export const autoContinueAfterFocusTransition =
 		pi: ExtensionAPI,
 		focus: FocusController,
 		runtime: FocusRuntime,
+		reminder: RegisteredSystemReminder<FocusReminderDetails>,
 	): ExtensionHandler<AgentEndEvent> =>
 	async () => {
 		const transition = runtime.consumeAutoContinue();
@@ -77,16 +75,14 @@ export const autoContinueAfterFocusTransition =
 		if (!runtime.isCurrentTransition(transition.id)) return;
 		if (focus.current !== transition.focusName) return;
 		if (transition.focusName !== BASE_FOCUS && !focus.active) return;
-		runtime.requestFocusReminder();
 		const isBase = transition.focusName === BASE_FOCUS;
 		// This message only wakes the agent up. Focus-specific guidance is rebuilt
-		// from current runtime state in the context hook. The transition id lets us
-		// drop older queued wakeups if a later focus change happens first.
-		pi.sendMessage(
+		// from current runtime state by the system reminder registry. The transition
+		// id lets the registry drop older queued wakeups if a later focus change wins.
+		reminder.sendWakeup(
+			pi,
 			{
-				customType: FOCUS_REMINDER_TYPE,
 				content: [
-					"<system-reminder>",
 					isBase
 						? "A focus exit completed. Continue from the latest focus state."
 						: "A focus transition completed. Continue from the latest focus state.",
@@ -94,9 +90,7 @@ export const autoContinueAfterFocusTransition =
 					isBase
 						? "Continue from the focus tool result and its exit handoff. If another focus is needed, use enter_focus."
 						: "Continue the user's request under the current focus. Follow the active focus instructions and available tools. Do not answer only with a focus status message.",
-					"</system-reminder>",
-				].join("\n"),
-				display: false,
+				],
 				details: {
 					queuedFocus: transition.focusName,
 					transitionId: transition.id,

--- a/files/pi/agent/extensions/user/lib/services.ts
+++ b/files/pi/agent/extensions/user/lib/services.ts
@@ -1,14 +1,20 @@
 import { type FocusSharedState, createFocusSharedState } from "./focus/state";
+import {
+	type SystemReminderRegistry,
+	createSystemReminderRegistry,
+} from "./system-reminder";
 import { type ToolCatalog, createToolCatalog } from "./tool";
 
 export type UserExtensionServices = {
 	readonly focus: FocusSharedState;
+	readonly reminders: SystemReminderRegistry;
 	readonly tools: ToolCatalog;
 };
 
 export function createUserExtensionServices(): UserExtensionServices {
 	return {
 		focus: createFocusSharedState(),
+		reminders: createSystemReminderRegistry(),
 		tools: createToolCatalog(),
 	};
 }

--- a/files/pi/agent/extensions/user/lib/system-reminder.ts
+++ b/files/pi/agent/extensions/user/lib/system-reminder.ts
@@ -1,0 +1,266 @@
+import type {
+	ContextEvent,
+	ExtensionAPI,
+	ExtensionHandler,
+} from "@earendil-works/pi-coding-agent";
+
+/**
+ * Centralized hidden <system-reminder> handling.
+ *
+ * A feature should register one source and use the returned handle to request
+ * reminders or send wakeups. This keeps content wrapping, stored-message
+ * removal, current-state regeneration, and stale wakeup cancellation in one
+ * place instead of duplicating fragile context-hook logic per feature.
+ */
+type ContextMessages = ContextEvent["messages"];
+type ContextMessage = ContextMessages[number];
+type ContextResult = { messages?: ContextMessages };
+type SendMessageOptions = Parameters<ExtensionAPI["sendMessage"]>[1];
+type SendMessageResult = ReturnType<ExtensionAPI["sendMessage"]>;
+
+type StoredSystemReminderMessage<TDetails extends object> = {
+	readonly customType: string;
+	readonly content: string;
+	readonly display: false;
+	readonly details?: TDetails;
+};
+
+type ContextSystemReminderMessage<TDetails extends object> =
+	StoredSystemReminderMessage<TDetails> & {
+		readonly role: "custom";
+		readonly timestamp: number;
+	};
+
+export type SystemReminderPayload<
+	TDetails extends object = Record<string, unknown>,
+> = {
+	/** Body text for the reminder. The registry wraps it in <system-reminder>. */
+	readonly content: string | readonly string[];
+	/** Metadata for routing/fencing only. This is not sent to the model. */
+	readonly details?: TDetails;
+};
+
+export type SystemReminderSource<
+	TDetails extends object = Record<string, unknown>,
+> = {
+	readonly customType: string;
+	/** Consume source-owned pending state. Called on every context build. */
+	readonly consumePending?: () => boolean;
+	/** Build the authoritative reminder from current state. */
+	readonly buildReminder: () => SystemReminderPayload<TDetails> | undefined;
+	/** Return false for stored wakeups that belong to an obsolete state. */
+	readonly isCurrent?: (details: unknown, message: ContextMessage) => boolean;
+	/** Optional source-specific no-op reminder for obsolete wakeups. */
+	readonly buildStaleReminder?: (
+		messages: readonly ContextMessage[],
+	) => SystemReminderPayload | undefined;
+};
+
+export type RegisteredSystemReminder<
+	TDetails extends object = Record<string, unknown>,
+> = {
+	readonly customType: string;
+	request(): void;
+	clear(): void;
+	createMessage(
+		payload: SystemReminderPayload<TDetails>,
+	): StoredSystemReminderMessage<TDetails>;
+	sendWakeup(
+		pi: ExtensionAPI,
+		payload: SystemReminderPayload<TDetails>,
+		options?: SendMessageOptions,
+	): SendMessageResult;
+};
+
+export type SystemReminderRegistry = {
+	register<TDetails extends object>(
+		source: SystemReminderSource<TDetails>,
+	): RegisteredSystemReminder<TDetails>;
+	request(customType: string): void;
+	clear(customType: string): void;
+	createMessage<TDetails extends object>(
+		customType: string,
+		payload: SystemReminderPayload<TDetails>,
+	): StoredSystemReminderMessage<TDetails>;
+	sendWakeup<TDetails extends object>(
+		pi: ExtensionAPI,
+		customType: string,
+		payload: SystemReminderPayload<TDetails>,
+		options?: SendMessageOptions,
+	): SendMessageResult;
+	readonly inject: ExtensionHandler<ContextEvent, ContextResult>;
+};
+
+function customTypeOf(message: ContextMessage): string | undefined {
+	const candidate = message as { role?: unknown; customType?: unknown };
+	return candidate.role === "custom" && typeof candidate.customType === "string"
+		? candidate.customType
+		: undefined;
+}
+
+function detailsOf(message: ContextMessage): unknown {
+	return (message as { details?: unknown }).details;
+}
+
+function formatReminderContent(content: string | readonly string[]): string {
+	const body = typeof content === "string" ? content : content.join("\n");
+	return `<system-reminder>\n${body}\n</system-reminder>`;
+}
+
+function buildStoredMessage<TDetails extends object>(
+	customType: string,
+	payload: SystemReminderPayload<TDetails>,
+): StoredSystemReminderMessage<TDetails> {
+	return {
+		customType,
+		content: formatReminderContent(payload.content),
+		display: false,
+		...(payload.details === undefined ? {} : { details: payload.details }),
+	};
+}
+
+function buildContextMessage<TDetails extends object>(
+	customType: string,
+	payload: SystemReminderPayload<TDetails>,
+	timestamp: number,
+): ContextSystemReminderMessage<TDetails> {
+	return {
+		role: "custom",
+		...buildStoredMessage(customType, payload),
+		timestamp,
+	};
+}
+
+function buildDefaultStaleReminder(
+	customType: string,
+): SystemReminderPayload<Record<string, unknown>> {
+	return {
+		content: [
+			"An obsolete system reminder wakeup was removed.",
+			"Do not call tools or continue previous work solely because of that obsolete wakeup.",
+			"If the latest user message contains a separate request, answer that request under the current system state; otherwise respond briefly that there is no pending action.",
+		],
+		details: { stale: true, customType },
+	};
+}
+
+export function createSystemReminderRegistry(): SystemReminderRegistry {
+	const sources = new Map<string, SystemReminderSource>();
+	const pending = new Set<string>();
+
+	function requireSource(customType: string): void {
+		if (!sources.has(customType)) {
+			throw new Error(`Unknown system reminder source: ${customType}`);
+		}
+	}
+
+	function request(customType: string): void {
+		requireSource(customType);
+		pending.add(customType);
+	}
+
+	function clear(customType: string): void {
+		requireSource(customType);
+		pending.delete(customType);
+	}
+
+	function createMessage<TDetails extends object>(
+		customType: string,
+		payload: SystemReminderPayload<TDetails>,
+	): StoredSystemReminderMessage<TDetails> {
+		requireSource(customType);
+		return buildStoredMessage(customType, payload);
+	}
+
+	function sendWakeup<TDetails extends object>(
+		pi: ExtensionAPI,
+		customType: string,
+		payload: SystemReminderPayload<TDetails>,
+		options?: SendMessageOptions,
+	): SendMessageResult {
+		request(customType);
+		return pi.sendMessage(createMessage(customType, payload), options);
+	}
+
+	return {
+		register<TDetails extends object>(source: SystemReminderSource<TDetails>) {
+			if (sources.has(source.customType)) {
+				throw new Error(
+					`Duplicate system reminder source: ${source.customType}`,
+				);
+			}
+			sources.set(source.customType, source as SystemReminderSource);
+			return {
+				customType: source.customType,
+				request: () => request(source.customType),
+				clear: () => clear(source.customType),
+				createMessage: (payload) => createMessage(source.customType, payload),
+				sendWakeup: (pi, payload, options) =>
+					sendWakeup(pi, source.customType, payload, options),
+			};
+		},
+		request,
+		clear,
+		createMessage,
+		sendWakeup,
+		inject: async (event) => {
+			const messagesByType = new Map<string, ContextMessage[]>();
+			const keptMessages: ContextMessage[] = [];
+
+			for (const message of event.messages) {
+				const customType = customTypeOf(message);
+				if (customType && sources.has(customType)) {
+					const messages = messagesByType.get(customType) ?? [];
+					messages.push(message);
+					messagesByType.set(customType, messages);
+					continue;
+				}
+				keptMessages.push(message);
+			}
+
+			const injectedMessages: ContextMessage[] = [];
+			const timestamp = Date.now();
+
+			for (const source of sources.values()) {
+				const storedMessages = messagesByType.get(source.customType) ?? [];
+				const servicePending = pending.delete(source.customType);
+				const sourcePending = source.consumePending?.() ?? false;
+				const hasCurrentStored = storedMessages.some((message) =>
+					source.isCurrent
+						? source.isCurrent(detailsOf(message), message)
+						: true,
+				);
+				const shouldInject =
+					servicePending || sourcePending || hasCurrentStored;
+
+				if (!shouldInject) {
+					if (storedMessages.length === 0) continue;
+					const staleReminder =
+						source.buildStaleReminder?.(storedMessages) ??
+						buildDefaultStaleReminder(source.customType);
+					if (staleReminder) {
+						injectedMessages.push(
+							buildContextMessage(source.customType, staleReminder, timestamp),
+						);
+					}
+					continue;
+				}
+
+				const reminder = source.buildReminder();
+				if (reminder) {
+					injectedMessages.push(
+						buildContextMessage(source.customType, reminder, timestamp),
+					);
+				}
+			}
+
+			if (
+				keptMessages.length === event.messages.length &&
+				injectedMessages.length === 0
+			) {
+				return undefined;
+			}
+			return { messages: [...keptMessages, ...injectedMessages] };
+		},
+	};
+}

--- a/files/pi/agent/extensions/user/main.ts
+++ b/files/pi/agent/extensions/user/main.ts
@@ -5,6 +5,7 @@ import { createExitConfirmFeature } from "./features/exit-confirm";
 import { createFocusFeature } from "./features/focus";
 import { createQuickActionsFeature } from "./features/quick-actions";
 import { createStatusFeature } from "./features/status";
+import { createSystemRemindersFeature } from "./features/system-reminders";
 import { createThinkingFeature } from "./features/thinking";
 import { createTmuxNoticeFeature } from "./features/tmux-notice";
 import { createToolFeature } from "./features/tool";
@@ -15,6 +16,7 @@ function createFeatures(): readonly Feature[] {
 		createStatusFeature(),
 		createTurnMetricsFeature(),
 		createExitConfirmFeature(),
+		createSystemRemindersFeature(),
 		createFocusFeature(),
 		createQuickActionsFeature(),
 		createThinkingFeature(),


### PR DESCRIPTION

## Summary

- add a shared system reminder registry for hidden reminder injection
- move focus reminder context handling onto the registry
- centralize reminder wrapping, wakeup delivery, and stale reminder handling

## Background

System reminders previously required feature-specific context hook logic, which made stale wakeup handling easy to duplicate incorrectly. This change gives future features a single registration path for reminders so current-state regeneration and stale wakeup cancellation stay in one place.
