### PR TITLE
Add user extension disable setting

### DIFF
--- a/files/agent-skills/pi-agent-user-settings/SKILL.md
+++ b/files/agent-skills/pi-agent-user-settings/SKILL.md
@@ -12,7 +12,7 @@ Use this skill only for:
 - Pi agent user settings
 - `.pi/settings.user.json`
 - project user settings for Pi
-- adding, editing, renaming, removing, reviewing, or explaining `tools`, `toolSets`, or `focuses` in `.pi/settings.user.json`
+- adding, editing, renaming, removing, reviewing, or explaining `enabled`, `tools`, `toolSets`, or `focuses` in `.pi/settings.user.json`
 
 Do not use this skill for ordinary shell commands, lint/test/format requests, Pi's native settings files, or non-Pi configuration.
 
@@ -82,6 +82,7 @@ Do not use this skill for ordinary shell commands, lint/test/format requests, Pi
 
 Currently supported project user settings include:
 
+- `enabled`: set to `false` to make this user extension a no-op for the project; omitted or any other value keeps it enabled.
 - `tools`: repository-defined tool definitions callable only for that project.
 - `toolSets`: reusable groups of tool names for focus tool lists.
 - `focuses`: project-local focus additions or overrides for user-extension focuses.

--- a/files/pi/agent/extensions/user/lib/project-settings.test.ts
+++ b/files/pi/agent/extensions/user/lib/project-settings.test.ts
@@ -6,6 +6,7 @@ import {
 	ensureProjectUserSettingsTrusted,
 	hasProjectUserSettings,
 	isProjectUserSettingsTrusted,
+	isUserExtensionEnabled,
 	loadProjectUserSettings,
 } from "./project-settings";
 
@@ -58,6 +59,35 @@ describe("project user settings", () => {
 		assert.throws(
 			() => loadProjectUserSettings(invalid),
 			/settings\.user\.json must contain a JSON object/u,
+		);
+	});
+
+	it("disables the user extension only when enabled is false", () => {
+		assert.equal(
+			isUserExtensionEnabled(
+				createTestPiProject({ includeUserSettings: false }).cwd,
+			),
+			true,
+		);
+		assert.equal(
+			isUserExtensionEnabled(createTestPiProject({ settings: {} }).cwd),
+			true,
+		);
+		assert.equal(
+			isUserExtensionEnabled(
+				createTestPiProject({ settings: { enabled: true } }).cwd,
+			),
+			true,
+		);
+		assert.equal(
+			isUserExtensionEnabled(
+				createTestPiProject({ settings: { enabled: false } }).cwd,
+			),
+			false,
+		);
+		assert.equal(
+			isUserExtensionEnabled(createTestPiProject({ rawSettings: "[]" }).cwd),
+			true,
 		);
 	});
 

--- a/files/pi/agent/extensions/user/lib/project-settings.ts
+++ b/files/pi/agent/extensions/user/lib/project-settings.ts
@@ -114,6 +114,14 @@ export function loadProjectUserSettings(cwd: string): ProjectUserSettings {
 	return parsed as ProjectUserSettings;
 }
 
+export function isUserExtensionEnabled(cwd: string): boolean {
+	try {
+		return loadProjectUserSettings(cwd).enabled !== false;
+	} catch {
+		return true;
+	}
+}
+
 function formatProjectUserSettingsTrustPrompt(cwd: string): string {
 	return `Trust project user settings?\n${cwd}\n\nThis allows the user extension to load ${PROJECT_USER_SETTINGS_RELATIVE_PATH} and enable project-defined tools. Project tools are repository-controlled commands.`;
 }

--- a/files/pi/agent/extensions/user/main.test.ts
+++ b/files/pi/agent/extensions/user/main.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { describe, it } from "vitest";
+import user from "./main";
+import { createTestPiProject } from "./lib/test-support/pi-project";
+
+function withCwd<T>(cwd: string, fn: () => T): T {
+	const original = process.cwd();
+	process.chdir(cwd);
+	try {
+		return fn();
+	} finally {
+		process.chdir(original);
+	}
+}
+
+describe("user extension", () => {
+	it("does not register features when project user settings disables it", () => {
+		const project = createTestPiProject({ settings: { enabled: false } });
+		const pi = new Proxy(
+			{},
+			{
+				get: (_target, property) => {
+					throw new Error(`Unexpected pi.${String(property)} access.`);
+				},
+			},
+		) as ExtensionAPI;
+
+		assert.doesNotThrow(() => withCwd(project.cwd, () => user(pi)));
+	});
+});

--- a/files/pi/agent/extensions/user/main.ts
+++ b/files/pi/agent/extensions/user/main.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { Feature } from "./feature";
+import { isUserExtensionEnabled } from "./lib/project-settings";
 import { createUserExtensionServices } from "./lib/services";
 import { createExitConfirmFeature } from "./features/exit-confirm";
 import { createFocusFeature } from "./features/focus";
@@ -42,6 +43,8 @@ function assertFeatureDependencies(features: readonly Feature[]): void {
 }
 
 export default function user(pi: ExtensionAPI): void {
+	if (!isUserExtensionEnabled(process.cwd())) return;
+
 	const services = createUserExtensionServices();
 	const features = createFeatures();
 	assertFeatureDependencies(features);


### PR DESCRIPTION
## Summary

- Add a project-level `enabled: false` setting for `.pi/settings.user.json`.
- Make the dotfiles user extension return early when that setting disables it.
- Document the new setting and cover the no-op behavior with tests.

## Background

Some projects need to opt out of this dotfiles user extension without changing the global Pi extension setup. This lets those projects declare the opt-out in the existing project user settings file while keeping the extension enabled everywhere else.
