### PR TITLE
Add oxlint fix to format tool

### DIFF
--- a/.pi/settings.user.json
+++ b/.pi/settings.user.json
@@ -77,16 +77,23 @@
       ]
     },
     "format": {
-      "description": "Format the project in place with treefmt.",
+      "description": "Format the project in place.",
       "executionMode": "sequential",
       "promptSnippet": "Format the project in place",
       "promptGuidelines": [
-        "Use format to auto-fix formatting, then run lint to verify."
+        "Use format to auto-fix formatting and supported lint issues, then run lint to verify."
       ],
       "commands": [
         {
           "label": "treefmt",
           "command": "treefmt"
+        },
+        {
+          "label": "oxlint --fix",
+          "command": "oxlint",
+          "arguments": [
+            "--fix"
+          ]
         }
       ]
     },


### PR DESCRIPTION
## Summary

- add `oxlint --fix` to the Pi project `format` tool
- keep `format` running sequentially after `treefmt` so supported lint fixes are applied automatically
