### PR TITLE
Add locked focus flag mode

### DIFF
--- a/files/pi/agent/extensions/user/features/focus.ts
+++ b/files/pi/agent/extensions/user/features/focus.ts
@@ -11,6 +11,7 @@ import {
 	registerBuiltInFocusPolicies,
 	showFocusSelector,
 } from "../lib/focus";
+import { getRequestedFocusName, registerFocusFlag } from "../lib/focus/cli";
 import { registerQuickActionHandler } from "../lib/quick-actions";
 import { guardToolCall } from "../lib/focus/guard";
 import { filterProviderTools } from "../lib/focus/provider-filter";
@@ -34,6 +35,13 @@ import {
 const openFocusQuickAction =
 	(focus: FocusController, runtime: FocusRuntime) =>
 	async (ctx: ExtensionContext): Promise<void> => {
+		if (runtime.lockedFocusName) {
+			ctx.ui.notify(
+				`Focus is locked to '${runtime.lockedFocusName}' by --focus.`,
+				"warning",
+			);
+			return;
+		}
 		const selected = await showFocusSelector(
 			ctx,
 			focus.registry,
@@ -56,6 +64,13 @@ const openFocusQuickAction =
 const toggleFocusSelector =
 	(focus: FocusController, runtime: FocusRuntime) =>
 	async (ctx: ExtensionContext): Promise<void> => {
+		if (runtime.lockedFocusName) {
+			ctx.ui.notify(
+				`Focus is locked to '${runtime.lockedFocusName}' by --focus.`,
+				"warning",
+			);
+			return;
+		}
 		runtime.setResetFocusAtAgentEndPending(false);
 		runtime.cancelAutoContinue();
 		if (focus.current !== BASE_FOCUS) {
@@ -68,6 +83,7 @@ const toggleFocusSelector =
 	};
 
 function register(pi: ExtensionAPI, services: UserExtensionServices): void {
+	registerFocusFlag(pi);
 	registerBuiltInFocusPolicies(services.tools);
 	const focus = createFocusController(pi, services.focus);
 	const runtime = createFocusRuntime();
@@ -85,16 +101,23 @@ function register(pi: ExtensionAPI, services: UserExtensionServices): void {
 		handler: toggleFocusSelector(focus, runtime),
 	});
 	pi.on("before_agent_start", injectFocusRestorePrompt(pi, focus, runtime));
-	pi.on("before_provider_request", filterProviderTools(pi, focus));
-	pi.on("session_before_switch", persistFocusBeforeNew(pi, focus));
+	pi.on("before_provider_request", filterProviderTools(pi, focus, runtime));
+	pi.on("session_before_switch", persistFocusBeforeNew(pi, focus, runtime));
 	pi.on("session_start", resetConfirmDecisions());
-	pi.on("session_start", restoreFocus(focus, runtime));
+	pi.on(
+		"session_start",
+		restoreFocus(focus, runtime, {
+			getLockedFocusName: () => getRequestedFocusName(pi),
+			onLockedFocusName: (focusName) =>
+				services.focus.setLockedFocusName(focusName),
+		}),
+	);
 	pi.on("agent_end", resetFocusAtAgentEnd(focus, runtime));
 	pi.on(
 		"agent_end",
 		autoContinueAfterFocusTransition(pi, focus, runtime, focusReminder),
 	);
-	pi.on("tool_call", guardToolCall(pi, focus, services.tools));
+	pi.on("tool_call", guardToolCall(pi, focus, services.tools, runtime));
 }
 
 export function createFocusFeature(): Feature {

--- a/files/pi/agent/extensions/user/features/tool.ts
+++ b/files/pi/agent/extensions/user/features/tool.ts
@@ -168,7 +168,9 @@ function register(pi: ExtensionAPI, services: UserExtensionServices): void {
 	pi.on("session_start", async (_event: SessionStartEvent, ctx) => {
 		await ensureProjectUserSettingsTrusted(ctx);
 		const projectTools = registerProjectTools(pi, ctx, services.tools);
-		activateFocusTools(pi, services.focus.activeFocusDefinition);
+		activateFocusTools(pi, services.focus.activeFocusDefinition, {
+			includeManagementTools: services.focus.lockedFocusName === undefined,
+		});
 		if (ctx.hasUI) {
 			setTimeout(() => {
 				const { groups, unfocusedTools } = projectToolGroups(

--- a/files/pi/agent/extensions/user/lib/focus/cli.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/cli.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { describe, it } from "vitest";
+import {
+	FOCUS_FLAG_NAME,
+	getRequestedFocusName,
+	registerFocusFlag,
+} from "./cli";
+
+describe("focus CLI flag", () => {
+	it("registers --focus as a string flag", () => {
+		const registrations: Record<string, unknown> = {};
+		const pi = {
+			registerFlag: (name: string, options: unknown) => {
+				registrations[name] = options;
+			},
+		} as ExtensionAPI;
+
+		registerFocusFlag(pi);
+
+		assert.deepEqual(registrations[FOCUS_FLAG_NAME], {
+			description:
+				"Start pi locked to a focus. The selected focus is the only focus mode for this process.",
+			type: "string",
+		});
+	});
+
+	it("returns a trimmed requested focus name", () => {
+		assert.equal(
+			getRequestedFocusName({ getFlag: () => "  interview  " }),
+			"interview",
+		);
+	});
+
+	it("ignores missing, non-string, and blank focus flag values", () => {
+		assert.equal(
+			getRequestedFocusName({ getFlag: () => undefined }),
+			undefined,
+		);
+		assert.equal(getRequestedFocusName({ getFlag: () => true }), undefined);
+		assert.equal(getRequestedFocusName({ getFlag: () => "   " }), undefined);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/focus/cli.ts
+++ b/files/pi/agent/extensions/user/lib/focus/cli.ts
@@ -1,0 +1,20 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export const FOCUS_FLAG_NAME = "focus";
+
+export function registerFocusFlag(pi: ExtensionAPI): void {
+	pi.registerFlag(FOCUS_FLAG_NAME, {
+		description:
+			"Start pi locked to a focus. The selected focus is the only focus mode for this process.",
+		type: "string",
+	});
+}
+
+export function getRequestedFocusName(
+	pi: Pick<ExtensionAPI, "getFlag">,
+): string | undefined {
+	const value = pi.getFlag(FOCUS_FLAG_NAME);
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}

--- a/files/pi/agent/extensions/user/lib/focus/controller.ts
+++ b/files/pi/agent/extensions/user/lib/focus/controller.ts
@@ -31,7 +31,11 @@ export type FocusController = {
 	enter(
 		ctx: ExtensionContext,
 		focusName: FocusName,
-		options?: { persist?: boolean; force?: boolean },
+		options?: {
+			readonly persist?: boolean;
+			readonly force?: boolean;
+			readonly includeManagementTools?: boolean;
+		},
 	): FocusDefinition;
 	leave(
 		ctx: ExtensionContext,
@@ -41,7 +45,10 @@ export type FocusController = {
 		ctx: ExtensionContext,
 		focusName: FocusName | typeof BASE_FOCUS | undefined,
 	): void;
-	allowedToolNames(pi: ExtensionAPI): ReadonlySet<string>;
+	allowedToolNames(
+		pi: ExtensionAPI,
+		options?: { readonly includeManagementTools?: boolean },
+	): ReadonlySet<string>;
 };
 
 export function buildFocusRestorePrompt(focus: FocusDefinition): string {
@@ -66,12 +73,20 @@ export function createFocusController(
 		sharedState.setFocusState(currentFocusName, currentFocus, registry);
 	}
 
-	function apply(ctx: ExtensionContext, options?: { force?: boolean }): void {
+	function apply(
+		ctx: ExtensionContext,
+		options?: {
+			readonly force?: boolean;
+			readonly includeManagementTools?: boolean;
+		},
+	): void {
 		if (!options?.force && currentFocusName === sharedState.currentFocusName) {
 			return;
 		}
 		publish();
-		activateFocusTools(pi, currentFocus);
+		activateFocusTools(pi, currentFocus, {
+			includeManagementTools: options?.includeManagementTools,
+		});
 		applyFocusStatus(ctx, currentFocus);
 	}
 
@@ -116,7 +131,10 @@ export function createFocusController(
 			currentFocusName = focus.name;
 			currentFocus = focus;
 			if (options?.persist ?? true) persist(focus.name);
-			apply(ctx, { force: true });
+			apply(ctx, {
+				force: true,
+				includeManagementTools: options?.includeManagementTools,
+			});
 			return focus;
 		},
 		leave(ctx, options) {
@@ -143,10 +161,10 @@ export function createFocusController(
 			applyFocusStatus(ctx, focus);
 			publish();
 		},
-		allowedToolNames(focusPi) {
+		allowedToolNames(focusPi, options) {
 			return new Set(
 				currentFocus
-					? getActiveFocusTools(focusPi, currentFocus)
+					? getActiveFocusTools(focusPi, currentFocus, options)
 					: getBaseFocusTools(focusPi),
 			);
 		},

--- a/files/pi/agent/extensions/user/lib/focus/guard.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/guard.test.ts
@@ -8,6 +8,8 @@ import { createToolCatalog } from "../tool/catalog";
 import { guardToolCall } from "./guard";
 import { registerBuiltInFocusPolicies } from "./policies";
 import type { FocusController } from "./controller";
+import { ENTER_FOCUS_TOOL, EXIT_FOCUS_TOOL } from "./definitions";
+import type { FocusRuntime } from "./runtime";
 
 function toolCall(toolName: string, input: unknown): ToolCallEvent {
 	return { toolName, input } as ToolCallEvent;
@@ -17,7 +19,17 @@ function focus(allowedToolNames: readonly string[]): FocusController {
 	return {
 		current: "edit",
 		active: undefined,
-		allowedToolNames: () => new Set(allowedToolNames),
+		allowedToolNames: (
+			_pi: ExtensionAPI,
+			options?: { readonly includeManagementTools?: boolean },
+		) =>
+			new Set(
+				options?.includeManagementTools === false
+					? allowedToolNames.filter(
+							(name) => name !== ENTER_FOCUS_TOOL && name !== EXIT_FOCUS_TOOL,
+						)
+					: allowedToolNames,
+			),
 	} as unknown as FocusController;
 }
 
@@ -55,6 +67,28 @@ describe("guardToolCall", () => {
 		assert.equal(
 			await guard(toolCall("read", { path: "README.md" }), undefined as never),
 			undefined,
+		);
+	});
+
+	it("blocks focus management tool calls when focus is locked", async () => {
+		const catalog = createToolCatalog();
+		const runtime = { lockedFocusName: "edit" } as FocusRuntime;
+		const guard = guardToolCall(
+			{} as ExtensionAPI,
+			focus(["read", ENTER_FOCUS_TOOL, EXIT_FOCUS_TOOL]),
+			catalog,
+			runtime,
+		);
+
+		assert.deepEqual(
+			await guard(
+				toolCall(ENTER_FOCUS_TOOL, { name: "explore" }),
+				undefined as never,
+			),
+			{
+				block: true,
+				reason: `${ENTER_FOCUS_TOOL} is not available in edit focus.`,
+			},
 		);
 	});
 });

--- a/files/pi/agent/extensions/user/lib/focus/guard.ts
+++ b/files/pi/agent/extensions/user/lib/focus/guard.ts
@@ -6,6 +6,7 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import type { ToolCatalog } from "../tool";
 import type { FocusController } from "./controller";
+import type { FocusRuntime } from "./runtime";
 
 type BlockedToolCall = { block: true; reason: string };
 
@@ -18,11 +19,14 @@ export const guardToolCall =
 		pi: ExtensionAPI,
 		focus: FocusController,
 		catalog: ToolCatalog,
+		runtime?: FocusRuntime,
 	): ExtensionHandler<ToolCallEvent, ToolCallEventResult> =>
 	async (event) => {
 		const notAllowed = catalog.checkToolAllowed(
 			focus.current,
-			focus.allowedToolNames(pi),
+			focus.allowedToolNames(pi, {
+				includeManagementTools: runtime?.lockedFocusName === undefined,
+			}),
 			event,
 		);
 		if (notAllowed) return block(notAllowed);

--- a/files/pi/agent/extensions/user/lib/focus/prompt.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/prompt.test.ts
@@ -137,6 +137,26 @@ describe("focus prompt injection", () => {
 		assert.doesNotMatch(second?.systemPrompt ?? "", /\[FOCUS RESTORED/u);
 	});
 
+	it("hides focus management tools and adds lock guidance in locked focus mode", async () => {
+		const runtime = createFocusRuntime();
+		runtime.setLockedFocusName("edit");
+		const focus = focusController({
+			active: activeFocus(),
+			allowed: ["read", ENTER_FOCUS_TOOL, EXIT_FOCUS_TOOL],
+		});
+
+		const result = await injectFocusRestorePrompt(
+			pi(),
+			focus,
+			runtime,
+		)(beforeAgentEvent(baseSystemPrompt) as never, undefined as never);
+
+		assert.match(result?.systemPrompt ?? "", /\[FOCUS LOCKED: edit\]/u);
+		assert.match(result?.systemPrompt ?? "", /- read: Read files/u);
+		assert.doesNotMatch(result?.systemPrompt ?? "", /enter_focus/u);
+		assert.doesNotMatch(result?.systemPrompt ?? "", /exit_focus/u);
+	});
+
 	it("builds current reminder payloads and rejects stale reminder details", () => {
 		const runtime = createFocusRuntime();
 		const transition = runtime.recordFocusChange("edit");

--- a/files/pi/agent/extensions/user/lib/focus/prompt.ts
+++ b/files/pi/agent/extensions/user/lib/focus/prompt.ts
@@ -98,8 +98,12 @@ function visiblePromptToolNames(
 	focus: FocusController,
 	runtime: FocusRuntime,
 ): ReadonlySet<string> {
-	const allowedToolNames = focus.allowedToolNames(pi);
-	if (!runtime.userSelectedFocus) return allowedToolNames;
+	const allowedToolNames = focus.allowedToolNames(pi, {
+		includeManagementTools: runtime.lockedFocusName === undefined,
+	});
+	if (!runtime.userSelectedFocus && !runtime.lockedFocusName) {
+		return allowedToolNames;
+	}
 	const managementTools = focusManagementToolNames();
 	return new Set(
 		[...allowedToolNames].filter((name) => !managementTools.has(name)),
@@ -150,10 +154,25 @@ function formatToolDefinitions(tools: readonly ToolInfo[]): string {
 	);
 }
 
-function buildActiveFocusPrompt(focus: FocusController): string | undefined {
-	return focus.active
-		? `[ACTIVE FOCUS: ${focus.active.name}]\n${focus.active.prompt}`
+function buildActiveFocusPrompt(
+	focus: FocusController,
+	runtime: FocusRuntime,
+): string | undefined {
+	if (!focus.active) return undefined;
+	const lockedPrompt = runtime.lockedFocusName
+		? [
+				`[FOCUS LOCKED: ${runtime.lockedFocusName}]`,
+				"This pi process was started with --focus and is dedicated to this focus only.",
+				"Do not try to enter, switch, or exit focuses. Continue using only the visible tools for this focus.",
+			].join("\n")
 		: undefined;
+	return [
+		`[ACTIVE FOCUS: ${focus.active.name}]`,
+		focus.active.prompt,
+		lockedPrompt,
+	]
+		.filter(Boolean)
+		.join("\n");
 }
 
 function buildFocusReminderPayloadWithTools(
@@ -162,7 +181,7 @@ function buildFocusReminderPayloadWithTools(
 	runtime: FocusRuntime,
 ): SystemReminderPayload<FocusReminderDetails> {
 	const tools = visibleToolDefinitions(pi, focus, runtime);
-	const activePrompt = buildActiveFocusPrompt(focus);
+	const activePrompt = buildActiveFocusPrompt(focus, runtime);
 	const focusInstructions = activePrompt
 		? `Focus instructions:\n${activePrompt}`
 		: `Focus routing instructions:\n${buildFocusSystemPrompt(focus)}`;
@@ -209,7 +228,7 @@ export const injectFocusRestorePrompt =
 				systemPrompt: `${systemPrompt}\n\n${buildFocusRestorePrompt(focus.active)}`,
 			};
 		}
-		const activePrompt = buildActiveFocusPrompt(focus);
+		const activePrompt = buildActiveFocusPrompt(focus, runtime);
 		return activePrompt
 			? { systemPrompt: `${systemPrompt}\n\n${activePrompt}` }
 			: systemPrompt === event.systemPrompt

--- a/files/pi/agent/extensions/user/lib/focus/provider-filter.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/provider-filter.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import type {
+	BeforeProviderRequestEvent,
+	ExtensionAPI,
+} from "@earendil-works/pi-coding-agent";
+import { describe, it } from "vitest";
+import type { FocusController } from "./controller";
+import { ENTER_FOCUS_TOOL, EXIT_FOCUS_TOOL } from "./definitions";
+import { filterProviderTools } from "./provider-filter";
+import type { FocusRuntime } from "./runtime";
+
+function focus(allowedToolNames: readonly string[]): FocusController {
+	return {
+		allowedToolNames: (
+			_pi: ExtensionAPI,
+			options?: { readonly includeManagementTools?: boolean },
+		) =>
+			new Set(
+				options?.includeManagementTools === false
+					? allowedToolNames.filter(
+							(name) => name !== ENTER_FOCUS_TOOL && name !== EXIT_FOCUS_TOOL,
+						)
+					: allowedToolNames,
+			),
+	} as unknown as FocusController;
+}
+
+function event(payload: unknown): BeforeProviderRequestEvent {
+	return { payload } as BeforeProviderRequestEvent;
+}
+
+describe("filterProviderTools", () => {
+	it("removes focus management tools from provider payloads when focus is locked", async () => {
+		const payload = {
+			tools: [
+				{ name: "read" },
+				{ name: ENTER_FOCUS_TOOL },
+				{ function: { name: EXIT_FOCUS_TOOL } },
+			],
+		};
+		const runtime = { lockedFocusName: "edit" } as FocusRuntime;
+
+		assert.deepEqual(
+			await filterProviderTools(
+				{} as ExtensionAPI,
+				focus(["read", ENTER_FOCUS_TOOL, EXIT_FOCUS_TOOL]),
+				runtime,
+			)(event(payload), undefined as never),
+			{ tools: [{ name: "read" }] },
+		);
+	});
+
+	it("filters nested function declarations with the locked tool set", async () => {
+		const payload = {
+			contents: [
+				{
+					tools: [
+						{
+							functionDeclarations: [
+								{ name: "read" },
+								{ name: ENTER_FOCUS_TOOL },
+							],
+						},
+					],
+				},
+			],
+		};
+		const runtime = { lockedFocusName: "edit" } as FocusRuntime;
+
+		assert.deepEqual(
+			await filterProviderTools(
+				{} as ExtensionAPI,
+				focus(["read", ENTER_FOCUS_TOOL]),
+				runtime,
+			)(event(payload), undefined as never),
+			{
+				contents: [
+					{
+						tools: [
+							{
+								functionDeclarations: [{ name: "read" }],
+							},
+						],
+					},
+				],
+			},
+		);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/focus/provider-filter.ts
+++ b/files/pi/agent/extensions/user/lib/focus/provider-filter.ts
@@ -4,6 +4,7 @@ import type {
 	ExtensionHandler,
 } from "@earendil-works/pi-coding-agent";
 import type { FocusController } from "./controller";
+import type { FocusRuntime } from "./runtime";
 
 type PayloadRecord = Record<string, unknown>;
 
@@ -78,6 +79,12 @@ export const filterProviderTools =
 	(
 		pi: ExtensionAPI,
 		focus: FocusController,
+		runtime?: FocusRuntime,
 	): ExtensionHandler<BeforeProviderRequestEvent, unknown> =>
 	async (event) =>
-		filterProviderPayloadTools(event.payload, focus.allowedToolNames(pi));
+		filterProviderPayloadTools(
+			event.payload,
+			focus.allowedToolNames(pi, {
+				includeManagementTools: runtime?.lockedFocusName === undefined,
+			}),
+		);

--- a/files/pi/agent/extensions/user/lib/focus/runtime.ts
+++ b/files/pi/agent/extensions/user/lib/focus/runtime.ts
@@ -18,10 +18,12 @@ export type FocusRuntime = {
 	readonly focusReminderPending: boolean;
 	readonly resetFocusAtAgentEndPending: boolean;
 	readonly userSelectedFocus: boolean;
+	readonly lockedFocusName: FocusName | undefined;
 	readonly latestTransition: FocusAutoContinue;
 	readonly pendingAutoContinue: FocusAutoContinue | undefined;
 	setRestorePromptPending(pending: boolean): void;
 	setFocusReminderPending(pending: boolean): void;
+	setLockedFocusName(focusName: FocusName | undefined): void;
 	requestFocusReminder(): void;
 	consumeFocusReminderPending(): boolean;
 	setResetFocusAtAgentEndPending(pending: boolean): void;
@@ -42,6 +44,7 @@ export function createFocusRuntime(): FocusRuntime {
 	let focusReminderPending = false;
 	let resetFocusAtAgentEndPending = false;
 	let userSelectedFocus = false;
+	let lockedFocusName: FocusName | undefined;
 	let nextTransitionId = 1;
 	let latestTransition: FocusAutoContinue = { id: 0, focusName: BASE_FOCUS };
 	let pendingAutoContinue: FocusAutoContinue | undefined;
@@ -66,6 +69,9 @@ export function createFocusRuntime(): FocusRuntime {
 		get userSelectedFocus() {
 			return userSelectedFocus;
 		},
+		get lockedFocusName() {
+			return lockedFocusName;
+		},
 		get latestTransition() {
 			return latestTransition;
 		},
@@ -77,6 +83,9 @@ export function createFocusRuntime(): FocusRuntime {
 		},
 		setFocusReminderPending(pending) {
 			focusReminderPending = pending;
+		},
+		setLockedFocusName(focusName) {
+			lockedFocusName = focusName;
 		},
 		requestFocusReminder() {
 			focusReminderPending = true;

--- a/files/pi/agent/extensions/user/lib/focus/session.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/session.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { describe, it } from "vitest";
+import { createTestPiProject } from "../test-support/pi-project";
+import { BASE_FOCUS, FOCUS_STATE_TYPE } from "./definitions";
+import { createFocusController } from "./controller";
+import { createFocusRuntime } from "./runtime";
+import { createFocusSharedState } from "./state";
+import { persistFocusBeforeNew, restoreFocus } from "./session";
+
+function fakePi(): ExtensionAPI & {
+	readonly entries: { customType: string; data: unknown }[];
+	activeTools: string[];
+} {
+	const entries: { customType: string; data: unknown }[] = [];
+	const api = {
+		entries,
+		activeTools: [] as string[],
+		getAllTools: () =>
+			[
+				"multi_tool_use.parallel",
+				"enter_focus",
+				"exit_focus",
+				"read",
+				"grep",
+				"find",
+				"ls",
+				"write",
+				"edit",
+				"mv",
+				"rm",
+			].map((name) => ({ name })),
+		setActiveTools: (tools: string[]) => {
+			api.activeTools = tools;
+		},
+		appendEntry: (customType: string, data: unknown) => {
+			entries.push({ customType, data });
+		},
+	};
+	return api as unknown as ExtensionAPI & {
+		readonly entries: { customType: string; data: unknown }[];
+		activeTools: string[];
+	};
+}
+
+function context(cwd: string): ExtensionContext & {
+	readonly notifications: string[];
+} {
+	const notifications: string[] = [];
+	return {
+		cwd,
+		hasUI: false,
+		isProjectTrusted: () => true,
+		sessionManager: { getEntries: () => [] },
+		ui: {
+			setStatus: () => undefined,
+			notify: (message: string) => notifications.push(message),
+		},
+		notifications,
+	} as unknown as ExtensionContext & { readonly notifications: string[] };
+}
+
+describe("focus session lifecycle", () => {
+	it("locks to --focus without persisting or exposing focus management tools", async () => {
+		const pi = fakePi();
+		const runtime = createFocusRuntime();
+		const sharedState = createFocusSharedState();
+		const focus = createFocusController(pi, sharedState);
+		const ctx = context(
+			createTestPiProject({ includeUserSettings: false }).cwd,
+		);
+
+		await restoreFocus(focus, runtime, {
+			getLockedFocusName: () => "explore",
+			onLockedFocusName: (name) => sharedState.setLockedFocusName(name),
+		})(undefined as never, ctx);
+
+		assert.equal(runtime.lockedFocusName, "explore");
+		assert.equal(sharedState.lockedFocusName, "explore");
+		assert.equal(focus.current, "explore");
+		assert.deepEqual(pi.entries, []);
+		assert.deepEqual(pi.activeTools, [
+			"multi_tool_use.parallel",
+			"read",
+			"grep",
+			"find",
+			"ls",
+		]);
+	});
+
+	it("reports unknown locked focuses", async () => {
+		const pi = fakePi();
+		const runtime = createFocusRuntime();
+		const focus = createFocusController(pi, createFocusSharedState());
+		const ctx = context(
+			createTestPiProject({ includeUserSettings: false }).cwd,
+		);
+
+		await assert.rejects(async () => {
+			await restoreFocus(focus, runtime, {
+				getLockedFocusName: () => "missing",
+			})(undefined as never, ctx);
+		}, /Unknown --focus 'missing'/u);
+		assert.equal(focus.current, BASE_FOCUS);
+	});
+
+	it("does not persist focus across new sessions when locked", async () => {
+		const pi = fakePi();
+		const runtime = createFocusRuntime();
+		const focus = createFocusController(pi, createFocusSharedState());
+		const ctx = context(
+			createTestPiProject({ includeUserSettings: false }).cwd,
+		);
+
+		focus.enter(ctx, "explore");
+		const entryCount = pi.entries.length;
+		await persistFocusBeforeNew(
+			pi,
+			focus,
+			runtime,
+		)({ reason: "new" } as never, ctx);
+		assert.deepEqual(pi.entries.at(-1), {
+			customType: FOCUS_STATE_TYPE,
+			data: { focus: "explore" },
+		});
+
+		runtime.setLockedFocusName("explore");
+		await persistFocusBeforeNew(
+			pi,
+			focus,
+			runtime,
+		)({ reason: "new" } as never, ctx);
+		assert.equal(pi.entries.length, entryCount + 1);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/focus/session.ts
+++ b/files/pi/agent/extensions/user/lib/focus/session.ts
@@ -9,7 +9,12 @@ import { ensureProjectUserSettingsTrusted } from "../project-settings";
 import type { RegisteredSystemReminder } from "../system-reminder";
 import { clearFocusTransitionDecisions } from "./confirmation";
 import type { FocusController } from "./controller";
-import { BASE_FOCUS, FOCUS_STATE_TYPE, getFocusExitMode } from "./definitions";
+import {
+	BASE_FOCUS,
+	FOCUS_STATE_TYPE,
+	type FocusName,
+	getFocusExitMode,
+} from "./definitions";
 import type { FocusReminderDetails } from "./prompt";
 import type { FocusRuntime } from "./runtime";
 import { findPersistedFocus } from "./startup";
@@ -20,28 +25,75 @@ export const persistFocusBeforeNew =
 	(
 		pi: ExtensionAPI,
 		focus: FocusController,
+		runtime: FocusRuntime,
 	): ExtensionHandler<SessionBeforeSwitchEvent, SessionBeforeSwitchResult> =>
 	async (event) => {
 		if (event.reason !== "new") return;
+		if (runtime.lockedFocusName) return;
 		pi.appendEntry(FOCUS_STATE_TYPE, { focus: focus.current });
 	};
+
+type RestoreFocusOptions = {
+	readonly getLockedFocusName?: () => FocusName | undefined;
+	readonly onLockedFocusName?: (focusName: FocusName | undefined) => void;
+};
+
+function formatUnknownLockedFocusMessage(
+	requested: FocusName,
+	available: readonly FocusName[],
+): string {
+	const availableText =
+		available.length > 0
+			? `Available focuses: ${available.map((name) => `'${name}'`).join(", ")}.`
+			: "No focuses are currently available.";
+	return `Unknown --focus '${requested}'. ${availableText}`;
+}
 
 export const restoreFocus =
 	(
 		focus: FocusController,
 		runtime: FocusRuntime,
+		options?: RestoreFocusOptions,
 	): ExtensionHandler<SessionStartEvent> =>
 	async (_event, ctx) => {
 		await ensureProjectUserSettingsTrusted(ctx);
 		focus.loadProjectFocuses(ctx);
+		const lockedFocusName = options?.getLockedFocusName?.();
+		runtime.setLockedFocusName(lockedFocusName);
+		options?.onLockedFocusName?.(lockedFocusName);
+		runtime.setResetFocusAtAgentEndPending(false);
+		runtime.setUserSelectedFocus(false);
+		runtime.cancelAutoContinue();
+
+		if (lockedFocusName) {
+			if (!focus.registry.get(lockedFocusName)) {
+				focus.restore(ctx, undefined);
+				const available = focus.registry
+					.list()
+					.map((definition) => definition.name);
+				const message = formatUnknownLockedFocusMessage(
+					lockedFocusName,
+					available,
+				);
+				if (ctx.hasUI) ctx.ui.notify(message, "error");
+				throw new Error(message);
+			}
+			focus.enter(ctx, lockedFocusName, {
+				persist: false,
+				force: true,
+				includeManagementTools: false,
+			});
+			runtime.recordFocusChange(focus.current);
+			runtime.setRestorePromptPending(true);
+			runtime.setFocusReminderPending(true);
+			return;
+		}
+
 		const persisted = findPersistedFocus(ctx);
 		focus.restore(ctx, persisted);
 		runtime.recordFocusChange(focus.current);
 		runtime.setRestorePromptPending(focus.active !== undefined);
 		runtime.setFocusReminderPending(focus.active !== undefined);
-		runtime.setResetFocusAtAgentEndPending(false);
-		runtime.setUserSelectedFocus(false);
-		runtime.cancelAutoContinue();
 	};
 
 export const resetFocusAtAgentEnd =
@@ -50,6 +102,7 @@ export const resetFocusAtAgentEnd =
 		runtime: FocusRuntime,
 	): ExtensionHandler<AgentEndEvent> =>
 	async (_event, ctx) => {
+		if (runtime.lockedFocusName) return;
 		if (runtime.pendingAutoContinue) return;
 		if (!focus.active || !runtime.resetFocusAtAgentEndPending) return;
 		if (getFocusExitMode(focus.active) !== "single-turn") {

--- a/files/pi/agent/extensions/user/lib/focus/state.ts
+++ b/files/pi/agent/extensions/user/lib/focus/state.ts
@@ -12,17 +12,20 @@ const emptyRegistry = loadFocusRegistry("/", {
 export type FocusSharedState = {
 	readonly currentFocusName: FocusName | typeof BASE_FOCUS;
 	readonly activeFocusDefinition: FocusDefinition | undefined;
+	readonly lockedFocusName: FocusName | undefined;
 	readonly registry: FocusRegistry;
 	setFocusState(
 		name: FocusName | typeof BASE_FOCUS,
 		definition: FocusDefinition | undefined,
 		registry: FocusRegistry,
 	): void;
+	setLockedFocusName(name: FocusName | undefined): void;
 };
 
 export function createFocusSharedState(): FocusSharedState {
 	let currentFocusName: FocusName | typeof BASE_FOCUS = BASE_FOCUS;
 	let activeFocusDefinition: FocusDefinition | undefined;
+	let lockedFocusName: FocusName | undefined;
 	let registry: FocusRegistry = emptyRegistry;
 
 	return {
@@ -32,6 +35,9 @@ export function createFocusSharedState(): FocusSharedState {
 		get activeFocusDefinition() {
 			return activeFocusDefinition;
 		},
+		get lockedFocusName() {
+			return lockedFocusName;
+		},
 		get registry() {
 			return registry;
 		},
@@ -39,6 +45,9 @@ export function createFocusSharedState(): FocusSharedState {
 			currentFocusName = nextName;
 			activeFocusDefinition = nextDefinition;
 			registry = nextRegistry;
+		},
+		setLockedFocusName(name) {
+			lockedFocusName = name;
 		},
 	};
 }

--- a/files/pi/agent/extensions/user/lib/focus/tool-access.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/tool-access.test.ts
@@ -73,6 +73,25 @@ describe("focus tool access", () => {
 		]);
 	});
 
+	it("can hide focus management tools for locked focus mode", () => {
+		const api = pi([
+			"read",
+			"write",
+			"multi_tool_use.parallel",
+			ENTER_FOCUS_TOOL,
+			EXIT_FOCUS_TOOL,
+		]);
+
+		assert.deepEqual(
+			getActiveFocusTools(api, focus(), { includeManagementTools: false }),
+			["multi_tool_use.parallel", "read", "write"],
+		);
+		assert.deepEqual(
+			activateFocusTools(api, focus(), { includeManagementTools: false }),
+			["multi_tool_use.parallel", "read", "write"],
+		);
+	});
+
 	it("explicit-exit focuses expose exit_focus instead of enter_focus", () => {
 		const api = pi([
 			"read",

--- a/files/pi/agent/extensions/user/lib/focus/tool-access.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/tool-access.test.ts
@@ -55,6 +55,20 @@ describe("focus tool access", () => {
 		]);
 	});
 
+	it("can hide base focus management tools for locked focus mode", () => {
+		const api = pi(["read", "multi_tool_use.parallel", ENTER_FOCUS_TOOL]);
+
+		assert.deepEqual(
+			getBaseFocusTools(api, { includeManagementTools: false }),
+			["multi_tool_use.parallel"],
+		);
+		assert.deepEqual(
+			activateBaseFocusTools(api, { includeManagementTools: false }),
+			["multi_tool_use.parallel"],
+		);
+		assert.deepEqual(api.activeTools, ["multi_tool_use.parallel"]);
+	});
+
 	it("active single-turn focuses get declared tools plus enter_focus", () => {
 		const api = pi([
 			"read",

--- a/files/pi/agent/extensions/user/lib/focus/tool-access.ts
+++ b/files/pi/agent/extensions/user/lib/focus/tool-access.ts
@@ -24,10 +24,16 @@ function filterAvailable(pi: ExtensionAPI, names: readonly string[]): string[] {
 	);
 }
 
-export function getBaseFocusTools(pi: ExtensionAPI): string[] {
+export function getBaseFocusTools(
+	pi: ExtensionAPI,
+	options?: FocusToolAccessOptions,
+): string[] {
 	return filterAvailable(
 		pi,
-		unique([...ALWAYS_ALLOWED_TOOL_NAMES, ENTER_FOCUS_TOOL]),
+		unique([
+			...ALWAYS_ALLOWED_TOOL_NAMES,
+			...(options?.includeManagementTools === false ? [] : [ENTER_FOCUS_TOOL]),
+		]),
 	);
 }
 
@@ -40,7 +46,15 @@ function declaredFocusToolNames(focus: FocusDefinition): string[] {
 	);
 }
 
-function activeFocusManagementToolNames(focus: FocusDefinition): string[] {
+type FocusToolAccessOptions = {
+	readonly includeManagementTools?: boolean;
+};
+
+function activeFocusManagementToolNames(
+	focus: FocusDefinition,
+	options?: FocusToolAccessOptions,
+): string[] {
+	if (options?.includeManagementTools === false) return [];
 	switch (getFocusExitMode(focus)) {
 		case "explicit":
 			return [EXIT_FOCUS_TOOL];
@@ -52,19 +66,23 @@ function activeFocusManagementToolNames(focus: FocusDefinition): string[] {
 export function getActiveFocusTools(
 	pi: ExtensionAPI,
 	focus: FocusDefinition,
+	options?: FocusToolAccessOptions,
 ): string[] {
 	return filterAvailable(
 		pi,
 		unique([
 			...ALWAYS_ALLOWED_TOOL_NAMES,
 			...declaredFocusToolNames(focus),
-			...activeFocusManagementToolNames(focus),
+			...activeFocusManagementToolNames(focus, options),
 		]),
 	);
 }
 
-export function activateBaseFocusTools(pi: ExtensionAPI): string[] {
-	const tools = getBaseFocusTools(pi);
+export function activateBaseFocusTools(
+	pi: ExtensionAPI,
+	options?: FocusToolAccessOptions,
+): string[] {
+	const tools = getBaseFocusTools(pi, options);
 	pi.setActiveTools(tools);
 	return tools;
 }
@@ -72,8 +90,11 @@ export function activateBaseFocusTools(pi: ExtensionAPI): string[] {
 export function activateFocusTools(
 	pi: ExtensionAPI,
 	focus: FocusDefinition | undefined,
+	options?: FocusToolAccessOptions,
 ): string[] {
-	const tools = focus ? getActiveFocusTools(pi, focus) : getBaseFocusTools(pi);
+	const tools = focus
+		? getActiveFocusTools(pi, focus, options)
+		: getBaseFocusTools(pi, options);
 	pi.setActiveTools(tools);
 	return tools;
 }


### PR DESCRIPTION

## Summary

- add a --focus flag that starts Pi locked to a single focus mode
- hide focus management tools and quick actions while focus is locked
- avoid persisting locked focus state and add tests for session, prompt, and tool access behavior

## Background

This lets a Pi process be dedicated to one focus from startup and fail early when an unknown focus name is requested.
