### PR TITLE
Add tests for Pi user extension

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,72 @@
+name: Test
+
+permissions:
+  contents: read
+  pull-requests: read
+
+on:
+  - pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CLICOLOR: 1
+
+jobs:
+  changes:
+    name: Detect test changes
+    runs-on: ubuntu-latest
+    outputs:
+      node: ${{ steps.filter.outputs.node }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            node:
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'tsconfig.json'
+              - '**/*.ts'
+              - '.github/workflows/test.yml'
+
+  test:
+    name: pnpm test
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+    if: ${{ needs.changes.outputs.node == 'true' }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: lts/*
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test
+
+  all-test-passed:
+    name: All Test Passed
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - test
+    if: ${{ always() }}
+    steps:
+      - name: Verify all test jobs passed
+        env:
+          RESULTS: ${{ join(needs.*.result, ',') }}
+        run: |
+          if [[ "$RESULTS" == *failure* || "$RESULTS" == *cancelled* ]]; then
+            echo "One or more jobs failed or were cancelled: $RESULTS"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
+coverage/
 .direnv/
 .pnpm-store/

--- a/.pi/settings.user.json
+++ b/.pi/settings.user.json
@@ -40,6 +40,24 @@
         }
       ]
     },
+    "test": {
+      "description": "Run the project test suite.",
+      "executionMode": "parallel",
+      "promptSnippet": "Run the project test suite",
+      "promptGuidelines": [
+        "Use test after adding or changing tests, or when verifying test behavior."
+      ],
+      "commands": [
+        {
+          "label": "test",
+          "command": "pnpm",
+          "arguments": [
+            "test"
+          ],
+          "timeoutSeconds": 120
+        }
+      ]
+    },
     "format": {
       "description": "Format the project in place with treefmt.",
       "executionMode": "sequential",
@@ -73,10 +91,11 @@
   "focuses": {
     "edit": {
       "description": "Use when making repository file changes for this dotfiles project; use format and lint when appropriate.",
-      "prompt": "For this dotfiles project, use format to auto-fix formatting and lint to verify changes after editing when appropriate.",
+      "prompt": "For this dotfiles project, use format to auto-fix formatting and lint/test to verify changes after editing when appropriate.",
       "tools": [
         "format",
-        "lint"
+        "lint",
+        "test"
       ]
     },
     "home-manager": {

--- a/.pi/settings.user.json
+++ b/.pi/settings.user.json
@@ -58,6 +58,24 @@
         }
       ]
     },
+    "coverage": {
+      "description": "Run the test suite with coverage reporting.",
+      "executionMode": "parallel",
+      "promptSnippet": "Run the test suite with coverage reporting",
+      "promptGuidelines": [
+        "Use coverage when evaluating test coverage or deciding where to add tests."
+      ],
+      "commands": [
+        {
+          "label": "coverage",
+          "command": "pnpm",
+          "arguments": [
+            "test:coverage"
+          ],
+          "timeoutSeconds": 120
+        }
+      ]
+    },
     "format": {
       "description": "Format the project in place with treefmt.",
       "executionMode": "sequential",
@@ -91,11 +109,12 @@
   "focuses": {
     "edit": {
       "description": "Use when making repository file changes for this dotfiles project; use format and lint when appropriate.",
-      "prompt": "For this dotfiles project, use format to auto-fix formatting and lint/test to verify changes after editing when appropriate.",
+      "prompt": "For this dotfiles project, use format to auto-fix formatting and lint/test/coverage to verify changes after editing when appropriate.",
       "tools": [
         "format",
         "lint",
-        "test"
+        "test",
+        "coverage"
       ]
     },
     "home-manager": {

--- a/files/pi/agent/extensions/user/lib/file/guard.test.ts
+++ b/files/pi/agent/extensions/user/lib/file/guard.test.ts
@@ -1,0 +1,110 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import {
+	assertNoIgnoredDescendants,
+	assertRepoPathAllowed,
+	createFsGuardContext,
+	displayRepoPath,
+	resolveRepoPath,
+} from "./guard";
+
+function tempRepo(): string {
+	const root = mkdtempSync(join(tmpdir(), "pi-file-guard-"));
+	execFileSync("git", ["init"], { cwd: root, stdio: "ignore" });
+	writeFileSync(join(root, ".gitignore"), "ignored.txt\nignored-dir/\n");
+	mkdirSync(join(root, "src", "nested"), { recursive: true });
+	writeFileSync(join(root, "src", "nested", "keep.txt"), "keep\n");
+	writeFileSync(join(root, "ignored.txt"), "ignored\n");
+	mkdirSync(join(root, "ignored-dir"), { recursive: true });
+	writeFileSync(join(root, "ignored-dir", "ignored.txt"), "ignored\n");
+	return root;
+}
+
+describe("file guard", () => {
+	it("resolves and displays repository paths safely", () => {
+		const root = tempRepo();
+
+		assert.equal(resolveRepoPath(root, "src", "Reading"), join(root, "src"));
+		assert.equal(displayRepoPath(root, root), ".");
+		assert.equal(
+			displayRepoPath(root, join(root, "src", "nested")),
+			"src/nested",
+		);
+		assert.equal(
+			displayRepoPath(root, resolve(root, "..")),
+			resolve(root, ".."),
+		);
+		assert.throws(
+			() => resolveRepoPath(root, "  ", "Reading"),
+			/Path must not be empty/u,
+		);
+	});
+
+	it("rejects paths outside the repo, inside .git, or ignored by gitignore", async () => {
+		const root = tempRepo();
+		const ctx = await createFsGuardContext(join(root, "src"));
+
+		assert.equal(ctx.repoRoot, root);
+		assert.equal(ctx.cwd, join(root, "src"));
+		await assertRepoPathAllowed(ctx, join(root, "src", "nested"), "Reading");
+		await assert.rejects(
+			assertRepoPathAllowed(ctx, resolve(root, ".."), "Reading"),
+			/Reading outside the repository is not allowed/u,
+		);
+		await assert.rejects(
+			assertRepoPathAllowed(ctx, join(root, ".git", "config"), "Reading"),
+			/Reading inside \.git is not allowed/u,
+		);
+		await assert.rejects(
+			assertRepoPathAllowed(ctx, join(root, "ignored.txt"), "Reading"),
+			/Reading ignored files is not allowed/u,
+		);
+	});
+
+	it("rejects missing paths and ignored descendants during recursive checks", async () => {
+		const root = tempRepo();
+		mkdirSync(join(root, "src", "with-ignored"), { recursive: true });
+		writeFileSync(
+			join(root, "src", "with-ignored", "ignored.txt"),
+			"ignored\n",
+		);
+		writeFileSync(
+			join(root, "src", "with-ignored", ".gitignore"),
+			"ignored.txt\n",
+		);
+		const ctx = await createFsGuardContext(root);
+
+		await assertNoIgnoredDescendants(
+			ctx,
+			join(root, "src", "nested"),
+			"Removing",
+		);
+		await assert.rejects(
+			assertNoIgnoredDescendants(ctx, join(root, "missing"), "Removing"),
+			/No such file or directory: missing/u,
+		);
+		await assert.rejects(
+			assertNoIgnoredDescendants(
+				ctx,
+				join(root, "src", "with-ignored"),
+				"Removing",
+			),
+			/Removing ignored files is not allowed: src\/with-ignored\/ignored\.txt/u,
+		);
+	});
+
+	it("allows non-git temp projects without running gitignore checks", async () => {
+		const root = mkdtempSync(join(tmpdir(), "pi-file-guard-no-git-"));
+		writeFileSync(join(root, "ignored.txt"), "not actually ignored\n");
+		const ctx = await createFsGuardContext(root);
+
+		assert.equal(ctx.isGitRepo, false);
+		await assertRepoPathAllowed(ctx, join(root, "ignored.txt"), "Reading");
+
+		rmSync(root, { recursive: true, force: true });
+	});
+});

--- a/files/pi/agent/extensions/user/lib/file/operations.test.ts
+++ b/files/pi/agent/extensions/user/lib/file/operations.test.ts
@@ -1,0 +1,171 @@
+import { execFileSync } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import {
+	executeMove,
+	executeRemove,
+	normalizeStringOrArray,
+} from "./operations";
+
+function tempRepo(): string {
+	const root = mkdtempSync(join(tmpdir(), "pi-file-operations-"));
+	execFileSync("git", ["init"], { cwd: root, stdio: "ignore" });
+	writeFileSync(join(root, ".gitignore"), "ignored.txt\nignored-dir/\n");
+	mkdirSync(join(root, "src"), { recursive: true });
+	writeFileSync(join(root, "src", "one.txt"), "one\n");
+	writeFileSync(join(root, "src", "two.txt"), "two\n");
+	writeFileSync(join(root, "ignored.txt"), "ignored\n");
+	mkdirSync(join(root, "ignored-dir"), { recursive: true });
+	writeFileSync(join(root, "ignored-dir", "ignored.txt"), "ignored\n");
+	return root;
+}
+
+describe("file operations", () => {
+	it("normalizes string and array inputs defensively", () => {
+		assert.deepEqual(normalizeStringOrArray("a"), ["a"]);
+		assert.deepEqual(normalizeStringOrArray(["a", 1, "b", null]), ["a", "b"]);
+		assert.deepEqual(normalizeStringOrArray(undefined), []);
+	});
+
+	it("removes files after repository and ignore checks", async () => {
+		const root = tempRepo();
+
+		const result = await executeRemove(
+			root,
+			{ path: "src/one.txt" },
+			undefined,
+		);
+
+		assert.equal(existsSync(join(root, "src", "one.txt")), false);
+		assert.deepEqual(result.details, {
+			operation: "rm",
+			removed: ["src/one.txt"],
+		});
+		assert.match(resultText(result), /Removed src\/one\.txt/u);
+	});
+
+	it("rejects missing, ignored, outside, and aborted removes before mutation", async () => {
+		const root = tempRepo();
+		const aborted = new AbortController();
+		aborted.abort();
+
+		await assert.rejects(
+			executeRemove(root, { path: [] }, undefined),
+			/Removing requires at least one path/u,
+		);
+		await assert.rejects(
+			executeRemove(root, { path: "missing.txt" }, undefined),
+			/No such file or directory: missing\.txt/u,
+		);
+		await assert.rejects(
+			executeRemove(root, { path: "ignored.txt" }, undefined),
+			/Removing ignored files is not allowed: ignored\.txt/u,
+		);
+		await assert.rejects(
+			executeRemove(root, { path: resolve(root, "..") }, undefined),
+			/Removing outside the repository is not allowed/u,
+		);
+		await assert.rejects(
+			executeRemove(root, { path: "src/one.txt" }, aborted.signal),
+			/Tool execution was aborted/u,
+		);
+		assert.equal(existsSync(join(root, "src", "one.txt")), true);
+	});
+
+	it("moves one source to a file path and multiple sources into a directory", async () => {
+		const root = tempRepo();
+		mkdirSync(join(root, "dest"));
+
+		const single = await executeMove(
+			root,
+			{ source: "src/one.txt", destination: "renamed.txt" },
+			undefined,
+		);
+		const multiple = await executeMove(
+			root,
+			{ source: ["src/two.txt", "renamed.txt"], destination: "dest" },
+			undefined,
+		);
+
+		assert.equal(readFileSync(join(root, "dest", "two.txt"), "utf8"), "two\n");
+		assert.equal(
+			readFileSync(join(root, "dest", "renamed.txt"), "utf8"),
+			"one\n",
+		);
+		assert.deepEqual(single.details.moves, [
+			{ source: "src/one.txt", destination: "renamed.txt" },
+		]);
+		assert.deepEqual(multiple.details.moves, [
+			{ source: "src/two.txt", destination: "dest/two.txt" },
+			{ source: "renamed.txt", destination: "dest/renamed.txt" },
+		]);
+	});
+
+	it("rejects unsafe move inputs before renaming", async () => {
+		const root = tempRepo();
+		mkdirSync(join(root, "dest"));
+		writeFileSync(join(root, "dest", "one.txt"), "already here\n");
+		const aborted = new AbortController();
+		aborted.abort();
+
+		await assert.rejects(
+			executeMove(root, { source: [], destination: "dest" }, undefined),
+			/Moving requires at least one source/u,
+		);
+		await assert.rejects(
+			executeMove(
+				root,
+				{ source: ["src/one.txt", "src/two.txt"], destination: "new-dir" },
+				undefined,
+			),
+			/Destination must be an existing directory/u,
+		);
+		await assert.rejects(
+			executeMove(
+				root,
+				{ source: "src/one.txt", destination: "ignored.txt" },
+				undefined,
+			),
+			/Moving to ignored files is not allowed: ignored\.txt/u,
+		);
+		await assert.rejects(
+			executeMove(
+				root,
+				{ source: "ignored.txt", destination: "dest/moved.txt" },
+				undefined,
+			),
+			/Moving ignored files is not allowed: ignored\.txt/u,
+		);
+		await assert.rejects(
+			executeMove(
+				root,
+				{ source: "src/one.txt", destination: "dest/one.txt" },
+				undefined,
+			),
+			/Destination already exists: dest\/one\.txt/u,
+		);
+		await assert.rejects(
+			executeMove(
+				root,
+				{ source: "src/one.txt", destination: "dest/new.txt" },
+				aborted.signal,
+			),
+			/Tool execution was aborted/u,
+		);
+		assert.equal(existsSync(join(root, "src", "one.txt")), true);
+	});
+});
+
+function resultText(result: Awaited<ReturnType<typeof executeRemove>>): string {
+	const content = result.content[0];
+	return content?.type === "text" ? content.text : "";
+}

--- a/files/pi/agent/extensions/user/lib/focus/confirmation.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/confirmation.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { beforeEach, describe, it } from "vitest";
+import {
+	clearFocusTransitionDecisions,
+	confirmExitFocusTransition,
+	confirmFocusTransition,
+	isFocusAllowedForSession,
+	isFocusDeniedForSession,
+	rememberFocusTransitionDecision,
+} from "./confirmation";
+
+type CustomComponent = {
+	handleInput(data: string): void;
+	render(width: number): string[];
+	invalidate(): void;
+};
+
+function identity(value: string): string {
+	return value;
+}
+
+function theme(): Record<string, unknown> {
+	return { fg: (_role: string, text: string) => text, bold: identity };
+}
+
+function keybindings(): Record<string, unknown> {
+	return {
+		matches: (data: string, action: string) =>
+			(data === "up" && action === "tui.select.up") ||
+			(data === "down" && action === "tui.select.down") ||
+			(data === "enter" && action === "tui.select.confirm") ||
+			(data === "esc" && action === "tui.select.cancel"),
+	};
+}
+
+function context(options: {
+	readonly inputs: readonly string[];
+	readonly editorResults?: readonly (string | undefined)[];
+}): ExtensionContext {
+	const inputs = [...options.inputs];
+	const editorResults = [...(options.editorResults ?? [])];
+	return {
+		hasUI: true,
+		ui: {
+			custom: async <T>(
+				build: (
+					tui: { requestRender(): void },
+					theme: Record<string, unknown>,
+					keybindings: Record<string, unknown>,
+					done: (value: T) => void,
+				) => CustomComponent,
+			): Promise<T> =>
+				new Promise((resolve) => {
+					const component = build(
+						{ requestRender: () => undefined },
+						theme(),
+						keybindings(),
+						resolve,
+					);
+					component.render(80);
+					component.invalidate();
+					component.handleInput(inputs.shift() ?? "esc");
+				}),
+			editor: async () => editorResults.shift(),
+		},
+	} as unknown as ExtensionContext;
+}
+
+describe("focus confirmation", () => {
+	beforeEach(() => clearFocusTransitionDecisions());
+
+	it("records allow and deny decisions for the current session", () => {
+		assert.equal(isFocusAllowedForSession("edit"), false);
+		assert.equal(isFocusDeniedForSession("edit"), false);
+
+		rememberFocusTransitionDecision("edit", "allow-session");
+		assert.equal(isFocusAllowedForSession("edit"), true);
+		assert.equal(isFocusDeniedForSession("edit"), false);
+
+		rememberFocusTransitionDecision("edit", "deny-session");
+		assert.equal(isFocusAllowedForSession("edit"), false);
+		assert.equal(isFocusDeniedForSession("edit"), true);
+
+		clearFocusTransitionDecisions();
+		assert.equal(isFocusAllowedForSession("edit"), false);
+		assert.equal(isFocusDeniedForSession("edit"), false);
+	});
+
+	it("selects enter-focus decisions from printable shortcuts and cancel keys", async () => {
+		assert.equal(
+			await confirmFocusTransition(
+				context({ inputs: ["a"] }),
+				"edit",
+				"Edit files",
+				"Need changes",
+			),
+			"allow-session",
+		);
+		assert.equal(
+			await confirmFocusTransition(
+				context({ inputs: ["esc"] }),
+				"edit",
+				"Edit files",
+				"Need changes",
+			),
+			undefined,
+		);
+	});
+
+	it("supports exit denial with an edited reject reason", async () => {
+		assert.deepEqual(
+			await confirmExitFocusTransition(
+				context({ inputs: ["r"], editorResults: [" needs tests "] }),
+				"interview",
+				"requirements complete",
+			),
+			{ confirmed: false, rejectReason: "needs tests" },
+		);
+	});
+
+	it("returns to the exit confirmation when reason editing is cancelled", async () => {
+		assert.deepEqual(
+			await confirmExitFocusTransition(
+				context({ inputs: ["r", "y"], editorResults: [undefined] }),
+				"interview",
+				"requirements complete",
+			),
+			{ confirmed: true },
+		);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/focus/controller.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/controller.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { describe, it } from "vitest";
+import { createTestPiProject } from "../test-support/pi-project";
+import { BASE_FOCUS, FOCUS_STATE_TYPE } from "./definitions";
+import { createFocusController } from "./controller";
+import { createFocusSharedState } from "./state";
+
+function fakePi(): ExtensionAPI & {
+	readonly entries: { customType: string; data: unknown }[];
+	activeTools: string[];
+} {
+	const entries: { customType: string; data: unknown }[] = [];
+	const api = {
+		entries,
+		activeTools: [] as string[],
+		getAllTools: () =>
+			[
+				"multi_tool_use.parallel",
+				"enter_focus",
+				"exit_focus",
+				"read",
+				"grep",
+				"find",
+				"ls",
+				"write",
+				"edit",
+				"mv",
+				"rm",
+			].map((name) => ({ name })),
+		setActiveTools: (tools: string[]) => {
+			api.activeTools = tools;
+		},
+		appendEntry: (customType: string, data: unknown) => {
+			entries.push({ customType, data });
+		},
+	};
+	return api as unknown as ExtensionAPI & {
+		readonly entries: { customType: string; data: unknown }[];
+		activeTools: string[];
+	};
+}
+
+function context(cwd: string): ExtensionContext & {
+	readonly statuses: Record<string, string | undefined>;
+	readonly notifications: string[];
+} {
+	const statuses: Record<string, string | undefined> = {};
+	const notifications: string[] = [];
+	return {
+		cwd,
+		hasUI: false,
+		statuses,
+		notifications,
+		isProjectTrusted: () => true,
+		ui: {
+			setStatus: (key: string, value: string | undefined) => {
+				statuses[key] = value;
+			},
+			notify: (message: string) => notifications.push(message),
+		},
+	} as unknown as ExtensionContext & {
+		readonly statuses: Record<string, string | undefined>;
+		readonly notifications: string[];
+	};
+}
+
+describe("createFocusController", () => {
+	it("enters, persists, restores, and leaves focuses", () => {
+		const pi = fakePi();
+		const sharedState = createFocusSharedState();
+		const controller = createFocusController(pi, sharedState);
+		const ctx = context(
+			createTestPiProject({ includeUserSettings: false }).cwd,
+		);
+
+		const entered = controller.enter(ctx, "explore");
+
+		assert.equal(entered.name, "explore");
+		assert.equal(controller.current, "explore");
+		assert.equal(sharedState.currentFocusName, "explore");
+		assert.deepEqual(pi.entries, [
+			{ customType: FOCUS_STATE_TYPE, data: { focus: "explore" } },
+		]);
+		assert.ok(pi.activeTools.includes("read"));
+		assert.equal(typeof ctx.statuses.focus, "string");
+
+		controller.restore(ctx, "edit");
+		assert.equal(controller.current, "edit");
+		assert.equal(controller.active?.name, "edit");
+
+		controller.restore(ctx, "missing");
+		assert.equal(controller.current, BASE_FOCUS);
+		assert.equal(controller.active, undefined);
+		assert.equal(ctx.statuses.focus, undefined);
+
+		controller.enter(ctx, "explore", { persist: false });
+		const previous = controller.leave(ctx);
+		assert.equal(previous?.name, "explore");
+		assert.equal(controller.current, BASE_FOCUS);
+		assert.deepEqual(pi.entries.at(-1), {
+			customType: FOCUS_STATE_TYPE,
+			data: { focus: BASE_FOCUS },
+		});
+	});
+
+	it("reloads project focuses, reports warnings, and drops stale active focus", () => {
+		const pi = fakePi();
+		const sharedState = createFocusSharedState();
+		sharedState.setFocusState("missing", undefined, sharedState.registry);
+		const controller = createFocusController(pi, sharedState);
+		const project = createTestPiProject({
+			rawSettings: JSON.stringify([]),
+			includeStandardPiConfig: true,
+		});
+		const ctx = context(project.cwd);
+
+		controller.loadProjectFocuses(ctx);
+
+		assert.equal(controller.current, BASE_FOCUS);
+		assert.equal(controller.registry.get("explore")?.name, "explore");
+		assert.match(ctx.notifications.join("\n"), /must contain a JSON object/u);
+		assert.deepEqual(
+			controller.allowedToolNames(pi),
+			new Set(["multi_tool_use.parallel", "enter_focus"]),
+		);
+	});
+
+	it("does not re-enter the same focus unless forced", () => {
+		const pi = fakePi();
+		const controller = createFocusController(pi, createFocusSharedState());
+		const ctx = context(
+			createTestPiProject({ includeUserSettings: false }).cwd,
+		);
+
+		controller.enter(ctx, "explore");
+		const entryCount = pi.entries.length;
+		controller.enter(ctx, "explore");
+		controller.enter(ctx, "explore", { force: true, persist: false });
+
+		assert.equal(pi.entries.length, entryCount);
+		assert.equal(controller.current, "explore");
+	});
+});

--- a/files/pi/agent/extensions/user/lib/focus/definitions.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/definitions.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import {
+	BASE_FOCUS_DEFINITIONS,
+	BUILT_IN_TOOL_SETS,
+	getFocusExitMode,
+	isFocusTransition,
+} from "./definitions";
+
+describe("focus definitions", () => {
+	it("has unique built-in focus names", () => {
+		const names = BASE_FOCUS_DEFINITIONS.map((focus) => focus.name);
+		assert.equal(new Set(names).size, names.length);
+	});
+
+	it("uses known tool sets", () => {
+		for (const focus of BASE_FOCUS_DEFINITIONS) {
+			for (const toolSet of focus.toolSets ?? []) {
+				assert.ok(
+					BUILT_IN_TOOL_SETS.has(toolSet),
+					`${focus.name} references unknown tool set ${toolSet}`,
+				);
+			}
+		}
+	});
+
+	it("defaults focus exit mode to single-turn", () => {
+		assert.equal(
+			getFocusExitMode({
+				name: "demo",
+				description: "demo",
+				prompt: "demo",
+				tools: [],
+				transition: "auto",
+			}),
+			"single-turn",
+		);
+		assert.equal(
+			getFocusExitMode({
+				name: "demo",
+				description: "demo",
+				prompt: "demo",
+				tools: [],
+				transition: "auto",
+				exitMode: "explicit",
+			}),
+			"explicit",
+		);
+	});
+
+	it("recognizes focus transition values", () => {
+		assert.equal(isFocusTransition("auto"), true);
+		assert.equal(isFocusTransition("confirm"), true);
+		assert.equal(isFocusTransition("manual"), true);
+		assert.equal(isFocusTransition("other"), false);
+		assert.equal(isFocusTransition(undefined), false);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/focus/guard.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/guard.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import type {
+	ExtensionAPI,
+	ToolCallEvent,
+} from "@earendil-works/pi-coding-agent";
+import { describe, it } from "vitest";
+import { createToolCatalog } from "../tool/catalog";
+import { guardToolCall } from "./guard";
+import { registerBuiltInFocusPolicies } from "./policies";
+import type { FocusController } from "./controller";
+
+function toolCall(toolName: string, input: unknown): ToolCallEvent {
+	return { toolName, input } as ToolCallEvent;
+}
+
+function focus(allowedToolNames: readonly string[]): FocusController {
+	return {
+		current: "edit",
+		active: undefined,
+		allowedToolNames: () => new Set(allowedToolNames),
+	} as unknown as FocusController;
+}
+
+describe("guardToolCall", () => {
+	it("blocks unavailable tools with built-in policy reasons", async () => {
+		const catalog = createToolCatalog();
+		registerBuiltInFocusPolicies(catalog);
+		const guard = guardToolCall({} as ExtensionAPI, focus(["read"]), catalog);
+
+		assert.deepEqual(await guard(toolCall("bash", {}), undefined as never), {
+			block: true,
+			reason: "Running bash commands is disabled in edit focus.",
+		});
+	});
+
+	it("blocks allowed tools when their input targets secrets", async () => {
+		const catalog = createToolCatalog();
+		registerBuiltInFocusPolicies(catalog);
+		const guard = guardToolCall({} as ExtensionAPI, focus(["read"]), catalog);
+
+		assert.deepEqual(
+			await guard(toolCall("read", { path: ".env" }), undefined as never),
+			{
+				block: true,
+				reason: "Reading secret files is disabled in edit focus.",
+			},
+		);
+	});
+
+	it("allows available non-secret tool calls", async () => {
+		const catalog = createToolCatalog();
+		registerBuiltInFocusPolicies(catalog);
+		const guard = guardToolCall({} as ExtensionAPI, focus(["read"]), catalog);
+
+		assert.equal(
+			await guard(toolCall("read", { path: "README.md" }), undefined as never),
+			undefined,
+		);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/focus/prompt.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/prompt.test.ts
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { describe, it } from "vitest";
+import type { SystemReminderRegistry } from "../system-reminder";
+import type { FocusController } from "./controller";
+import {
+	ENTER_FOCUS_TOOL,
+	EXIT_FOCUS_TOOL,
+	type FocusDefinition,
+} from "./definitions";
+import {
+	type FocusReminderDetails,
+	injectFocusRestorePrompt,
+	registerFocusReminderSource,
+} from "./prompt";
+import { createFocusRuntime } from "./runtime";
+
+function activeFocus(
+	overrides: Partial<FocusDefinition> = {},
+): FocusDefinition {
+	return {
+		name: "edit",
+		description: "Edit files",
+		prompt: "Edit prompt",
+		tools: ["read", "write"],
+		transition: "confirm",
+		...overrides,
+	};
+}
+
+function pi(): ExtensionAPI {
+	return {
+		getAllTools: () => [
+			{
+				name: "read",
+				description: "Read files",
+				parameters: { type: "object" },
+			},
+			{
+				name: "write",
+				description: "Write files",
+				parameters: { type: "object" },
+			},
+			{ name: ENTER_FOCUS_TOOL, description: "Enter focus", parameters: {} },
+			{ name: EXIT_FOCUS_TOOL, description: "Exit focus", parameters: {} },
+		],
+	} as unknown as ExtensionAPI;
+}
+
+function focusController(options: {
+	readonly current?: string;
+	readonly active?: FocusDefinition;
+	readonly allowed?: readonly string[];
+}): FocusController {
+	const active = options.active;
+	return {
+		current: options.current ?? active?.name ?? "base",
+		active,
+		allowedToolNames: () =>
+			new Set(options.allowed ?? ["read", ENTER_FOCUS_TOOL]),
+		registry: {
+			search: () => [activeFocus({ name: "explore", description: "Explore" })],
+		},
+	} as unknown as FocusController;
+}
+
+function beforeAgentEvent(systemPrompt: string): {
+	readonly systemPrompt: string;
+	readonly systemPromptOptions: {
+		readonly toolSnippets: Record<string, string>;
+	};
+} {
+	return {
+		systemPrompt,
+		systemPromptOptions: {
+			toolSnippets: {
+				read: "Read files",
+				write: "Write files",
+				[ENTER_FOCUS_TOOL]: "Enter focus",
+				[EXIT_FOCUS_TOOL]: "Exit focus",
+			},
+		},
+	};
+}
+
+const baseSystemPrompt = [
+	"Available tools:",
+	"old tools",
+	"",
+	"In addition to the tools above",
+	"",
+	"Guidelines:",
+	"old guidelines",
+	"",
+	"Pi documentation",
+	"",
+	"The following skills provide specialized instructions for specific tasks.",
+	"<available_skills>",
+	"  <skill />",
+	"</available_skills>",
+].join("\n");
+
+describe("focus prompt injection", () => {
+	it("rewrites visible tools and appends routing instructions in base focus", async () => {
+		const runtime = createFocusRuntime();
+		const result = await injectFocusRestorePrompt(
+			pi(),
+			focusController({ allowed: [ENTER_FOCUS_TOOL] }),
+			runtime,
+		)(beforeAgentEvent(baseSystemPrompt) as never, undefined as never);
+
+		assert.match(result?.systemPrompt ?? "", /- enter_focus: Enter focus/u);
+		assert.doesNotMatch(result?.systemPrompt ?? "", /- read: Read files/u);
+		assert.doesNotMatch(result?.systemPrompt ?? "", /<available_skills>/u);
+		assert.match(result?.systemPrompt ?? "", /\[FOCUS\]/u);
+		assert.match(result?.systemPrompt ?? "", /explore: Explore/u);
+	});
+
+	it("injects restore prompts once for restored active focuses", async () => {
+		const runtime = createFocusRuntime();
+		runtime.setRestorePromptPending(true);
+		const focus = focusController({ active: activeFocus(), allowed: ["read"] });
+
+		const first = await injectFocusRestorePrompt(
+			pi(),
+			focus,
+			runtime,
+		)(beforeAgentEvent(baseSystemPrompt) as never, undefined as never);
+		const second = await injectFocusRestorePrompt(
+			pi(),
+			focus,
+			runtime,
+		)(beforeAgentEvent(baseSystemPrompt) as never, undefined as never);
+
+		assert.match(first?.systemPrompt ?? "", /\[FOCUS RESTORED: edit\]/u);
+		assert.match(second?.systemPrompt ?? "", /\[ACTIVE FOCUS: edit\]/u);
+		assert.doesNotMatch(second?.systemPrompt ?? "", /\[FOCUS RESTORED/u);
+	});
+
+	it("builds current reminder payloads and rejects stale reminder details", () => {
+		const runtime = createFocusRuntime();
+		const transition = runtime.recordFocusChange("edit");
+		runtime.requestFocusReminder();
+		const registered: Parameters<SystemReminderRegistry["register"]>[0][] = [];
+		const reminders = {
+			register: (source: Parameters<SystemReminderRegistry["register"]>[0]) => {
+				registered.push(source);
+				return { sendWakeup: () => undefined };
+			},
+		} as unknown as SystemReminderRegistry;
+
+		registerFocusReminderSource(
+			pi(),
+			focusController({ active: activeFocus(), allowed: ["read"] }),
+			runtime,
+			reminders,
+		);
+		const source = registered[0] as unknown as {
+			consumePending: () => boolean;
+			isCurrent: (details: unknown, message: never) => boolean;
+			buildReminder: () => {
+				content: string;
+				details: FocusReminderDetails;
+			};
+		};
+		const payload = source.buildReminder();
+
+		assert.equal(source.consumePending(), true);
+		assert.equal(source.consumePending(), false);
+		assert.equal(
+			source.isCurrent({ transitionId: transition.id }, undefined as never),
+			true,
+		);
+		assert.equal(
+			source.isCurrent({ transitionId: transition.id - 1 }, undefined as never),
+			false,
+		);
+		assert.equal(payload.details.focus, "edit");
+		assert.match(payload.content, /\[ACTIVE FOCUS: edit\]/u);
+		assert.match(payload.content, /"name": "read"/u);
+		assert.doesNotMatch(payload.content, /"name": "write"/u);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/focus/registry.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/registry.test.ts
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { createTestPiProject } from "../test-support/pi-project";
+import { loadFocusRegistry } from "./registry";
+
+function testProjectCwd(settings: Record<string, unknown>): string {
+	return createTestPiProject({ settings }).cwd;
+}
+
+describe("loadFocusRegistry", () => {
+	it("merges project settings into existing focuses without changing transition security", () => {
+		const cwd = testProjectCwd({
+			toolSets: {
+				verify: ["lint", "test", "lint"],
+				all_verify: ["verify", "coverage"],
+			},
+			focuses: {
+				edit: {
+					description: "Project edit focus",
+					prompt: "Project-specific edit instructions.",
+					exitPrompt: "Project exit instructions.",
+					tools: ["format", "lint"],
+					toolSets: ["all_verify"],
+					transition: "auto",
+					color: "caution",
+				},
+			},
+		});
+
+		const { registry, warnings } = loadFocusRegistry(cwd);
+		const edit = registry.get("edit");
+
+		assert.deepEqual(warnings, []);
+		assert.equal(edit?.description, "Project edit focus");
+		assert.match(edit?.prompt ?? "", /Make focused file changes/u);
+		assert.match(edit?.prompt ?? "", /Project-specific edit instructions/u);
+		assert.equal(edit?.exitPrompt, "Project exit instructions.");
+		assert.equal(edit?.transition, "confirm");
+		assert.equal(edit?.color, "caution");
+		assert.deepEqual(edit?.settingsTools, [
+			"lint",
+			"test",
+			"coverage",
+			"format",
+		]);
+		for (const tool of [
+			"read",
+			"write",
+			"edit",
+			"lint",
+			"test",
+			"coverage",
+			"format",
+		]) {
+			assert.ok(edit?.tools.includes(tool), `edit tools include ${tool}`);
+		}
+	});
+
+	it("creates new project focuses with safe defaults", () => {
+		const cwd = testProjectCwd({
+			toolSets: { verify: ["lint", "test"] },
+			focuses: {
+				ci: {
+					description: "Run CI checks",
+					prompt: "Use CI tools only.",
+					toolSets: ["verify"],
+					exitMode: "explicit",
+					color: "positive",
+				},
+			},
+		});
+
+		const { registry, warnings } = loadFocusRegistry(cwd);
+		const ci = registry.get("ci");
+
+		assert.deepEqual(warnings, []);
+		assert.equal(ci?.transition, "confirm");
+		assert.equal(ci?.exitMode, "explicit");
+		assert.equal(ci?.color, "positive");
+		assert.deepEqual(ci?.tools, ["lint", "test"]);
+		assert.deepEqual(ci?.settingsTools, ["lint", "test"]);
+	});
+
+	it("reports invalid project focus settings without dropping base focuses", () => {
+		const cwd = testProjectCwd({
+			toolSets: {
+				bad_cycle_a: ["bad_cycle_b"],
+				bad_cycle_b: ["bad_cycle_a"],
+				Invalid: ["lint"],
+			},
+			focuses: {
+				needs_prompt: {
+					description: "Missing prompt",
+					tools: ["lint"],
+				},
+				bad_tools: {
+					description: "Bad tools",
+					prompt: "Bad tools",
+					tools: [""],
+				},
+				cycle: {
+					description: "Cycle",
+					prompt: "Cycle",
+					toolSets: ["bad_cycle_a"],
+				},
+				unknown: {
+					description: "Unknown",
+					prompt: "Unknown",
+					toolSets: ["missing"],
+				},
+			},
+		});
+
+		const { registry, warnings } = loadFocusRegistry(cwd);
+
+		assert.ok(registry.get("edit"));
+		assert.equal(registry.get("needs_prompt"), undefined);
+		assert.equal(registry.get("bad_tools"), undefined);
+		assert.equal(registry.get("cycle"), undefined);
+		assert.equal(registry.get("unknown"), undefined);
+		assert.equal(warnings.length, 5);
+		assert.match(warnings.join("\n"), /Invalid toolSet name 'Invalid'/u);
+		assert.match(warnings.join("\n"), /needs_prompt\.prompt is required/u);
+		assert.match(warnings.join("\n"), /bad_tools\.tools\[0\]/u);
+		assert.match(warnings.join("\n"), /Circular toolSet reference/u);
+		assert.match(warnings.join("\n"), /Unknown toolSet 'missing'/u);
+	});
+
+	it("can skip project settings and interactive-only focuses", () => {
+		const cwd = testProjectCwd({
+			focuses: {
+				ci: {
+					description: "Run CI checks",
+					prompt: "Use CI tools only.",
+					tools: ["lint"],
+				},
+			},
+		});
+
+		const { registry } = loadFocusRegistry(cwd, {
+			includeProject: false,
+			includeInteractive: false,
+		});
+
+		assert.equal(registry.get("ci"), undefined);
+		assert.equal(registry.get("interview"), undefined);
+		assert.equal(registry.get("edit")?.name, "edit");
+	});
+
+	it("searches non-manual focuses by name and description", () => {
+		const cwd = testProjectCwd({
+			focuses: {
+				ci: {
+					description: "Run project pipeline verification",
+					prompt: "Use CI tools only.",
+					tools: ["lint"],
+				},
+			},
+		});
+		const { registry } = loadFocusRegistry(cwd);
+
+		assert.deepEqual(
+			registry.search("pipeline").map((focus) => focus.name),
+			["ci"],
+		);
+		assert.equal(
+			registry.search().some((focus) => focus.name === "yolo"),
+			false,
+		);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/focus/runtime.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/runtime.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { BASE_FOCUS } from "./definitions";
+import { createFocusRuntime } from "./runtime";
+
+describe("createFocusRuntime", () => {
+	it("tracks reminder flags independently and consumes pending reminders", () => {
+		const runtime = createFocusRuntime();
+
+		assert.equal(runtime.restorePromptPending, false);
+		assert.equal(runtime.consumeFocusReminderPending(), false);
+
+		runtime.setRestorePromptPending(true);
+		runtime.requestFocusReminder();
+		runtime.setResetFocusAtAgentEndPending(true);
+		runtime.setUserSelectedFocus(true);
+
+		assert.equal(runtime.restorePromptPending, true);
+		assert.equal(runtime.focusReminderPending, true);
+		assert.equal(runtime.resetFocusAtAgentEndPending, true);
+		assert.equal(runtime.userSelectedFocus, true);
+		assert.equal(runtime.consumeFocusReminderPending(), true);
+		assert.equal(runtime.consumeFocusReminderPending(), false);
+	});
+
+	it("uses transition ids to reject stale auto-continue wakeups", () => {
+		const runtime = createFocusRuntime();
+
+		const first = runtime.recordFocusChange("edit");
+		const second = runtime.scheduleAutoContinue("explore");
+
+		assert.deepEqual(first, { id: 1, focusName: "edit" });
+		assert.deepEqual(runtime.latestTransition, second);
+		assert.equal(runtime.pendingAutoContinue, second);
+		assert.equal(runtime.isCurrentTransition(first.id), false);
+		assert.equal(runtime.isCurrentTransition(second.id), true);
+		assert.equal(runtime.isCurrentTransition(undefined), true);
+		assert.deepEqual(runtime.consumeAutoContinue(), second);
+		assert.equal(runtime.consumeAutoContinue(), undefined);
+	});
+
+	it("can cancel pending auto-continue without changing the latest transition", () => {
+		const runtime = createFocusRuntime();
+		const transition = runtime.scheduleAutoContinue(BASE_FOCUS);
+
+		runtime.cancelAutoContinue();
+
+		assert.equal(runtime.pendingAutoContinue, undefined);
+		assert.deepEqual(runtime.latestTransition, transition);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/focus/tool-access.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/tool-access.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { describe, it } from "vitest";
+import {
+	ENTER_FOCUS_TOOL,
+	EXIT_FOCUS_TOOL,
+	type FocusDefinition,
+} from "./definitions";
+import {
+	activateBaseFocusTools,
+	activateFocusTools,
+	getActiveFocusTools,
+	getBaseFocusTools,
+} from "./tool-access";
+
+function pi(
+	names: readonly string[],
+): ExtensionAPI & { activeTools: string[] } {
+	const api = {
+		activeTools: [] as string[],
+		getAllTools: () => names.map((name) => ({ name })),
+		setActiveTools: (tools: string[]) => {
+			api.activeTools = tools;
+		},
+	};
+	return api as unknown as ExtensionAPI & { activeTools: string[] };
+}
+
+function focus(overrides: Partial<FocusDefinition> = {}): FocusDefinition {
+	return {
+		name: "edit",
+		description: "Edit files",
+		prompt: "Edit files",
+		tools: ["read", "write", ENTER_FOCUS_TOOL, EXIT_FOCUS_TOOL],
+		transition: "confirm",
+		...overrides,
+	};
+}
+
+describe("focus tool access", () => {
+	it("base focus exposes only always-allowed and enter_focus when registered", () => {
+		const api = pi(["read", "multi_tool_use.parallel", ENTER_FOCUS_TOOL]);
+
+		assert.deepEqual(getBaseFocusTools(api), [
+			"multi_tool_use.parallel",
+			ENTER_FOCUS_TOOL,
+		]);
+		assert.deepEqual(activateBaseFocusTools(api), [
+			"multi_tool_use.parallel",
+			ENTER_FOCUS_TOOL,
+		]);
+		assert.deepEqual(api.activeTools, [
+			"multi_tool_use.parallel",
+			ENTER_FOCUS_TOOL,
+		]);
+	});
+
+	it("active single-turn focuses get declared tools plus enter_focus", () => {
+		const api = pi([
+			"read",
+			"write",
+			"missing",
+			"multi_tool_use.parallel",
+			ENTER_FOCUS_TOOL,
+			EXIT_FOCUS_TOOL,
+		]);
+
+		assert.deepEqual(getActiveFocusTools(api, focus()), [
+			"multi_tool_use.parallel",
+			"read",
+			"write",
+			ENTER_FOCUS_TOOL,
+		]);
+	});
+
+	it("explicit-exit focuses expose exit_focus instead of enter_focus", () => {
+		const api = pi([
+			"read",
+			"multi_tool_use.parallel",
+			ENTER_FOCUS_TOOL,
+			EXIT_FOCUS_TOOL,
+		]);
+
+		assert.deepEqual(
+			activateFocusTools(api, focus({ exitMode: "explicit", tools: ["read"] })),
+			["multi_tool_use.parallel", "read", EXIT_FOCUS_TOOL],
+		);
+		assert.deepEqual(api.activeTools, [
+			"multi_tool_use.parallel",
+			"read",
+			EXIT_FOCUS_TOOL,
+		]);
+	});
+
+	it("falls back to base tools when no focus is active", () => {
+		const api = pi(["multi_tool_use.parallel", ENTER_FOCUS_TOOL]);
+
+		assert.deepEqual(activateFocusTools(api, undefined), [
+			"multi_tool_use.parallel",
+			ENTER_FOCUS_TOOL,
+		]);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/focus/tool.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/tool.test.ts
@@ -1,0 +1,282 @@
+import assert from "node:assert/strict";
+import type {
+	AgentToolResult,
+	ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { describe, it } from "vitest";
+import { createToolCatalog } from "../tool/catalog";
+import type { FocusController } from "./controller";
+import { BASE_FOCUS, type FocusDefinition } from "./definitions";
+import { rememberFocusTransitionDecision } from "./confirmation";
+import { createFocusRuntime } from "./runtime";
+import { registerEnterFocusTool, registerExitFocusTool } from "./tool";
+
+type FocusToolDefinition = {
+	execute: (
+		toolCallId: string,
+		params: Record<string, string | undefined>,
+		signal: AbortSignal | undefined,
+		onUpdate: undefined,
+		ctx: ExtensionContext,
+	) => Promise<AgentToolResult<Record<string, unknown>>>;
+};
+
+function definition(overrides: Partial<FocusDefinition> = {}): FocusDefinition {
+	return {
+		name: "explore",
+		description: "Explore files",
+		prompt: "Explore prompt",
+		tools: ["read"],
+		transition: "auto",
+		...overrides,
+	};
+}
+
+function context(hasUI = false): ExtensionContext {
+	return { hasUI } as ExtensionContext;
+}
+
+function resultText(result: AgentToolResult<Record<string, unknown>>): string {
+	const content = result.content[0];
+	return content?.type === "text" ? content.text : "";
+}
+
+function focusController(options: {
+	readonly current?: string;
+	readonly active?: FocusDefinition;
+	readonly definitions?: readonly FocusDefinition[];
+}): FocusController & {
+	readonly entered: string[];
+	readonly left: string[];
+} {
+	let current = options.current ?? options.active?.name ?? BASE_FOCUS;
+	let active = options.active;
+	const definitions = options.definitions ?? [definition()];
+	const entered: string[] = [];
+	const left: string[] = [];
+	return {
+		entered,
+		left,
+		get current() {
+			return current;
+		},
+		get active() {
+			return active;
+		},
+		registry: {
+			get: (name: string) => definitions.find((focus) => focus.name === name),
+			list: () => definitions,
+			search: () => definitions,
+		},
+		enter: (_ctx: ExtensionContext, name: string) => {
+			const next = definitions.find((focus) => focus.name === name);
+			if (!next) throw new Error(`Unknown focus: ${name}`);
+			entered.push(name);
+			current = next.name;
+			active = next;
+			return next;
+		},
+		leave: () => {
+			const previous = active;
+			left.push(previous?.name ?? BASE_FOCUS);
+			current = BASE_FOCUS;
+			active = undefined;
+			return previous;
+		},
+	} as unknown as FocusController & {
+		readonly entered: string[];
+		readonly left: string[];
+	};
+}
+
+function registerEnter(
+	focus: FocusController,
+	runtime = createFocusRuntime(),
+): FocusToolDefinition {
+	const catalog = createToolCatalog();
+	registerEnterFocusTool(focus, runtime, catalog);
+	return catalog.list()[0]?.definition as unknown as FocusToolDefinition;
+}
+
+function registerExit(
+	focus: FocusController,
+	runtime = createFocusRuntime(),
+): FocusToolDefinition {
+	const catalog = createToolCatalog();
+	registerExitFocusTool(focus, runtime, catalog);
+	return catalog.list()[0]?.definition as unknown as FocusToolDefinition;
+}
+
+describe("focus management tools", () => {
+	it("reports unknown focuses with enterable alternatives only", async () => {
+		const tool = registerEnter(
+			focusController({
+				definitions: [
+					definition({ name: "explore", transition: "auto" }),
+					definition({ name: "yolo", transition: "manual" }),
+				],
+			}),
+		);
+
+		const result = await tool.execute(
+			"call",
+			{ name: "missing" },
+			undefined,
+			undefined,
+			context(),
+		);
+
+		assert.equal(result.details.ok, false);
+		assert.equal(result.details.reason, "unknown-focus");
+		assert.deepEqual(result.details.availableFocuses, ["explore"]);
+		assert.match(resultText(result), /Unknown focus 'missing'/u);
+	});
+
+	it("blocks manual focuses and explicit-exit focus switches", async () => {
+		const manualTool = registerEnter(
+			focusController({
+				definitions: [definition({ name: "yolo", transition: "manual" })],
+			}),
+		);
+		const manual = await manualTool.execute(
+			"call",
+			{ name: "yolo" },
+			undefined,
+			undefined,
+			context(),
+		);
+		assert.equal(manual.details.reason, "manual-only");
+
+		const active = definition({
+			name: "interview",
+			exitMode: "explicit",
+			transition: "auto",
+		});
+		const switchTool = registerEnter(
+			focusController({
+				current: "interview",
+				active,
+				definitions: [active, definition({ name: "explore" })],
+			}),
+		);
+		const blocked = await switchTool.execute(
+			"call",
+			{ name: "explore" },
+			undefined,
+			undefined,
+			context(),
+		);
+		assert.equal(blocked.details.reason, "explicit-exit-required");
+	});
+
+	it("requires reasons and UI for confirm focuses unless session-allowed", async () => {
+		const confirm = definition({ name: "edit", transition: "confirm" });
+		const focus = focusController({ definitions: [confirm] });
+		const tool = registerEnter(focus);
+
+		const missingReason = await tool.execute(
+			"call",
+			{ name: "edit" },
+			undefined,
+			undefined,
+			context(),
+		);
+		const noUi = await tool.execute(
+			"call",
+			{ name: "edit", reason: "Need edits" },
+			undefined,
+			undefined,
+			context(false),
+		);
+		rememberFocusTransitionDecision("edit", "allow-session");
+		const allowed = await tool.execute(
+			"call",
+			{ name: "edit" },
+			undefined,
+			undefined,
+			context(),
+		);
+
+		assert.equal(missingReason.details.reason, "reason-required");
+		assert.equal(noUi.details.reason, "confirmation-unavailable");
+		assert.equal(allowed.details.ok, true);
+		assert.equal(allowed.terminate, true);
+		assert.deepEqual(focus.entered, ["edit"]);
+	});
+
+	it("enters auto focuses and schedules auto-continue", async () => {
+		const runtime = createFocusRuntime();
+		const focus = focusController({
+			definitions: [definition({ name: "explore" })],
+		});
+		const tool = registerEnter(focus, runtime);
+
+		const result = await tool.execute(
+			"call",
+			{ name: "explore" },
+			undefined,
+			undefined,
+			context(),
+		);
+
+		assert.equal(result.details.ok, true);
+		assert.equal(result.details.focus, "explore");
+		assert.equal(result.terminate, true);
+		assert.equal(runtime.pendingAutoContinue?.focusName, "explore");
+		assert.match(resultText(result), /Entered focus 'explore'/u);
+	});
+
+	it("exits base and active focuses with runtime handoff", async () => {
+		const baseTool = registerExit(focusController({}));
+		const base = await baseTool.execute(
+			"call",
+			{ reason: "done" },
+			undefined,
+			undefined,
+			context(),
+		);
+		assert.equal(base.details.reason, "already-base");
+
+		const runtime = createFocusRuntime();
+		const focus = focusController({
+			current: "explore",
+			active: definition({ name: "explore", exitPrompt: "Exit prompt" }),
+		});
+		const exitTool = registerExit(focus, runtime);
+		const exited = await exitTool.execute(
+			"call",
+			{ reason: "done" },
+			undefined,
+			undefined,
+			context(),
+		);
+
+		assert.equal(exited.details.ok, true);
+		assert.equal(exited.details.previous, "explore");
+		assert.equal(exited.details.exitPrompt, "Exit prompt");
+		assert.equal(exited.terminate, true);
+		assert.equal(runtime.pendingAutoContinue?.focusName, BASE_FOCUS);
+		assert.deepEqual(focus.left, ["explore"]);
+	});
+
+	it("blocks explicit focus exits when UI confirmation is unavailable", async () => {
+		const active = definition({
+			name: "interview",
+			exitMode: "explicit",
+		});
+		const tool = registerExit(
+			focusController({ current: "interview", active, definitions: [active] }),
+		);
+
+		const result = await tool.execute(
+			"call",
+			{ reason: "done" },
+			undefined,
+			undefined,
+			context(false),
+		);
+
+		assert.equal(result.details.ok, false);
+		assert.equal(result.details.reason, "confirmation-unavailable");
+	});
+});

--- a/files/pi/agent/extensions/user/lib/math.test.ts
+++ b/files/pi/agent/extensions/user/lib/math.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { clamp } from "./math";
+
+describe("clamp", () => {
+	it("keeps values inside the inclusive range", () => {
+		assert.equal(clamp(2, 1, 3), 2);
+		assert.equal(clamp(0, 1, 3), 1);
+		assert.equal(clamp(4, 1, 3), 3);
+	});
+
+	it("prefers the minimum when max is lower than min", () => {
+		assert.equal(clamp(0, 5, 3), 5);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/policy.test.ts
+++ b/files/pi/agent/extensions/user/lib/policy.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { makeSecretActionReason } from "./policy";
+
+describe("makeSecretActionReason", () => {
+	it("formats focus-specific secret action reasons", () => {
+		assert.equal(
+			makeSecretActionReason("Reading")("explore"),
+			"Reading secret files is disabled in explore focus.",
+		);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/project-settings.test.ts
+++ b/files/pi/agent/extensions/user/lib/project-settings.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { describe, it } from "vitest";
+import { createTestPiProject } from "./test-support/pi-project";
+import {
+	ensureProjectUserSettingsTrusted,
+	hasProjectUserSettings,
+	isProjectUserSettingsTrusted,
+	loadProjectUserSettings,
+} from "./project-settings";
+
+function context(
+	cwd: string,
+	overrides: Partial<{
+		readonly trusted: boolean;
+		readonly hasUI: boolean;
+		readonly selected: string;
+		readonly notifications: string[];
+	}> = {},
+): ExtensionContext {
+	const notifications = overrides.notifications ?? [];
+	return {
+		cwd,
+		hasUI: overrides.hasUI ?? false,
+		isProjectTrusted: () => overrides.trusted ?? true,
+		ui: {
+			select: async () => overrides.selected ?? "Trust (this session only)",
+			notify: (message: string) => notifications.push(message),
+		},
+	} as unknown as ExtensionContext;
+}
+
+function withArgv<T>(argv: readonly string[], fn: () => T): T {
+	const original = process.argv;
+	process.argv = [original[0] ?? "node", original[1] ?? "pi", ...argv];
+	try {
+		return fn();
+	} finally {
+		process.argv = original;
+	}
+}
+
+describe("project user settings", () => {
+	it("loads the project user settings file only when it is a JSON object", () => {
+		const missing = createTestPiProject({ includeUserSettings: false }).cwd;
+		assert.equal(hasProjectUserSettings(missing), false);
+		assert.deepEqual(loadProjectUserSettings(missing), {});
+
+		const valid = createTestPiProject({
+			settings: { tools: { test: {} } },
+		}).cwd;
+		assert.equal(hasProjectUserSettings(valid), true);
+		assert.deepEqual(loadProjectUserSettings(valid), { tools: { test: {} } });
+
+		const invalid = createTestPiProject({
+			rawSettings: JSON.stringify([]),
+		}).cwd;
+		assert.throws(
+			() => loadProjectUserSettings(invalid),
+			/settings\.user\.json must contain a JSON object/u,
+		);
+	});
+
+	it("requires project trust before considering user settings trusted", () => {
+		const cwd = createTestPiProject({ settings: { tools: {} } }).cwd;
+
+		assert.equal(
+			isProjectUserSettingsTrusted(context(cwd, { trusted: false })),
+			false,
+		);
+	});
+
+	it("honors CLI trust overrides before saved or session trust", () => {
+		const cwd = createTestPiProject({ settings: { tools: {} } }).cwd;
+
+		withArgv(["--approve"], () => {
+			assert.equal(isProjectUserSettingsTrusted(context(cwd)), true);
+		});
+		withArgv(["--no-approve"], () => {
+			assert.equal(isProjectUserSettingsTrusted(context(cwd)), false);
+		});
+		withArgv(["--", "--approve"], () => {
+			assert.equal(isProjectUserSettingsTrusted(context(cwd)), false);
+		});
+	});
+
+	it("records UI session trust decisions for settings.user-only projects", async () => {
+		const cwd = createTestPiProject({ settings: { tools: {} } }).cwd;
+		const ctx = context(cwd, {
+			hasUI: true,
+			selected: "Trust (this session only)",
+		});
+
+		assert.equal(isProjectUserSettingsTrusted(ctx), false);
+		await ensureProjectUserSettingsTrusted(ctx);
+		assert.equal(isProjectUserSettingsTrusted(ctx), true);
+	});
+
+	it("does not prompt when there is no project user settings file", async () => {
+		const cwd = createTestPiProject({ includeUserSettings: false }).cwd;
+		let prompted = false;
+		const ctx = {
+			cwd,
+			hasUI: true,
+			isProjectTrusted: () => true,
+			ui: {
+				select: async () => {
+					prompted = true;
+					return "Trust";
+				},
+				notify: () => undefined,
+			},
+		} as unknown as ExtensionContext;
+
+		await ensureProjectUserSettingsTrusted(ctx);
+
+		assert.equal(prompted, false);
+		assert.equal(isProjectUserSettingsTrusted(ctx), true);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/secrets.test.ts
+++ b/files/pi/agent/extensions/user/lib/secrets.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { isSecretPath } from "./secrets";
+
+describe("isSecretPath", () => {
+	it("matches dotenv-style secret files", () => {
+		assert.equal(isSecretPath(".env"), true);
+		assert.equal(isSecretPath("config/.env.local"), true);
+		assert.equal(isSecretPath("subdir/.envrc"), true);
+	});
+
+	it("does not match non-secret lookalikes", () => {
+		assert.equal(isSecretPath("env"), false);
+		assert.equal(isSecretPath(".environment"), false);
+		assert.equal(isSecretPath(".env/example"), false);
+		assert.equal(isSecretPath("README.md"), false);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/services.test.ts
+++ b/files/pi/agent/extensions/user/lib/services.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { BASE_FOCUS } from "./focus/definitions";
+import { createUserExtensionServices } from "./services";
+
+describe("createUserExtensionServices", () => {
+	it("creates independent focus, reminder, and tool services", () => {
+		const services = createUserExtensionServices();
+
+		assert.equal(services.focus.currentFocusName, BASE_FOCUS);
+		assert.equal(services.focus.activeFocusDefinition, undefined);
+		assert.equal(typeof services.reminders.inject, "function");
+		assert.deepEqual(services.tools.list(), []);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/status/format.test.ts
+++ b/files/pi/agent/extensions/user/lib/status/format.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import {
+	formatCount,
+	formatCwd,
+	formatPercent,
+	pickRemainingColor,
+} from "./format";
+import { colors } from "../theme";
+
+describe("status format helpers", () => {
+	it("formats counts with compact suffixes", () => {
+		assert.equal(formatCount(-1), "0");
+		assert.equal(formatCount(Number.NaN), "0");
+		assert.equal(formatCount(999.6), "1000");
+		assert.equal(formatCount(1_250), "1.3K");
+		assert.equal(formatCount(12_500), "13K");
+		assert.equal(formatCount(1_250_000), "1.3M");
+		assert.equal(formatCount(12_500_000), "13M");
+	});
+
+	it("formats percents with one decimal place", () => {
+		assert.equal(formatPercent(12), "12.0%");
+		assert.equal(formatPercent(12.34), "12.3%");
+	});
+
+	it("keeps cwd labels short", () => {
+		assert.equal(formatCwd("/tmp/example-project"), "example-project");
+		assert.equal(formatCwd("/"), "/");
+	});
+
+	it("selects remaining-context colors by threshold", () => {
+		assert.equal(pickRemainingColor(50), colors.positive);
+		assert.equal(pickRemainingColor(49.9), colors.caution);
+		assert.equal(pickRemainingColor(20), colors.caution);
+		assert.equal(pickRemainingColor(19.9), colors.alert);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/status/render-trigger.test.ts
+++ b/files/pi/agent/extensions/user/lib/status/render-trigger.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { createRenderTrigger } from "./render-trigger";
+
+describe("createRenderTrigger", () => {
+	it("triggers the current render callback", () => {
+		const trigger = createRenderTrigger();
+		let calls = 0;
+
+		trigger.trigger();
+		trigger.set(() => calls++);
+		trigger.trigger();
+		trigger.set(() => (calls += 10));
+		trigger.trigger();
+		trigger.set(undefined);
+		trigger.trigger();
+
+		assert.equal(calls, 11);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/status/usage.test.ts
+++ b/files/pi/agent/extensions/user/lib/status/usage.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import type { SessionEntry } from "@earendil-works/pi-coding-agent";
+import { describe, it } from "vitest";
+import { getAssistantTotals } from "./usage";
+
+describe("getAssistantTotals", () => {
+	it("sums assistant usage and ignores other entries", () => {
+		const entries = [
+			{ type: "message", message: { role: "user" } },
+			{ type: "tool-call" },
+			{ type: "message", message: { role: "assistant" } },
+			{
+				type: "message",
+				message: {
+					role: "assistant",
+					usage: { input: 10, output: 20, cost: { total: 0.125 } },
+				},
+			},
+			{
+				type: "message",
+				message: {
+					role: "assistant",
+					usage: { input: 2, output: undefined, cost: {} },
+				},
+			},
+		] as unknown as SessionEntry[];
+
+		assert.deepEqual(getAssistantTotals(entries), {
+			input: 12,
+			output: 20,
+			cost: 0.125,
+		});
+	});
+});

--- a/files/pi/agent/extensions/user/lib/system-reminder.test.ts
+++ b/files/pi/agent/extensions/user/lib/system-reminder.test.ts
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import type {
+	ContextEvent,
+	ExtensionAPI,
+} from "@earendil-works/pi-coding-agent";
+import { afterEach, describe, it, vi } from "vitest";
+import { createSystemReminderRegistry } from "./system-reminder";
+
+type ContextMessage = ContextEvent["messages"][number];
+
+function context(messages: readonly ContextMessage[]): ContextEvent {
+	return { messages } as ContextEvent;
+}
+
+describe("createSystemReminderRegistry", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("creates wrapped hidden reminder messages", () => {
+		const registry = createSystemReminderRegistry();
+		const reminder = registry.register<{ id: number }>({
+			customType: "demo-reminder",
+			buildReminder: () => undefined,
+		});
+
+		assert.deepEqual(reminder.createMessage({ content: "hello" }), {
+			customType: "demo-reminder",
+			content: "<system-reminder>\nhello\n</system-reminder>",
+			display: false,
+		});
+		assert.deepEqual(
+			registry.createMessage("demo-reminder", {
+				content: ["line one", "line two"],
+				details: { id: 1 },
+			}),
+			{
+				customType: "demo-reminder",
+				content: "<system-reminder>\nline one\nline two\n</system-reminder>",
+				display: false,
+				details: { id: 1 },
+			},
+		);
+	});
+
+	it("rejects duplicate and unknown sources", () => {
+		const registry = createSystemReminderRegistry();
+		registry.register({
+			customType: "demo-reminder",
+			buildReminder: () => undefined,
+		});
+
+		assert.throws(
+			() =>
+				registry.register({
+					customType: "demo-reminder",
+					buildReminder: () => undefined,
+				}),
+			/Duplicate system reminder source/u,
+		);
+		assert.throws(
+			() => registry.request("missing-reminder"),
+			/Unknown system reminder source/u,
+		);
+	});
+
+	it("injects requested reminders and keeps unrelated messages", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-02T03:04:05Z"));
+		const registry = createSystemReminderRegistry();
+		const reminder = registry.register<{ state: string }>({
+			customType: "demo-reminder",
+			buildReminder: () => ({
+				content: "fresh reminder",
+				details: { state: "current" },
+			}),
+		});
+		const userMessage = { role: "user", content: "hello" } as ContextMessage;
+
+		reminder.request();
+		const result = await registry.inject(
+			context([userMessage]),
+			undefined as never,
+		);
+
+		assert.deepEqual(result?.messages, [
+			userMessage,
+			{
+				role: "custom",
+				customType: "demo-reminder",
+				content: "<system-reminder>\nfresh reminder\n</system-reminder>",
+				display: false,
+				details: { state: "current" },
+				timestamp: Date.now(),
+			},
+		]);
+	});
+
+	it("refreshes current stored reminders", async () => {
+		const registry = createSystemReminderRegistry();
+		registry.register<{ id: number }>({
+			customType: "demo-reminder",
+			isCurrent: (details) =>
+				typeof details === "object" &&
+				details !== null &&
+				(details as { id?: unknown }).id === 1,
+			buildReminder: () => ({
+				content: "current reminder",
+				details: { id: 1 },
+			}),
+		});
+		const stored = {
+			role: "custom",
+			customType: "demo-reminder",
+			content: "old",
+			display: false,
+			details: { id: 1 },
+			timestamp: 1,
+		} as ContextMessage;
+		const unrelated = {
+			role: "custom",
+			customType: "other-reminder",
+			content: "keep me",
+		} as ContextMessage;
+
+		const result = await registry.inject(
+			context([stored, unrelated]),
+			undefined as never,
+		);
+
+		assert.equal(result?.messages?.[0], unrelated);
+		assert.deepEqual(result?.messages?.[1], {
+			role: "custom",
+			customType: "demo-reminder",
+			content: "<system-reminder>\ncurrent reminder\n</system-reminder>",
+			display: false,
+			details: { id: 1 },
+			timestamp: result?.messages?.[1]?.timestamp,
+		});
+	});
+
+	it("replaces obsolete wakeups with stale reminders", async () => {
+		const registry = createSystemReminderRegistry();
+		registry.register({
+			customType: "demo-reminder",
+			isCurrent: () => false,
+			buildReminder: () => ({ content: "should not be used" }),
+		});
+		const stored = {
+			role: "custom",
+			customType: "demo-reminder",
+			content: "old",
+			display: false,
+			timestamp: 1,
+		} as ContextMessage;
+
+		const result = await registry.inject(context([stored]), undefined as never);
+
+		const [message] = result?.messages ?? [];
+		assert.match(
+			(message as { content?: string }).content ?? "",
+			/obsolete system reminder wakeup/u,
+		);
+		assert.deepEqual((message as { details?: unknown }).details, {
+			stale: true,
+			customType: "demo-reminder",
+		});
+	});
+
+	it("sends wakeups through the extension api", () => {
+		const registry = createSystemReminderRegistry();
+		const reminder = registry.register({
+			customType: "demo-reminder",
+			buildReminder: () => undefined,
+		});
+		const calls: unknown[] = [];
+		const pi = {
+			sendMessage: (message: unknown, options: unknown) => {
+				calls.push([message, options]);
+				return Promise.resolve();
+			},
+		} as unknown as ExtensionAPI;
+
+		reminder.sendWakeup(pi, { content: "wake up" }, { triggerTurn: false });
+
+		assert.deepEqual(calls, [
+			[
+				{
+					customType: "demo-reminder",
+					content: "<system-reminder>\nwake up\n</system-reminder>",
+					display: false,
+				},
+				{ triggerTurn: false },
+			],
+		]);
+	});
+
+	it("returns undefined when no messages change", async () => {
+		const registry = createSystemReminderRegistry();
+		registry.register({
+			customType: "demo-reminder",
+			buildReminder: () => ({ content: "not pending" }),
+		});
+
+		assert.equal(
+			await registry.inject(context([]), undefined as never),
+			undefined,
+		);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/test-support/pi-project.ts
+++ b/files/pi/agent/extensions/user/lib/test-support/pi-project.ts
@@ -1,0 +1,54 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { PROJECT_USER_SETTINGS_RELATIVE_PATH } from "../project-settings";
+
+export type TestPiProject = {
+	readonly cwd: string;
+	readonly userSettingsPath: string;
+	readonly notifications: string[];
+};
+
+export function createTestPiProject(options?: {
+	readonly settings?: Record<string, unknown>;
+	readonly rawSettings?: string;
+	readonly includeUserSettings?: boolean;
+	readonly includeStandardPiConfig?: boolean;
+}): TestPiProject {
+	const cwd = join(tmpdir(), `pi-user-extension-test-${randomUUID()}`);
+	const userSettingsPath = join(cwd, PROJECT_USER_SETTINGS_RELATIVE_PATH);
+	const notifications: string[] = [];
+	mkdirSync(cwd, { recursive: true });
+
+	if (options?.includeStandardPiConfig) {
+		writeProjectFile(cwd, ".pi/settings.json", "{}\n");
+	}
+
+	const shouldWriteUserSettings = options?.includeUserSettings ?? true;
+	if (shouldWriteUserSettings) {
+		writeProjectFile(
+			cwd,
+			PROJECT_USER_SETTINGS_RELATIVE_PATH,
+			options?.rawSettings ??
+				JSON.stringify(options?.settings ?? {}, undefined, 2),
+		);
+	}
+
+	return { cwd, userSettingsPath, notifications };
+}
+
+export function readTestPiProjectUserSettings(
+	project: TestPiProject,
+): Record<string, unknown> {
+	return JSON.parse(readFileSync(project.userSettingsPath, "utf8")) as Record<
+		string,
+		unknown
+	>;
+}
+
+function writeProjectFile(cwd: string, path: string, content: string): void {
+	const absolutePath = join(cwd, path);
+	mkdirSync(dirname(absolutePath), { recursive: true });
+	writeFileSync(absolutePath, content);
+}

--- a/files/pi/agent/extensions/user/lib/tool/catalog.test.ts
+++ b/files/pi/agent/extensions/user/lib/tool/catalog.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import type {
+	ToolCallEvent,
+	ToolDefinition,
+	ToolResultEvent,
+} from "@earendil-works/pi-coding-agent";
+import { describe, it } from "vitest";
+import { Type } from "typebox";
+import { createToolCatalog, defineToolContribution } from "./catalog";
+
+const schema = Type.Object({ path: Type.String() });
+
+function demoTool<TDetails = undefined>(
+	description = "demo",
+	details = undefined as TDetails,
+): ToolDefinition<typeof schema, TDetails> {
+	return {
+		name: "demo",
+		label: "Demo",
+		description,
+		parameters: schema,
+		execute: async () => ({ content: [], details }),
+	};
+}
+
+function toolCall(toolName: string, input: unknown): ToolCallEvent {
+	return { toolName, input } as ToolCallEvent;
+}
+
+function toolResult(toolName: string, details: unknown): ToolResultEvent {
+	return { toolName, details } as ToolResultEvent;
+}
+
+describe("createToolCatalog", () => {
+	it("registers and replaces tool contributions by name", () => {
+		const catalog = createToolCatalog();
+		const first = defineToolContribution({
+			policy: { name: "demo" },
+			definition: demoTool("first"),
+		});
+		const replacement = defineToolContribution({
+			policy: { name: "demo" },
+			definition: demoTool("replacement"),
+		});
+
+		catalog.register(first);
+		catalog.register(replacement);
+
+		assert.deepEqual(catalog.list(), [replacement]);
+	});
+
+	it("rejects mismatched contribution and policy names", () => {
+		const catalog = createToolCatalog();
+
+		assert.throws(
+			() =>
+				catalog.register(
+					defineToolContribution({
+						policy: { name: "other" },
+						definition: demoTool(),
+					}),
+				),
+			/mismatched policy/u,
+		);
+	});
+
+	it("reports tool-result errors via contribution hooks", () => {
+		const catalog = createToolCatalog();
+		catalog.register(
+			defineToolContribution({
+				policy: { name: "demo" },
+				definition: demoTool<{ ok: boolean }>("demo", { ok: true }),
+				isErrorResult: (details) => !details.ok,
+			}),
+		);
+
+		assert.deepEqual(
+			catalog.toolResultError(toolResult("demo", { ok: false })),
+			{
+				isError: true,
+			},
+		);
+		assert.equal(
+			catalog.toolResultError(toolResult("demo", { ok: true })),
+			undefined,
+		);
+		assert.equal(
+			catalog.toolResultError(toolResult("unknown", { ok: false })),
+			undefined,
+		);
+	});
+
+	it("uses policy-specific or fallback not-allowed reasons", () => {
+		const catalog = createToolCatalog();
+		catalog.registerPolicy({
+			name: "demo",
+			notAllowedReason: (focusName) => `blocked in ${focusName}`,
+		});
+
+		assert.equal(
+			catalog.checkToolAllowed("edit", new Set(), toolCall("demo", {})),
+			"blocked in edit",
+		);
+		assert.equal(
+			catalog.checkToolAllowed("edit", new Set(["demo"]), toolCall("demo", {})),
+			undefined,
+		);
+		assert.equal(
+			catalog.checkToolAllowed("edit", new Set(), toolCall("unknown", {})),
+			"unknown is not available in edit focus.",
+		);
+	});
+
+	it("blocks configured secret paths", () => {
+		const catalog = createToolCatalog();
+		catalog.registerPolicy({
+			name: "demo",
+			extractSecretPaths: (input: { path: string }) => [input.path],
+			secretBlockReason: (focusName) => `secret blocked in ${focusName}`,
+		});
+
+		assert.equal(
+			catalog.checkSecretBlock("explore", toolCall("demo", { path: ".env" })),
+			"secret blocked in explore",
+		);
+		assert.equal(
+			catalog.checkSecretBlock(
+				"explore",
+				toolCall("demo", { path: "README.md" }),
+			),
+			undefined,
+		);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/tool/project/arguments.test.ts
+++ b/files/pi/agent/extensions/user/lib/tool/project/arguments.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { buildShellCommand } from "./arguments";
+import type {
+	ProjectToolCommandArgument,
+	ResolvedProjectToolCommand,
+} from "./types";
+
+function command(
+	argumentsConfig: readonly ProjectToolCommandArgument[],
+): ResolvedProjectToolCommand {
+	return {
+		index: 0,
+		label: "demo",
+		command: "demo",
+		arguments: argumentsConfig,
+		displayLabel: "demo",
+		displayCommand: "demo",
+		absoluteCwd: "/repo",
+		displayCwd: ".",
+	};
+}
+
+describe("buildShellCommand", () => {
+	it("renders literals, parameters, flags, options, and arrays", () => {
+		const rendered = buildShellCommand(
+			command([
+				{ kind: "literal", value: "run" },
+				{ kind: "param", name: "path" },
+				{ kind: "flag", flag: "--verbose", when: "verbose" },
+				{ kind: "option", option: "--count", name: "count" },
+				{ kind: "array", style: "repeat", option: "--tag", name: "tags" },
+				{ kind: "array", style: "spread", name: "files" },
+				{
+					kind: "array",
+					style: "join",
+					option: "--include",
+					name: "include",
+					separator: ",",
+				},
+			]),
+			{
+				path: "src/main.ts",
+				verbose: true,
+				count: 3,
+				tags: ["unit", "fast"],
+				files: ["a.ts", "b.ts"],
+				include: ["*.ts", "*.json"],
+			},
+		);
+
+		assert.equal(
+			rendered,
+			"'demo' 'run' 'src/main.ts' '--verbose' '--count' '3' '--tag' 'unit' '--tag' 'fast' 'a.ts' 'b.ts' '--include' '*.ts,*.json'",
+		);
+	});
+
+	it("omits unset optional arguments and false flags", () => {
+		assert.equal(
+			buildShellCommand(
+				command([
+					{ kind: "param", name: "path" },
+					{ kind: "flag", flag: "--verbose", when: "verbose" },
+					{ kind: "array", style: "spread", name: "files" },
+				]),
+				{ verbose: false, files: [] },
+			),
+			"'demo'",
+		);
+	});
+
+	it("quotes empty strings and single quotes safely", () => {
+		assert.equal(
+			buildShellCommand(command([{ kind: "param", name: "message" }]), {
+				message: "it's ok",
+			}),
+			"'demo' 'it'\\''s ok'",
+		);
+		assert.equal(
+			buildShellCommand(command([{ kind: "param", name: "message" }]), {
+				message: "",
+			}),
+			"'demo' ''",
+		);
+	});
+
+	it("rejects incompatible parameter shapes", () => {
+		assert.throws(
+			() =>
+				buildShellCommand(command([{ kind: "param", name: "path" }]), {
+					path: ["a", "b"],
+				}),
+			/Parameter 'path' must be a scalar value/u,
+		);
+		assert.throws(
+			() =>
+				buildShellCommand(
+					command([{ kind: "array", style: "spread", name: "paths" }]),
+					{ paths: "a" },
+				),
+			/Parameter 'paths' must be an array value/u,
+		);
+		assert.throws(
+			() =>
+				buildShellCommand(command([{ kind: "param", name: "count" }]), {
+					count: Number.POSITIVE_INFINITY,
+				}),
+			/finite numbers/u,
+		);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/tool/project/details.test.ts
+++ b/files/pi/agent/extensions/user/lib/tool/project/details.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import {
+	buildDetails,
+	formatDuration,
+	formatLlmOutput,
+	isProjectToolDetails,
+	statusLine,
+} from "./details";
+import type { MutableCommandState } from "./details";
+
+type StateOverrides = Partial<Omit<MutableCommandState, "output">> & {
+	readonly output?: Pick<MutableCommandState["output"], "snapshot">;
+};
+
+function state(overrides: StateOverrides = {}): MutableCommandState {
+	return {
+		config: {
+			index: 0,
+			label: "demo",
+			command: "demo",
+			arguments: [],
+			displayLabel: "demo",
+			displayCommand: "pnpm test",
+			absoluteCwd: "/repo",
+			displayCwd: ".",
+			timeoutSeconds: 120,
+		},
+		output: {
+			snapshot: () => ({
+				content: "done\n",
+				truncated: false,
+				totalLines: 1,
+				totalBytes: 5,
+			}),
+		},
+		status: "succeeded",
+		startedAt: 1_000,
+		endedAt: 2_500,
+		...overrides,
+	} as MutableCommandState;
+}
+
+describe("project tool details", () => {
+	it("builds command details from mutable command state", () => {
+		assert.deepEqual(buildDetails("test", [state()], "finished"), {
+			kind: "project-tool",
+			toolName: "test",
+			status: "finished",
+			commandCount: 1,
+			failed: false,
+			commands: [
+				{
+					label: "demo",
+					command: "pnpm test",
+					cwd: ".",
+					timeoutSeconds: 120,
+					status: "succeeded",
+					exitCode: undefined,
+					error: undefined,
+					output: "done\n",
+					fullOutputPath: undefined,
+					truncated: false,
+					durationMs: 1_500,
+				},
+			],
+		});
+	});
+
+	it("formats status and duration variants", () => {
+		assert.equal(statusLine({ status: "succeeded" } as never), "exit 0");
+		assert.equal(
+			statusLine({ status: "failed", exitCode: 2 } as never),
+			"exit 2",
+		);
+		assert.equal(
+			statusLine({ status: "failed", error: "boom" } as never),
+			"boom",
+		);
+		assert.equal(statusLine({ status: "running" } as never), "running");
+		assert.equal(formatDuration(undefined), undefined);
+		assert.equal(formatDuration(1_250), "1.3s");
+	});
+
+	it("formats llm output for success and failure", () => {
+		const success = buildDetails("test", [state()], "finished");
+		assert.match(formatLlmOutput(success), /Project tool "test" succeeded\./u);
+		assert.match(formatLlmOutput(success), /duration: 1\.5s/u);
+
+		const failed = buildDetails(
+			"test",
+			[
+				state({
+					status: "failed",
+					exitCode: 1,
+					output: {
+						snapshot: () => ({
+							content: "",
+							truncated: true,
+							fullOutputPath: "/tmp/full.log",
+							totalLines: 0,
+							totalBytes: 0,
+						}),
+					},
+				}),
+			],
+			"finished",
+		);
+
+		const output = formatLlmOutput(failed);
+		assert.match(output, /failed: 1 of 1 commands failed/u);
+		assert.match(output, /\(no output\)/u);
+		assert.match(output, /Full output: \/tmp\/full\.log/u);
+	});
+
+	it("recognizes project tool details", () => {
+		assert.equal(
+			isProjectToolDetails(buildDetails("test", [], "running")),
+			true,
+		);
+		assert.equal(
+			isProjectToolDetails({ kind: "project-tool", commands: [] }),
+			true,
+		);
+		assert.equal(isProjectToolDetails({ kind: "other", commands: [] }), false);
+		assert.equal(isProjectToolDetails(null), false);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/tool/project/execute.test.ts
+++ b/files/pi/agent/extensions/user/lib/tool/project/execute.test.ts
@@ -1,0 +1,220 @@
+import assert from "node:assert/strict";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { beforeEach, describe, it, vi } from "vitest";
+import { executeProjectTool } from "./execute";
+import type {
+	ProjectToolInput,
+	ResolvedProjectTool,
+	ResolvedProjectToolCommand,
+} from "./types";
+
+const mocks = vi.hoisted(() => ({
+	exec: vi.fn(),
+	createLocalBashOperations: vi.fn(),
+	settingsCreate: vi.fn(),
+}));
+
+vi.mock("@earendil-works/pi-coding-agent", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@earendil-works/pi-coding-agent")>();
+	return {
+		...actual,
+		createLocalBashOperations: mocks.createLocalBashOperations,
+		SettingsManager: { create: mocks.settingsCreate },
+	};
+});
+
+function command(
+	overrides: Partial<ResolvedProjectToolCommand> = {},
+): ResolvedProjectToolCommand {
+	return {
+		index: 0,
+		label: "demo",
+		displayLabel: "demo",
+		command: "pnpm",
+		arguments: [{ kind: "literal", value: "test" }],
+		displayCommand: "pnpm test",
+		absoluteCwd: "/repo",
+		displayCwd: ".",
+		timeoutSeconds: 30,
+		...overrides,
+	};
+}
+
+function tool(
+	overrides: Partial<ResolvedProjectTool> = {},
+): ResolvedProjectTool {
+	return {
+		name: "demo_tool",
+		description: "Run demo",
+		projectRoot: "/repo",
+		parameters: {},
+		parametersSchema: { type: "object" } as never,
+		executionMode: "sequential",
+		commands: [command()],
+		...overrides,
+	};
+}
+
+function context(): ExtensionContext {
+	return { cwd: "/repo" } as ExtensionContext;
+}
+
+describe("executeProjectTool", () => {
+	beforeEach(() => {
+		mocks.exec.mockReset();
+		mocks.createLocalBashOperations.mockReset();
+		mocks.settingsCreate.mockReset();
+		mocks.createLocalBashOperations.mockReturnValue({ exec: mocks.exec });
+		mocks.settingsCreate.mockReturnValue({
+			getShellPath: () => "/bin/zsh",
+			getShellCommandPrefix: () => "set -euo pipefail",
+		});
+	});
+
+	it("runs sequential commands with shell settings and streams updates", async () => {
+		const calls: string[] = [];
+		mocks.exec.mockImplementation(async (cmd, cwd, options) => {
+			calls.push(`${cwd}:${cmd}`);
+			options.onData(Buffer.from(`output from ${cmd}\n`));
+			return { exitCode: 0 };
+		});
+		const onUpdate = vi.fn();
+
+		const result = await executeProjectTool(
+			tool({
+				commands: [
+					command({
+						index: 0,
+						label: "lint",
+						displayLabel: "lint",
+						arguments: [{ kind: "literal", value: "lint" }],
+					}),
+					command({
+						index: 1,
+						label: "test",
+						displayLabel: "test",
+						arguments: [{ kind: "literal", value: "test" }],
+						absoluteCwd: "/repo/app",
+						displayCwd: "app",
+						timeoutSeconds: 60,
+					}),
+				],
+			}),
+			{},
+			context(),
+			undefined,
+			onUpdate,
+		);
+
+		assert.deepEqual(calls, [
+			"/repo:set -euo pipefail\n'pnpm' 'lint'",
+			"/repo/app:set -euo pipefail\n'pnpm' 'test'",
+		]);
+		assert.equal(mocks.settingsCreate.mock.calls[0]?.[0], "/repo");
+		assert.deepEqual(mocks.createLocalBashOperations.mock.calls[0]?.[0], {
+			shellPath: "/bin/zsh",
+		});
+		assert.equal(result.details.status, "finished");
+		assert.equal(result.details.failed, false);
+		assert.equal(result.details.commands[0]?.status, "succeeded");
+		assert.equal(result.details.commands[1]?.cwd, "app");
+		assert.match(resultText(result), /succeeded/u);
+		assert.equal(onUpdate.mock.calls.length > 0, true);
+		assert.equal(onUpdate.mock.calls[0]?.[0].details.status, "running");
+	});
+
+	it("captures non-zero exits, timeouts, aborts, and thrown errors", async () => {
+		mocks.settingsCreate.mockReturnValue({
+			getShellPath: () => "/bin/bash",
+			getShellCommandPrefix: () => undefined,
+		});
+		mocks.exec.mockImplementation(async (cmd, _cwd, options) => {
+			options.onData(Buffer.from(`${cmd}\n`));
+			if (cmd.includes("nonzero")) return { exitCode: 2 };
+			if (cmd.includes("timeout")) throw new Error("timeout:5");
+			if (cmd.includes("abort")) throw new Error("aborted");
+			throw new Error("boom");
+		});
+
+		const result = await executeProjectTool(
+			tool({
+				executionMode: "parallel",
+				commands: [
+					command({
+						index: 0,
+						label: "nonzero",
+						displayLabel: "nonzero",
+						arguments: [{ kind: "literal", value: "nonzero" }],
+					}),
+					command({
+						index: 1,
+						label: "timeout",
+						displayLabel: "timeout",
+						arguments: [{ kind: "literal", value: "timeout" }],
+					}),
+					command({
+						index: 2,
+						label: "abort",
+						displayLabel: "abort",
+						arguments: [{ kind: "literal", value: "abort" }],
+					}),
+					command({
+						index: 3,
+						label: "boom",
+						displayLabel: "boom",
+						arguments: [{ kind: "literal", value: "boom" }],
+					}),
+				],
+			}),
+			{} satisfies ProjectToolInput,
+			context(),
+			new AbortController().signal,
+			undefined,
+		);
+
+		assert.equal(result.details.failed, true);
+		assert.deepEqual(
+			result.details.commands.map((item) => ({
+				label: item.label,
+				status: item.status,
+				exitCode: item.exitCode,
+				error: item.error,
+			})),
+			[
+				{
+					label: "nonzero",
+					status: "failed",
+					exitCode: 2,
+					error: undefined,
+				},
+				{
+					label: "timeout",
+					status: "failed",
+					exitCode: null,
+					error: "timed out after 5s",
+				},
+				{
+					label: "abort",
+					status: "failed",
+					exitCode: null,
+					error: "aborted",
+				},
+				{
+					label: "boom",
+					status: "failed",
+					exitCode: null,
+					error: "boom",
+				},
+			],
+		);
+		assert.match(resultText(result), /failed: 4 of 4/u);
+	});
+});
+
+function resultText(
+	result: Awaited<ReturnType<typeof executeProjectTool>>,
+): string {
+	const content = result.content[0];
+	return content?.type === "text" ? content.text : "";
+}

--- a/files/pi/agent/extensions/user/lib/tool/project/normalize.test.ts
+++ b/files/pi/agent/extensions/user/lib/tool/project/normalize.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { normalizeTool } from "./normalize";
+
+describe("normalizeTool", () => {
+	it("normalizes a project tool with parameters and command arguments", () => {
+		assert.deepEqual(
+			normalizeTool("demo", {
+				description: "Run demo",
+				executionMode: "parallel",
+				cwd: "packages/demo",
+				timeoutSeconds: 30,
+				promptSnippet: "Run demo checks",
+				promptGuidelines: ["Use after changing demo files."],
+				parameters: {
+					path: { type: "string", required: true },
+					count: { type: "number", description: "repeat count" },
+					verbose: { type: "boolean" },
+					tags: { type: "string[]" },
+					ids: { type: "array", items: { type: "number" } },
+				},
+				commands: [
+					{
+						label: "demo",
+						command: "demo",
+						arguments: [
+							"run",
+							"{{path}}",
+							{ option: "--count", value: "{{count}}" },
+							{ flag: "--verbose", when: "verbose" },
+							{ option: "--tag", values: "{{tags}}", style: "repeat" },
+							{ values: "{{ids}}", style: "join", separator: "," },
+						],
+					},
+				],
+			}),
+			{
+				name: "demo",
+				description: "Run demo",
+				executionMode: "parallel",
+				cwd: "packages/demo",
+				timeoutSeconds: 30,
+				promptSnippet: "Run demo checks",
+				promptGuidelines: ["Use after changing demo files."],
+				parameters: {
+					path: { type: "string", required: true, description: undefined },
+					count: {
+						type: "number",
+						required: false,
+						description: "repeat count",
+					},
+					verbose: { type: "boolean", required: false, description: undefined },
+					tags: {
+						type: "array",
+						items: { type: "string" },
+						required: false,
+						description: undefined,
+					},
+					ids: {
+						type: "array",
+						items: { type: "number" },
+						required: false,
+						description: undefined,
+					},
+				},
+				commands: [
+					{
+						label: "demo",
+						command: "demo",
+						arguments: [
+							{ kind: "literal", value: "run" },
+							{ kind: "param", name: "path" },
+							{ kind: "option", option: "--count", name: "count" },
+							{ kind: "flag", flag: "--verbose", when: "verbose" },
+							{
+								kind: "array",
+								style: "repeat",
+								option: "--tag",
+								name: "tags",
+							},
+							{
+								kind: "array",
+								style: "join",
+								name: "ids",
+								separator: ",",
+							},
+						],
+						cwd: undefined,
+						timeoutSeconds: undefined,
+					},
+				],
+			},
+		);
+	});
+
+	it("rejects invalid tool and command configuration", () => {
+		assert.throws(() => normalizeTool("BadName", {}), /Invalid tool name/u);
+		assert.throws(
+			() =>
+				normalizeTool("demo", {
+					description: "Run demo",
+					commands: [],
+				}),
+			/commands is required/u,
+		);
+		assert.throws(
+			() =>
+				normalizeTool("demo", {
+					description: "Run demo",
+					commands: [{ command: "pnpm test" }],
+				}),
+			/single executable token/u,
+		);
+	});
+
+	it("rejects invalid parameter references", () => {
+		assert.throws(
+			() =>
+				normalizeTool("demo", {
+					description: "Run demo",
+					parameters: { files: { type: "string[]" } },
+					commands: [{ command: "demo", arguments: ["{{files}}"] }],
+				}),
+			/references array parameter 'files'/u,
+		);
+		assert.throws(
+			() =>
+				normalizeTool("demo", {
+					description: "Run demo",
+					parameters: { path: { type: "string" } },
+					commands: [{ command: "demo", arguments: ["prefix-{{path}}"] }],
+				}),
+			/parameter references must be the whole argument/u,
+		);
+		assert.throws(
+			() =>
+				normalizeTool("demo", {
+					description: "Run demo",
+					parameters: { enabled: { type: "boolean" } },
+					commands: [
+						{
+							command: "demo",
+							arguments: [{ option: "--enabled", value: "{{enabled}}" }],
+						},
+					],
+				}),
+			/value must reference a string or number parameter/u,
+		);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/tool/project/output.test.ts
+++ b/files/pi/agent/extensions/user/lib/tool/project/output.test.ts
@@ -1,0 +1,49 @@
+import { existsSync, readFileSync } from "node:fs";
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { StreamingOutput, truncateLines } from "./output";
+
+describe("project tool output", () => {
+	it("keeps only the requested tail lines", () => {
+		assert.equal(truncateLines("one\ntwo\nthree", 2), "two\nthree");
+		assert.equal(truncateLines("one\ntwo", 3), "one\ntwo");
+	});
+
+	it("tracks streaming output snapshots", () => {
+		const output = new StreamingOutput("demo command", {
+			maxLines: 3,
+			maxBytes: 1024,
+		});
+
+		output.append(Buffer.from("one\n"));
+		output.append(Buffer.from("two"));
+		output.finish();
+
+		assert.deepEqual(output.snapshot(), {
+			content: "one\ntwo",
+			truncated: false,
+			fullOutputPath: undefined,
+			totalLines: 2,
+			totalBytes: 7,
+		});
+	});
+
+	it("spools full output to a safe temporary file after truncation", () => {
+		const output = new StreamingOutput("demo command!", {
+			maxLines: 1,
+			maxBytes: 1024,
+		});
+
+		output.append(Buffer.from("one\ntwo"));
+		const snapshot = output.snapshot();
+
+		assert.equal(snapshot.content, "two");
+		assert.equal(snapshot.truncated, true);
+		assert.ok(snapshot.fullOutputPath?.endsWith("demo_command.log"));
+		assert.ok(existsSync(snapshot.fullOutputPath ?? ""));
+		assert.equal(
+			readFileSync(snapshot.fullOutputPath ?? "", "utf8"),
+			"one\ntwo",
+		);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/tool/project/register.test.ts
+++ b/files/pi/agent/extensions/user/lib/tool/project/register.test.ts
@@ -1,0 +1,178 @@
+import { randomUUID } from "node:crypto";
+import assert from "node:assert/strict";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { describe, it } from "vitest";
+import { createToolCatalog } from "../catalog";
+import {
+	type TestPiProject,
+	createTestPiProject,
+	readTestPiProjectUserSettings,
+} from "../../test-support/pi-project";
+import { isProjectToolAvailable, registerProjectTools } from "./register";
+
+function tempProject(settings: Record<string, unknown>): TestPiProject {
+	return createTestPiProject({
+		settings,
+		includeStandardPiConfig: true,
+	});
+}
+
+function context(project: TestPiProject): ExtensionContext {
+	return {
+		cwd: project.cwd,
+		hasUI: false,
+		isProjectTrusted: () => true,
+		ui: {
+			notify: (message: string) => project.notifications.push(message),
+		},
+	} as unknown as ExtensionContext;
+}
+
+type RegisteredTool = { readonly name: string };
+
+function fakeExtensionApi(existingToolNames: readonly string[] = []): {
+	readonly extensionApi: ExtensionAPI;
+	readonly registered: RegisteredTool[];
+} {
+	const registered: RegisteredTool[] = [];
+	return {
+		registered,
+		extensionApi: {
+			getAllTools: () => existingToolNames.map((name) => ({ name })),
+			registerTool: (tool: RegisteredTool) => registered.push(tool),
+		} as unknown as ExtensionAPI,
+	};
+}
+
+describe("registerProjectTools", () => {
+	it("registers valid project tools into pi and the catalog", () => {
+		const project = tempProject({
+			tools: {
+				[`demo_${randomUUID().replaceAll("-", "_")}`]: {
+					description: "Run demo",
+					executionMode: "parallel",
+					parameters: {
+						path: { type: "string", required: true },
+					},
+					commands: [
+						{
+							label: "demo",
+							command: "pnpm",
+							arguments: ["test", "{{path}}"],
+							timeoutSeconds: 30,
+						},
+					],
+				},
+			},
+		});
+		const toolName = Object.keys(
+			projectSettings(project).tools as Record<string, unknown>,
+		)[0] as string;
+		const { extensionApi, registered } = fakeExtensionApi();
+		const catalog = createToolCatalog();
+
+		const summaries = registerProjectTools(
+			extensionApi,
+			context(project),
+			catalog,
+		);
+
+		assert.deepEqual(summaries, [{ name: toolName, commandCount: 1 }]);
+		assert.equal(registered[0]?.name, toolName);
+		assert.equal(catalog.list()[0]?.definition.name, toolName);
+		assert.equal(isProjectToolAvailable(toolName), true);
+	});
+
+	it("warns and skips invalid or conflicting project tools", () => {
+		const project = tempProject({
+			tools: {
+				conflict: {
+					description: "Conflicts with an existing tool",
+					commands: [{ command: "pnpm" }],
+				},
+				bad: {
+					description: "Invalid command",
+					commands: [{ command: "pnpm test" }],
+				},
+			},
+		});
+		const { extensionApi, registered } = fakeExtensionApi(["conflict"]);
+		const catalog = createToolCatalog();
+
+		const summaries = registerProjectTools(
+			extensionApi,
+			context(project),
+			catalog,
+		);
+
+		assert.deepEqual(summaries, []);
+		assert.deepEqual(registered, []);
+		assert.equal(catalog.list().length, 0);
+		assert.match(
+			project.notifications.join("\n"),
+			/Project tool 'conflict' conflicts with an existing tool/u,
+		);
+		assert.match(
+			project.notifications.join("\n"),
+			/Project tool 'bad' ignored: bad\.commands\[0\]\.command must be a single executable token/u,
+		);
+	});
+
+	it("disables previously registered project tools after reloading different settings", () => {
+		const previousName = `previous_${randomUUID().replaceAll("-", "_")}`;
+		const nextName = `next_${randomUUID().replaceAll("-", "_")}`;
+		const firstProject = tempProject({
+			tools: {
+				[previousName]: {
+					description: "Previous tool",
+					commands: [{ command: "pnpm" }],
+				},
+			},
+		});
+		const secondProject = tempProject({
+			tools: {
+				[nextName]: {
+					description: "Next tool",
+					commands: [{ command: "pnpm" }],
+				},
+			},
+		});
+
+		registerProjectTools(
+			fakeExtensionApi().extensionApi,
+			context(firstProject),
+			createToolCatalog(),
+		);
+		assert.equal(isProjectToolAvailable(previousName), true);
+
+		registerProjectTools(
+			fakeExtensionApi().extensionApi,
+			context(secondProject),
+			createToolCatalog(),
+		);
+
+		assert.equal(isProjectToolAvailable(previousName), false);
+		assert.equal(isProjectToolAvailable(nextName), true);
+	});
+
+	it("warns when the tools setting is not an object", () => {
+		const project = tempProject({ tools: [] });
+		const summaries = registerProjectTools(
+			fakeExtensionApi().extensionApi,
+			context(project),
+			createToolCatalog(),
+		);
+
+		assert.deepEqual(summaries, []);
+		assert.deepEqual(project.notifications, [
+			"Project tools ignored: tools must be an object.",
+		]);
+	});
+});
+
+function projectSettings(project: TestPiProject): Record<string, unknown> {
+	return readTestPiProjectUserSettings(project);
+}

--- a/files/pi/agent/extensions/user/lib/tool/project/resolve.test.ts
+++ b/files/pi/agent/extensions/user/lib/tool/project/resolve.test.ts
@@ -1,0 +1,140 @@
+import { mkdirSync, mkdtempSync, realpathSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve as resolvePath } from "node:path";
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { resolveTool } from "./resolve";
+import type { ProjectToolConfig } from "./types";
+
+function tempProject(): string {
+	const root = mkdtempSync(join(tmpdir(), "pi-resolve-tool-"));
+	mkdirSync(join(root, "packages", "app"), { recursive: true });
+	mkdirSync(join(root, "scripts"), { recursive: true });
+	return root;
+}
+
+function tool(overrides: Partial<ProjectToolConfig> = {}): ProjectToolConfig {
+	return {
+		name: "demo",
+		description: "Run demo",
+		parameters: {},
+		commands: [{ command: "pnpm", arguments: [] }],
+		...overrides,
+	};
+}
+
+describe("resolveTool", () => {
+	it("resolves project-relative cwd and command display metadata", () => {
+		const root = tempProject();
+		const resolved = resolveTool(
+			root,
+			tool({
+				cwd: "packages/app",
+				timeoutSeconds: 60,
+				parameters: {
+					path: { type: "string", required: true },
+					verbose: { type: "boolean", required: false },
+					tags: {
+						type: "array",
+						items: { type: "string" },
+						required: false,
+					},
+				},
+				commands: [
+					{
+						label: "check",
+						command: "pnpm",
+						cwd: "scripts",
+						timeoutSeconds: 10,
+						arguments: [
+							{ kind: "literal", value: "test" },
+							{ kind: "param", name: "path" },
+							{ kind: "flag", flag: "--verbose", when: "verbose" },
+							{ kind: "option", option: "--config", name: "path" },
+							{
+								kind: "array",
+								style: "repeat",
+								option: "--tag",
+								name: "tags",
+							},
+							{ kind: "array", style: "spread", name: "tags" },
+							{
+								kind: "array",
+								style: "join",
+								option: "--tags",
+								name: "tags",
+								separator: ",",
+							},
+						],
+					},
+				],
+			}),
+		);
+
+		assert.equal(resolved.cwd, "packages/app");
+		assert.equal(resolved.projectRoot, realpathSync(root));
+		assert.equal(resolved.commands[0]?.index, 0);
+		assert.equal(resolved.commands[0]?.displayLabel, "check");
+		assert.equal(resolved.commands[0]?.absoluteCwd, join(root, "scripts"));
+		assert.equal(resolved.commands[0]?.displayCwd, "scripts");
+		assert.equal(resolved.commands[0]?.timeoutSeconds, 10);
+		assert.equal(
+			resolved.commands[0]?.displayCommand,
+			'pnpm test {{path}} --verbose when verbose --config {{path}} --tag {{tags}}... {{tags}}... --tags join({{tags}}, ",")',
+		);
+		assert.equal(
+			(
+				resolved.parametersSchema as { readonly required?: readonly string[] }
+			).required?.includes("path"),
+			true,
+		);
+	});
+
+	it("inherits tool cwd and timeout when command values are omitted", () => {
+		const root = tempProject();
+		const resolved = resolveTool(
+			root,
+			tool({
+				cwd: "packages/app",
+				timeoutSeconds: 60,
+				commands: [{ command: "pnpm", arguments: [] }],
+			}),
+		);
+
+		assert.equal(resolved.commands[0]?.displayLabel, "1");
+		assert.equal(resolved.commands[0]?.displayCwd, "packages/app");
+		assert.equal(resolved.commands[0]?.timeoutSeconds, 60);
+	});
+
+	it("rejects cwd values outside the project root", () => {
+		const root = tempProject();
+		assert.throws(
+			() => resolveTool(root, tool({ cwd: "/tmp" })),
+			/demo\.cwd must be relative to the project root/u,
+		);
+		assert.throws(
+			() => resolveTool(root, tool({ cwd: ".." })),
+			/demo\.cwd must stay inside the project root/u,
+		);
+	});
+
+	it("rejects symlink escapes after realpath resolution", () => {
+		const root = tempProject();
+		const outside = mkdtempSync(join(tmpdir(), "pi-resolve-outside-"));
+		symlinkSync(outside, join(root, "outside-link"));
+
+		assert.throws(
+			() => resolveTool(root, tool({ cwd: "outside-link" })),
+			/demo\.cwd must stay inside the project root/u,
+		);
+	});
+
+	it("normalizes empty cwd to the project root", () => {
+		const root = tempProject();
+		const resolved = resolveTool(root, tool({ cwd: "" }));
+
+		assert.equal(resolved.cwd, undefined);
+		assert.equal(resolved.commands[0]?.absoluteCwd, resolvePath(root));
+		assert.equal(resolved.commands[0]?.displayCwd, ".");
+	});
+});

--- a/files/pi/agent/extensions/user/lib/tool/project/schema.test.ts
+++ b/files/pi/agent/extensions/user/lib/tool/project/schema.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { buildParameterSchema } from "./schema";
+
+type ObjectSchema = {
+	readonly type?: string;
+	readonly additionalProperties?: boolean;
+	readonly required?: readonly string[];
+	readonly properties?: Record<
+		string,
+		{
+			readonly type?: string;
+			readonly description?: string;
+			readonly items?: { readonly type?: string };
+		}
+	>;
+};
+
+describe("buildParameterSchema", () => {
+	it("builds a closed object schema with required and optional parameters", () => {
+		const schema = buildParameterSchema({
+			path: {
+				type: "string",
+				description: "Path to check",
+				required: true,
+			},
+			count: { type: "number", required: false },
+			verbose: { type: "boolean", required: false },
+			tags: {
+				type: "array",
+				items: { type: "string" },
+				description: "Tags to include",
+				required: false,
+			},
+		}) as ObjectSchema;
+
+		assert.equal(schema.type, "object");
+		assert.equal(schema.additionalProperties, false);
+		assert.deepEqual(schema.required, ["path"]);
+		assert.equal(schema.properties?.path?.type, "string");
+		assert.equal(schema.properties?.path?.description, "Path to check");
+		assert.equal(schema.properties?.count?.type, "number");
+		assert.equal(schema.properties?.verbose?.type, "boolean");
+		assert.equal(schema.properties?.tags?.type, "array");
+		assert.equal(schema.properties?.tags?.description, "Tags to include");
+		assert.equal(schema.properties?.tags?.items?.type, "string");
+	});
+
+	it("omits required when all parameters are optional", () => {
+		const schema = buildParameterSchema({
+			force: { type: "boolean", required: false },
+		}) as ObjectSchema;
+
+		assert.equal(schema.required, undefined);
+	});
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "test": "vitest run"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",
@@ -10,7 +11,8 @@
   },
   "devDependencies": {
     "@types/node": "^25.9.2",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9"
   },
   "packageManager": "pnpm@11.7.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "scripts": {
     "lint": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",
@@ -11,6 +12,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.9.2",
+    "@vitest/coverage-v8": "^4.1.9",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,12 +24,15 @@ importers:
       '@types/node':
         specifier: ^25.9.2
         version: 25.9.3
+      '@vitest/coverage-v8':
+        specifier: ^4.1.9
+        version: 4.1.9(vitest@4.1.9)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@types/node@25.9.3)(vite@8.0.16(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.0.16(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0))
 
 packages:
 
@@ -143,9 +146,30 @@ packages:
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
     engines: {node: '>=18.0.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@earendil-works/pi-agent-core@0.79.3':
     resolution: {integrity: sha512-Ksvnu6CpQLYGbCSgnQEetzliI7yb+QkqtSlmmunJ69QluT45kd3DjQZRNHfRLk++Dd02Y8QvsRKMopSJCcWoWw==}
@@ -183,8 +207,15 @@ packages:
       '@modelcontextprotocol/sdk':
         optional: true
 
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@mariozechner/clipboard-darwin-arm64@0.3.9':
     resolution: {integrity: sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==}
@@ -458,6 +489,15 @@ packages:
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
+  '@vitest/coverage-v8@4.1.9':
+    resolution: {integrity: sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==}
+    peerDependencies:
+      '@vitest/browser': 4.1.9
+      vitest: 4.1.9
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.9':
     resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
 
@@ -497,6 +537,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.4:
+    resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -626,12 +669,19 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
   hosted-git-info@9.0.3:
     resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -648,9 +698,24 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
@@ -748,6 +813,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   marked@15.0.12:
     resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
@@ -851,6 +923,11 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  semver@7.8.4:
+    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -877,6 +954,10 @@ packages:
 
   strnum@2.4.0:
     resolution: {integrity: sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1275,7 +1356,22 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.2.4': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@babel/runtime@7.29.7': {}
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@earendil-works/pi-agent-core@0.79.3(ws@8.21.0)(zod@4.4.3)':
     dependencies:
@@ -1372,7 +1468,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@mariozechner/clipboard-darwin-arm64@0.3.9':
     optional: true
@@ -1587,6 +1690,20 @@ snapshots:
 
   '@types/retry@0.12.0': {}
 
+  '@vitest/coverage-v8@4.1.9(vitest@4.1.9)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.9
+      ast-v8-to-istanbul: 1.0.4
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.3
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.0.16(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0))
+
   '@vitest/expect@4.1.9':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -1633,6 +1750,12 @@ snapshots:
   anynum@1.0.0: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.4:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   balanced-match@4.0.4: {}
 
@@ -1751,11 +1874,15 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  has-flag@4.0.0: {}
+
   highlight.js@10.7.3: {}
 
   hosted-git-info@9.0.3:
     dependencies:
       lru-cache: 11.5.1
+
+  html-escaper@2.0.2: {}
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -1775,7 +1902,22 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jiti@2.7.0: {}
+
+  js-tokens@10.0.0: {}
 
   json-bigint@1.0.0:
     dependencies:
@@ -1853,6 +1995,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.4
 
   marked@15.0.12: {}
 
@@ -1956,6 +2108,8 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  semver@7.8.4: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -1975,6 +2129,10 @@ snapshots:
   strnum@2.4.0:
     dependencies:
       anynum: 1.0.0
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   tinybench@2.9.0: {}
 
@@ -2014,7 +2172,7 @@ snapshots:
       jiti: 2.7.0
       yaml: 2.9.0
 
-  vitest@4.1.9(@types/node@25.9.3)(vite@8.0.16(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0)):
+  vitest@4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.0.16(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0))
@@ -2038,6 +2196,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.3
+      '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@25.9.3)(vite@8.0.16(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0))
 
 packages:
 
@@ -162,6 +165,15 @@ packages:
     resolution: {integrity: sha512-cpmkEM1aEuGUx6YZM36VlzpulwLzqD5T2cUEkGHndDTNGEbnn5sj/9SYm+QBfKjvZsWoHfZuFBnu4+hh96/FbA==}
     engines: {node: '>=22.19.0'}
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
   '@google/genai@1.52.0':
     resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
     engines: {node: '>=20.0.0'}
@@ -170,6 +182,9 @@ packages:
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
         optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@mariozechner/clipboard-darwin-arm64@0.3.9':
     resolution: {integrity: sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==}
@@ -242,8 +257,17 @@ packages:
   '@mistralai/mistralai@2.2.1':
     resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
 
+  '@napi-rs/wasm-runtime@1.1.5':
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@nodable/entities@2.2.0':
     resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
+
+  '@oxc-project/types@0.133.0':
+    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -271,6 +295,104 @@ packages:
 
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+
+  '@rolldown/binding-android-arm64@1.0.3':
+    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.3':
+    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@silvia-odwyer/photon-node@0.3.4':
     resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
@@ -315,11 +437,55 @@ packages:
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/node@25.9.3':
     resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
+  '@vitest/expect@4.1.9':
+    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+
+  '@vitest/mocker@4.1.9':
+    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.9':
+    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
+
+  '@vitest/runner@4.1.9':
+    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+
+  '@vitest/snapshot@4.1.9':
+    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+
+  '@vitest/spy@4.1.9':
+    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+
+  '@vitest/utils@4.1.9':
+    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -327,6 +493,10 @@ packages:
 
   anynum@1.0.0:
     resolution: {integrity: sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -348,9 +518,16 @@ packages:
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -369,12 +546,26 @@ packages:
       supports-color:
         optional: true
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
 
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -386,6 +577,15 @@ packages:
     resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
     hasBin: true
 
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
@@ -393,6 +593,11 @@ packages:
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   gaxios@7.1.5:
     resolution: {integrity: sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==}
@@ -460,12 +665,89 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
     engines: {node: 20 || >=22}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   marked@15.0.12:
     resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
@@ -483,6 +765,11 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -491,6 +778,10 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
 
   openai@6.26.0:
     resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
@@ -523,6 +814,20 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
@@ -538,6 +843,11 @@ packages:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -549,11 +859,39 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
   strnum@2.4.0:
     resolution: {integrity: sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
@@ -579,6 +917,90 @@ packages:
     resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
     engines: {node: '>=22.19.0'}
 
+  vite@8.0.16:
+    resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.9:
+    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.9
+      '@vitest/browser-preview': 4.1.9
+      '@vitest/browser-webdriverio': 4.1.9
+      '@vitest/coverage-istanbul': 4.1.9
+      '@vitest/coverage-v8': 4.1.9
+      '@vitest/ui': 4.1.9
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -586,6 +1008,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   ws@8.21.0:
@@ -918,6 +1345,22 @@ snapshots:
       get-east-asian-width: 1.6.0
       marked: 15.0.12
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@google/genai@1.52.0':
     dependencies:
       google-auth-library: 10.7.0
@@ -928,6 +1371,8 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@mariozechner/clipboard-darwin-arm64@0.3.9':
     optional: true
@@ -982,7 +1427,16 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
   '@nodable/entities@2.2.0': {}
+
+  '@oxc-project/types@0.133.0': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -1003,6 +1457,57 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.1': {}
+
+  '@rolldown/binding-android-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@silvia-odwyer/photon-node@0.3.4': {}
 
@@ -1060,15 +1565,74 @@ snapshots:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.8.1
 
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
   '@types/node@25.9.3':
     dependencies:
       undici-types: 7.24.6
 
   '@types/retry@0.12.0': {}
 
+  '@vitest/expect@4.1.9':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.16(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.9':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.9':
+    dependencies:
+      '@vitest/utils': 4.1.9
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/utils': 4.1.9
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.9': {}
+
+  '@vitest/utils@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   agent-base@7.1.4: {}
 
   anynum@1.0.0: {}
+
+  assertion-error@2.0.1: {}
 
   balanced-match@4.0.4: {}
 
@@ -1084,7 +1648,11 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
+  chai@6.2.2: {}
+
   chalk@5.6.2: {}
+
+  convert-source-map@2.0.0: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -1098,11 +1666,21 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  detect-libc@2.1.2: {}
+
   diff@8.0.4: {}
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
+
+  es-module-lexer@2.1.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.3.0: {}
 
   extend@3.0.2: {}
 
@@ -1118,6 +1696,10 @@ snapshots:
       path-expression-matcher: 1.5.0
       strnum: 2.4.0
 
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
   fetch-blob@3.2.0:
     dependencies:
       node-domexception: 1.0.0
@@ -1126,6 +1708,9 @@ snapshots:
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
+
+  fsevents@2.3.3:
+    optional: true
 
   gaxios@7.1.5:
     dependencies:
@@ -1212,9 +1797,62 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   long@5.3.2: {}
 
   lru-cache@11.5.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   marked@15.0.12: {}
 
@@ -1226,6 +1864,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  nanoid@3.3.12: {}
+
   node-domexception@1.0.0: {}
 
   node-fetch@3.3.2:
@@ -1233,6 +1873,8 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  obug@2.1.3: {}
 
   openai@6.26.0(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
@@ -1254,6 +1896,18 @@ snapshots:
     dependencies:
       lru-cache: 11.5.1
       minipass: 7.1.3
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   proper-lockfile@4.1.2:
     dependencies:
@@ -1279,6 +1933,27 @@ snapshots:
 
   retry@0.13.1: {}
 
+  rolldown@1.0.3:
+    dependencies:
+      '@oxc-project/types': 0.133.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.3
+      '@rolldown/binding-darwin-arm64': 1.0.3
+      '@rolldown/binding-darwin-x64': 1.0.3
+      '@rolldown/binding-freebsd-x64': 1.0.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
+      '@rolldown/binding-linux-arm64-gnu': 1.0.3
+      '@rolldown/binding-linux-arm64-musl': 1.0.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
+      '@rolldown/binding-linux-s390x-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-musl': 1.0.3
+      '@rolldown/binding-openharmony-arm64': 1.0.3
+      '@rolldown/binding-wasm32-wasi': 1.0.3
+      '@rolldown/binding-win32-arm64-msvc': 1.0.3
+      '@rolldown/binding-win32-x64-msvc': 1.0.3
+
   safe-buffer@5.2.1: {}
 
   shebang-command@2.0.0:
@@ -1287,11 +1962,30 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   strnum@2.4.0:
     dependencies:
       anynum: 1.0.0
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   ts-algebra@2.0.0: {}
 
@@ -1307,11 +2001,56 @@ snapshots:
 
   undici@8.3.0: {}
 
+  vite@8.0.16(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.9.3
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      yaml: 2.9.0
+
+  vitest@4.1.9(@types/node@25.9.3)(vite@8.0.16(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.3
+    transitivePeerDependencies:
+      - msw
+
   web-streams-polyfill@3.3.3: {}
 
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   ws@8.21.0: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
 		coverage: {
 			provider: "v8",
 			reporter: ["text", "json-summary", "html"],
-			include: ["files/pi/agent/extensions/user/**/*.ts"],
+			include: ["files/pi/agent/extensions/user/lib/**/*.ts"],
 			exclude: [
 				"files/pi/agent/extensions/**/*.test.ts",
 				"files/pi/agent/extensions/**/test-support/**",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
 			include: ["files/pi/agent/extensions/user/**/*.ts"],
 			exclude: [
 				"files/pi/agent/extensions/**/*.test.ts",
+				"files/pi/agent/extensions/**/test-support/**",
 				"files/pi/agent/extensions/**/index.ts",
 				"files/pi/agent/extensions/**/types.ts",
 			],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["files/pi/agent/extensions/**/*.test.ts"],
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "json-summary", "html"],
+			include: ["files/pi/agent/extensions/user/**/*.ts"],
+			exclude: [
+				"files/pi/agent/extensions/**/*.test.ts",
+				"files/pi/agent/extensions/**/index.ts",
+				"files/pi/agent/extensions/**/types.ts",
+			],
+		},
+	},
+});


### PR DESCRIPTION
## Summary

- Add a Vitest test script and dev dependency for Pi user extension tests.
- Cover focus definitions, status formatting, math helpers, and tool catalog behavior.
- Add the project-local `test` tool so Pi can run `pnpm test` from edit focus.
