### PR TITLE
Refine focus mode tool access

### DIFF
--- a/files/pi/agent/extensions/user/lib/focus/definitions.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/definitions.test.ts
@@ -3,7 +3,10 @@ import { describe, it } from "vitest";
 import {
 	BASE_FOCUS_DEFINITIONS,
 	BUILT_IN_TOOL_SETS,
+	FOCUS_EXIT_MODE,
+	FOCUS_TRANSITION,
 	getFocusExitMode,
+	isFocusExitMode,
 	isFocusTransition,
 } from "./definitions";
 
@@ -31,9 +34,9 @@ describe("focus definitions", () => {
 				description: "demo",
 				prompt: "demo",
 				tools: [],
-				transition: "auto",
+				transition: FOCUS_TRANSITION.AUTO,
 			}),
-			"single-turn",
+			FOCUS_EXIT_MODE.SINGLE_TURN,
 		);
 		assert.equal(
 			getFocusExitMode({
@@ -41,17 +44,24 @@ describe("focus definitions", () => {
 				description: "demo",
 				prompt: "demo",
 				tools: [],
-				transition: "auto",
-				exitMode: "explicit",
+				transition: FOCUS_TRANSITION.AUTO,
+				exitMode: FOCUS_EXIT_MODE.EXPLICIT,
 			}),
-			"explicit",
+			FOCUS_EXIT_MODE.EXPLICIT,
 		);
 	});
 
+	it("recognizes focus exit mode values", () => {
+		assert.equal(isFocusExitMode(FOCUS_EXIT_MODE.SINGLE_TURN), true);
+		assert.equal(isFocusExitMode(FOCUS_EXIT_MODE.EXPLICIT), true);
+		assert.equal(isFocusExitMode("other"), false);
+		assert.equal(isFocusExitMode(undefined), false);
+	});
+
 	it("recognizes focus transition values", () => {
-		assert.equal(isFocusTransition("auto"), true);
-		assert.equal(isFocusTransition("confirm"), true);
-		assert.equal(isFocusTransition("manual"), true);
+		assert.equal(isFocusTransition(FOCUS_TRANSITION.AUTO), true);
+		assert.equal(isFocusTransition(FOCUS_TRANSITION.CONFIRM), true);
+		assert.equal(isFocusTransition(FOCUS_TRANSITION.MANUAL), true);
 		assert.equal(isFocusTransition("other"), false);
 		assert.equal(isFocusTransition(undefined), false);
 	});

--- a/files/pi/agent/extensions/user/lib/focus/definitions.ts
+++ b/files/pi/agent/extensions/user/lib/focus/definitions.ts
@@ -1,7 +1,18 @@
 import type { ColorRole } from "../theme";
 
-export type FocusTransition = "auto" | "confirm" | "manual";
-export type FocusExitMode = "single-turn" | "explicit";
+export const FOCUS_TRANSITION = {
+	AUTO: "auto",
+	CONFIRM: "confirm",
+	MANUAL: "manual",
+} as const;
+export type FocusTransition =
+	(typeof FOCUS_TRANSITION)[keyof typeof FOCUS_TRANSITION];
+export const FOCUS_EXIT_MODE = {
+	SINGLE_TURN: "single-turn",
+	EXPLICIT: "explicit",
+} as const;
+export type FocusExitMode =
+	(typeof FOCUS_EXIT_MODE)[keyof typeof FOCUS_EXIT_MODE];
 export type FocusName = string;
 
 export type FocusDefinition = {
@@ -25,7 +36,7 @@ export const ENTER_FOCUS_TOOL = "enter_focus";
 export const EXIT_FOCUS_TOOL = "exit_focus";
 
 export function getFocusExitMode(focus: FocusDefinition): FocusExitMode {
-	return focus.exitMode ?? "single-turn";
+	return focus.exitMode ?? FOCUS_EXIT_MODE.SINGLE_TURN;
 }
 
 export const BUILT_IN_TOOL_SETS: ReadonlyMap<string, readonly string[]> =
@@ -43,7 +54,7 @@ export const BASE_FOCUS_DEFINITIONS: readonly FocusDefinition[] = [
 			"You are in explore focus. Read and search the repository to understand the task.",
 		tools: [],
 		toolSets: ["file_read"],
-		transition: "auto",
+		transition: FOCUS_TRANSITION.AUTO,
 		color: "accent",
 	},
 	{
@@ -54,7 +65,7 @@ export const BASE_FOCUS_DEFINITIONS: readonly FocusDefinition[] = [
 			"You are in edit focus. Make focused file changes with read/write/edit/mv/rm. Keep changes minimal.",
 		tools: [],
 		toolSets: ["file_read", "file_write"],
-		transition: "confirm",
+		transition: FOCUS_TRANSITION.CONFIRM,
 		color: "positive",
 	},
 	{
@@ -77,8 +88,8 @@ export const BASE_FOCUS_DEFINITIONS: readonly FocusDefinition[] = [
 			"Interview focus has ended. Continue from the agreed requirements instead of stopping. If the user approved implementation, enter the appropriate implementation focus and proceed; otherwise follow the agreed next action.",
 		tools: ["ask_user_question"],
 		toolSets: ["file_read"],
-		transition: "auto",
-		exitMode: "explicit",
+		transition: FOCUS_TRANSITION.AUTO,
+		exitMode: FOCUS_EXIT_MODE.EXPLICIT,
 		interactiveOnly: true,
 		color: "accent",
 	},
@@ -103,7 +114,7 @@ export const BASE_FOCUS_DEFINITIONS: readonly FocusDefinition[] = [
 			"github_compare",
 			"github_pr_checks",
 		],
-		transition: "auto",
+		transition: FOCUS_TRANSITION.AUTO,
 		color: "accent",
 	},
 	{
@@ -113,11 +124,21 @@ export const BASE_FOCUS_DEFINITIONS: readonly FocusDefinition[] = [
 		prompt:
 			"You are in yolo focus. Use read, write, edit, and bash to inspect and modify files and run shell commands. Avoid exposing secrets or credentials. If a command may print secrets, use a safer command or mask sensitive output. Ask for confirmation for gray-area destructive or privacy-sensitive actions.",
 		tools: ["read", "write", "edit", "bash"],
-		transition: "manual",
+		transition: FOCUS_TRANSITION.MANUAL,
 		color: "alert",
 	},
 ];
 
 export function isFocusTransition(value: unknown): value is FocusTransition {
-	return value === "auto" || value === "confirm" || value === "manual";
+	return (
+		value === FOCUS_TRANSITION.AUTO ||
+		value === FOCUS_TRANSITION.CONFIRM ||
+		value === FOCUS_TRANSITION.MANUAL
+	);
+}
+
+export function isFocusExitMode(value: unknown): value is FocusExitMode {
+	return (
+		value === FOCUS_EXIT_MODE.SINGLE_TURN || value === FOCUS_EXIT_MODE.EXPLICIT
+	);
 }

--- a/files/pi/agent/extensions/user/lib/focus/prompt.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/prompt.test.ts
@@ -6,6 +6,7 @@ import type { FocusController } from "./controller";
 import {
 	ENTER_FOCUS_TOOL,
 	EXIT_FOCUS_TOOL,
+	FOCUS_TRANSITION,
 	type FocusDefinition,
 } from "./definitions";
 import {
@@ -23,7 +24,7 @@ function activeFocus(
 		description: "Edit files",
 		prompt: "Edit prompt",
 		tools: ["read", "write"],
-		transition: "confirm",
+		transition: FOCUS_TRANSITION.CONFIRM,
 		...overrides,
 	};
 }
@@ -51,6 +52,7 @@ function focusController(options: {
 	readonly current?: string;
 	readonly active?: FocusDefinition;
 	readonly allowed?: readonly string[];
+	readonly searchable?: readonly FocusDefinition[];
 }): FocusController {
 	const active = options.active;
 	return {
@@ -59,7 +61,14 @@ function focusController(options: {
 		allowedToolNames: () =>
 			new Set(options.allowed ?? ["read", ENTER_FOCUS_TOOL]),
 		registry: {
-			search: () => [activeFocus({ name: "explore", description: "Explore" })],
+			search: () =>
+				options.searchable ?? [
+					activeFocus({
+						name: "explore",
+						description: "Explore",
+						transition: FOCUS_TRANSITION.AUTO,
+					}),
+				],
 		},
 	} as unknown as FocusController;
 }
@@ -114,6 +123,35 @@ describe("focus prompt injection", () => {
 		assert.doesNotMatch(result?.systemPrompt ?? "", /<available_skills>/u);
 		assert.match(result?.systemPrompt ?? "", /\[FOCUS\]/u);
 		assert.match(result?.systemPrompt ?? "", /explore: Explore/u);
+	});
+
+	it("marks confirmation-required focuses in routing instructions", async () => {
+		const runtime = createFocusRuntime();
+		const result = await injectFocusRestorePrompt(
+			pi(),
+			focusController({
+				allowed: [ENTER_FOCUS_TOOL],
+				searchable: [
+					activeFocus({
+						name: "explore",
+						description: "Explore",
+						transition: FOCUS_TRANSITION.AUTO,
+					}),
+					activeFocus({
+						name: "edit",
+						description: "Edit files",
+						transition: FOCUS_TRANSITION.CONFIRM,
+					}),
+				],
+			}),
+			runtime,
+		)(beforeAgentEvent(baseSystemPrompt) as never, undefined as never);
+
+		assert.match(result?.systemPrompt ?? "", /- explore: Explore/u);
+		assert.match(
+			result?.systemPrompt ?? "",
+			/- edit \(reason required\): Edit files/u,
+		);
 	});
 
 	it("injects restore prompts once for restored active focuses", async () => {

--- a/files/pi/agent/extensions/user/lib/focus/prompt.ts
+++ b/files/pi/agent/extensions/user/lib/focus/prompt.ts
@@ -9,6 +9,8 @@ import {
 	ENTER_FOCUS_TOOL,
 	EXIT_FOCUS_TOOL,
 	FOCUS_REMINDER_TYPE,
+	FOCUS_TRANSITION,
+	type FocusTransition,
 } from "./definitions";
 import type { FocusRuntime } from "./runtime";
 import type {
@@ -26,10 +28,20 @@ export type FocusReminderDetails = {
 };
 
 function formatFocusList(
-	focuses: readonly { name: string; description: string }[],
+	focuses: readonly {
+		name: string;
+		description: string;
+		transition: FocusTransition;
+	}[],
 ): string {
 	return focuses
-		.map((focus) => `- ${focus.name}: ${focus.description}`)
+		.map((focus) => {
+			const label =
+				focus.transition === FOCUS_TRANSITION.CONFIRM
+					? `${focus.name} (reason required)`
+					: focus.name;
+			return `- ${label}: ${focus.description}`;
+		})
 		.join("\n");
 }
 
@@ -37,6 +49,7 @@ function buildFocusSystemPrompt(focus: FocusController): string {
 	const focuses = focus.registry.search().map((definition) => ({
 		name: definition.name,
 		description: definition.description,
+		transition: definition.transition,
 	}));
 	return `[FOCUS]\nUse focuses to solve the user's request.\n\nFocus rules:\n- A focus is an operational mode that controls available tools and instructions.\n- Use the descriptions below to choose when to enter each focus.\n- Enter the appropriate focus before doing substantive work.\n- Auto focuses may be entered without asking the user.\n- Do not ask the user for information that can be discovered after entering an appropriate focus.\n- If a needed capability is not visible, first check whether another available focus exposes it.\n\nAvailable focuses:\n${formatFocusList(focuses)}`;
 }

--- a/files/pi/agent/extensions/user/lib/focus/registry.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/registry.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "vitest";
 import { createTestPiProject } from "../test-support/pi-project";
+import { FOCUS_EXIT_MODE, FOCUS_TRANSITION } from "./definitions";
 import { loadFocusRegistry } from "./registry";
 
 function testProjectCwd(settings: Record<string, unknown>): string {
@@ -21,7 +22,7 @@ describe("loadFocusRegistry", () => {
 					exitPrompt: "Project exit instructions.",
 					tools: ["format", "lint"],
 					toolSets: ["all_verify"],
-					transition: "auto",
+					transition: FOCUS_TRANSITION.AUTO,
 					color: "caution",
 				},
 			},
@@ -35,7 +36,7 @@ describe("loadFocusRegistry", () => {
 		assert.match(edit?.prompt ?? "", /Make focused file changes/u);
 		assert.match(edit?.prompt ?? "", /Project-specific edit instructions/u);
 		assert.equal(edit?.exitPrompt, "Project exit instructions.");
-		assert.equal(edit?.transition, "confirm");
+		assert.equal(edit?.transition, FOCUS_TRANSITION.CONFIRM);
 		assert.equal(edit?.color, "caution");
 		assert.deepEqual(edit?.settingsTools, [
 			"lint",
@@ -64,7 +65,7 @@ describe("loadFocusRegistry", () => {
 					description: "Run CI checks",
 					prompt: "Use CI tools only.",
 					toolSets: ["verify"],
-					exitMode: "explicit",
+					exitMode: FOCUS_EXIT_MODE.EXPLICIT,
 					color: "positive",
 				},
 			},
@@ -74,8 +75,8 @@ describe("loadFocusRegistry", () => {
 		const ci = registry.get("ci");
 
 		assert.deepEqual(warnings, []);
-		assert.equal(ci?.transition, "confirm");
-		assert.equal(ci?.exitMode, "explicit");
+		assert.equal(ci?.transition, FOCUS_TRANSITION.CONFIRM);
+		assert.equal(ci?.exitMode, FOCUS_EXIT_MODE.EXPLICIT);
 		assert.equal(ci?.color, "positive");
 		assert.deepEqual(ci?.tools, ["lint", "test"]);
 		assert.deepEqual(ci?.settingsTools, ["lint", "test"]);

--- a/files/pi/agent/extensions/user/lib/focus/registry.ts
+++ b/files/pi/agent/extensions/user/lib/focus/registry.ts
@@ -8,10 +8,12 @@ import {
 	BASE_FOCUS,
 	BASE_FOCUS_DEFINITIONS,
 	BUILT_IN_TOOL_SETS,
+	FOCUS_TRANSITION,
 	type FocusDefinition,
 	type FocusExitMode,
 	type FocusName,
 	type FocusTransition,
+	isFocusExitMode,
 	isFocusTransition,
 } from "./definitions";
 
@@ -101,7 +103,7 @@ function normalizeExitMode(
 	path: string,
 ): FocusExitMode | undefined {
 	if (value === undefined) return undefined;
-	if (value !== "single-turn" && value !== "explicit") {
+	if (!isFocusExitMode(value)) {
 		throw new Error(`${path} must be single-turn or explicit.`);
 	}
 	return value;
@@ -285,7 +287,7 @@ function createProjectFocus(
 		exitPrompt: project.exitPrompt,
 		tools: unique(projectTools),
 		settingsTools: unique(projectTools),
-		transition: project.transition ?? "confirm",
+		transition: project.transition ?? FOCUS_TRANSITION.CONFIRM,
 		exitMode: project.exitMode,
 		color: project.color,
 	};
@@ -308,7 +310,7 @@ function createRegistry(
 		list: () => [...byName.values()],
 		search(query) {
 			const searchable = [...byName.values()].filter(
-				(focus) => focus.transition !== "manual",
+				(focus) => focus.transition !== FOCUS_TRANSITION.MANUAL,
 			);
 			const normalized = query?.trim().toLowerCase();
 			if (!normalized) return searchable;

--- a/files/pi/agent/extensions/user/lib/focus/session.ts
+++ b/files/pi/agent/extensions/user/lib/focus/session.ts
@@ -11,6 +11,7 @@ import { clearFocusTransitionDecisions } from "./confirmation";
 import type { FocusController } from "./controller";
 import {
 	BASE_FOCUS,
+	FOCUS_EXIT_MODE,
 	FOCUS_STATE_TYPE,
 	type FocusName,
 	getFocusExitMode,
@@ -105,7 +106,7 @@ export const resetFocusAtAgentEnd =
 		if (runtime.lockedFocusName) return;
 		if (runtime.pendingAutoContinue) return;
 		if (!focus.active || !runtime.resetFocusAtAgentEndPending) return;
-		if (getFocusExitMode(focus.active) !== "single-turn") {
+		if (getFocusExitMode(focus.active) !== FOCUS_EXIT_MODE.SINGLE_TURN) {
 			runtime.setResetFocusAtAgentEndPending(false);
 			return;
 		}

--- a/files/pi/agent/extensions/user/lib/focus/tool-access.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/tool-access.test.ts
@@ -4,6 +4,8 @@ import { describe, it } from "vitest";
 import {
 	ENTER_FOCUS_TOOL,
 	EXIT_FOCUS_TOOL,
+	FOCUS_EXIT_MODE,
+	FOCUS_TRANSITION,
 	type FocusDefinition,
 } from "./definitions";
 import {
@@ -32,7 +34,7 @@ function focus(overrides: Partial<FocusDefinition> = {}): FocusDefinition {
 		description: "Edit files",
 		prompt: "Edit files",
 		tools: ["read", "write", ENTER_FOCUS_TOOL, EXIT_FOCUS_TOOL],
-		transition: "confirm",
+		transition: FOCUS_TRANSITION.CONFIRM,
 		...overrides,
 	};
 }
@@ -87,6 +89,30 @@ describe("focus tool access", () => {
 		]);
 	});
 
+	it("active manual focuses do not expose focus management tools", () => {
+		const api = pi([
+			"read",
+			"write",
+			"multi_tool_use.parallel",
+			ENTER_FOCUS_TOOL,
+			EXIT_FOCUS_TOOL,
+		]);
+
+		assert.deepEqual(
+			getActiveFocusTools(api, focus({ transition: FOCUS_TRANSITION.MANUAL })),
+			["multi_tool_use.parallel", "read", "write"],
+		);
+		assert.deepEqual(
+			activateFocusTools(api, focus({ transition: FOCUS_TRANSITION.MANUAL })),
+			["multi_tool_use.parallel", "read", "write"],
+		);
+		assert.deepEqual(api.activeTools, [
+			"multi_tool_use.parallel",
+			"read",
+			"write",
+		]);
+	});
+
 	it("can hide focus management tools for locked focus mode", () => {
 		const api = pi([
 			"read",
@@ -115,7 +141,10 @@ describe("focus tool access", () => {
 		]);
 
 		assert.deepEqual(
-			activateFocusTools(api, focus({ exitMode: "explicit", tools: ["read"] })),
+			activateFocusTools(
+				api,
+				focus({ exitMode: FOCUS_EXIT_MODE.EXPLICIT, tools: ["read"] }),
+			),
 			["multi_tool_use.parallel", "read", EXIT_FOCUS_TOOL],
 		);
 		assert.deepEqual(api.activeTools, [

--- a/files/pi/agent/extensions/user/lib/focus/tool-access.ts
+++ b/files/pi/agent/extensions/user/lib/focus/tool-access.ts
@@ -3,11 +3,33 @@ import { isProjectToolAvailable } from "../tool/project";
 import {
 	ENTER_FOCUS_TOOL,
 	EXIT_FOCUS_TOOL,
+	FOCUS_EXIT_MODE,
+	FOCUS_TRANSITION,
 	type FocusDefinition,
+	type FocusExitMode,
+	type FocusTransition,
 	getFocusExitMode,
 } from "./definitions";
 
 const ALWAYS_ALLOWED_TOOL_NAMES = ["multi_tool_use.parallel"] as const;
+const NO_FOCUS_MANAGEMENT_TOOLS: readonly string[] = [];
+const FOCUS_MANAGEMENT_TOOLS_BY_TRANSITION_AND_EXIT_MODE: Record<
+	FocusTransition,
+	Record<FocusExitMode, readonly string[]>
+> = {
+	[FOCUS_TRANSITION.AUTO]: {
+		[FOCUS_EXIT_MODE.SINGLE_TURN]: [ENTER_FOCUS_TOOL],
+		[FOCUS_EXIT_MODE.EXPLICIT]: [EXIT_FOCUS_TOOL],
+	},
+	[FOCUS_TRANSITION.CONFIRM]: {
+		[FOCUS_EXIT_MODE.SINGLE_TURN]: [ENTER_FOCUS_TOOL],
+		[FOCUS_EXIT_MODE.EXPLICIT]: [EXIT_FOCUS_TOOL],
+	},
+	[FOCUS_TRANSITION.MANUAL]: {
+		[FOCUS_EXIT_MODE.SINGLE_TURN]: NO_FOCUS_MANAGEMENT_TOOLS,
+		[FOCUS_EXIT_MODE.EXPLICIT]: NO_FOCUS_MANAGEMENT_TOOLS,
+	},
+};
 
 function unique(names: readonly string[]): string[] {
 	return [...new Set(names)];
@@ -53,14 +75,12 @@ type FocusToolAccessOptions = {
 function activeFocusManagementToolNames(
 	focus: FocusDefinition,
 	options?: FocusToolAccessOptions,
-): string[] {
-	if (options?.includeManagementTools === false) return [];
-	switch (getFocusExitMode(focus)) {
-		case "explicit":
-			return [EXIT_FOCUS_TOOL];
-		case "single-turn":
-			return [ENTER_FOCUS_TOOL];
-	}
+): readonly string[] {
+	return options?.includeManagementTools === false
+		? NO_FOCUS_MANAGEMENT_TOOLS
+		: FOCUS_MANAGEMENT_TOOLS_BY_TRANSITION_AND_EXIT_MODE[focus.transition][
+				getFocusExitMode(focus)
+			];
 }
 
 export function getActiveFocusTools(

--- a/files/pi/agent/extensions/user/lib/focus/tool.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/tool.test.ts
@@ -6,7 +6,12 @@ import type {
 import { describe, it } from "vitest";
 import { createToolCatalog } from "../tool/catalog";
 import type { FocusController } from "./controller";
-import { BASE_FOCUS, type FocusDefinition } from "./definitions";
+import {
+	BASE_FOCUS,
+	FOCUS_EXIT_MODE,
+	FOCUS_TRANSITION,
+	type FocusDefinition,
+} from "./definitions";
 import { rememberFocusTransitionDecision } from "./confirmation";
 import { createFocusRuntime } from "./runtime";
 import { registerEnterFocusTool, registerExitFocusTool } from "./tool";
@@ -27,7 +32,7 @@ function definition(overrides: Partial<FocusDefinition> = {}): FocusDefinition {
 		description: "Explore files",
 		prompt: "Explore prompt",
 		tools: ["read"],
-		transition: "auto",
+		transition: FOCUS_TRANSITION.AUTO,
 		...overrides,
 	};
 }
@@ -112,8 +117,11 @@ describe("focus management tools", () => {
 		const tool = registerEnter(
 			focusController({
 				definitions: [
-					definition({ name: "explore", transition: "auto" }),
-					definition({ name: "yolo", transition: "manual" }),
+					definition({ name: "explore", transition: FOCUS_TRANSITION.AUTO }),
+					definition({
+						name: "yolo",
+						transition: FOCUS_TRANSITION.MANUAL,
+					}),
 				],
 			}),
 		);
@@ -135,7 +143,12 @@ describe("focus management tools", () => {
 	it("blocks manual focuses and explicit-exit focus switches", async () => {
 		const manualTool = registerEnter(
 			focusController({
-				definitions: [definition({ name: "yolo", transition: "manual" })],
+				definitions: [
+					definition({
+						name: "yolo",
+						transition: FOCUS_TRANSITION.MANUAL,
+					}),
+				],
 			}),
 		);
 		const manual = await manualTool.execute(
@@ -149,8 +162,8 @@ describe("focus management tools", () => {
 
 		const active = definition({
 			name: "interview",
-			exitMode: "explicit",
-			transition: "auto",
+			exitMode: FOCUS_EXIT_MODE.EXPLICIT,
+			transition: FOCUS_TRANSITION.AUTO,
 		});
 		const switchTool = registerEnter(
 			focusController({
@@ -170,7 +183,10 @@ describe("focus management tools", () => {
 	});
 
 	it("requires reasons and UI for confirm focuses unless session-allowed", async () => {
-		const confirm = definition({ name: "edit", transition: "confirm" });
+		const confirm = definition({
+			name: "edit",
+			transition: FOCUS_TRANSITION.CONFIRM,
+		});
 		const focus = focusController({ definitions: [confirm] });
 		const tool = registerEnter(focus);
 
@@ -262,7 +278,7 @@ describe("focus management tools", () => {
 	it("blocks explicit focus exits when UI confirmation is unavailable", async () => {
 		const active = definition({
 			name: "interview",
-			exitMode: "explicit",
+			exitMode: FOCUS_EXIT_MODE.EXPLICIT,
 		});
 		const tool = registerExit(
 			focusController({ current: "interview", active, definitions: [active] }),

--- a/files/pi/agent/extensions/user/lib/focus/tool.ts
+++ b/files/pi/agent/extensions/user/lib/focus/tool.ts
@@ -16,6 +16,8 @@ import {
 	BASE_FOCUS,
 	ENTER_FOCUS_TOOL,
 	EXIT_FOCUS_TOOL,
+	FOCUS_EXIT_MODE,
+	FOCUS_TRANSITION,
 	getFocusExitMode,
 } from "./definitions";
 import type { FocusController } from "./controller";
@@ -47,7 +49,7 @@ function isOkResult(result: AgentToolResult<FocusToolDetails>): boolean {
 function getEnterableFocusNames(focus: FocusController): readonly string[] {
 	return focus.registry
 		.list()
-		.filter((definition) => definition.transition !== "manual")
+		.filter((definition) => definition.transition !== FOCUS_TRANSITION.MANUAL)
 		.map((definition) => definition.name);
 }
 
@@ -122,7 +124,7 @@ export function registerEnterFocusTool(
 				if (
 					activeFocus &&
 					activeFocus.name !== definition.name &&
-					getFocusExitMode(activeFocus) === "explicit"
+					getFocusExitMode(activeFocus) === FOCUS_EXIT_MODE.EXPLICIT
 				) {
 					return {
 						content: [
@@ -156,7 +158,7 @@ export function registerEnterFocusTool(
 					};
 				}
 
-				if (definition.transition === "manual") {
+				if (definition.transition === FOCUS_TRANSITION.MANUAL) {
 					return {
 						content: [
 							{
@@ -168,7 +170,7 @@ export function registerEnterFocusTool(
 					};
 				}
 
-				if (definition.transition === "confirm") {
+				if (definition.transition === FOCUS_TRANSITION.CONFIRM) {
 					const confirmationReason = params.reason?.trim();
 					if (isFocusDeniedForSession(definition.name)) {
 						return {
@@ -236,7 +238,7 @@ export function registerEnterFocusTool(
 				}
 
 				runtime.setResetFocusAtAgentEndPending(
-					getFocusExitMode(definition) === "single-turn",
+					getFocusExitMode(definition) === FOCUS_EXIT_MODE.SINGLE_TURN,
 				);
 				runtime.setUserSelectedFocus(false);
 				const entered = focus.enter(ctx, definition.name);
@@ -333,7 +335,7 @@ export function registerExitFocusTool(
 					};
 				}
 
-				if (getFocusExitMode(active) === "explicit") {
+				if (getFocusExitMode(active) === FOCUS_EXIT_MODE.EXPLICIT) {
 					if (!ctx.hasUI) {
 						return {
 							content: [

--- a/files/pi/agent/extensions/user/lib/focus/ui.ts
+++ b/files/pi/agent/extensions/user/lib/focus/ui.ts
@@ -3,6 +3,8 @@ import { colors, fg } from "../theme";
 import { type FilterSelectItem, showFilterSelect } from "../ui";
 import {
 	BASE_FOCUS,
+	FOCUS_EXIT_MODE,
+	FOCUS_TRANSITION,
 	type FocusDefinition,
 	type FocusName,
 	getFocusExitMode,
@@ -29,11 +31,11 @@ export function applyFocusStatus(
 function describeFocus(focus: FocusDefinition): string {
 	const tags: string[] = [];
 
-	if (focus.transition === "manual") {
+	if (focus.transition === FOCUS_TRANSITION.MANUAL) {
 		tags.push("manual");
 	}
 
-	if (getFocusExitMode(focus) === "explicit") {
+	if (getFocusExitMode(focus) === FOCUS_EXIT_MODE.EXPLICIT) {
 		tags.push("explicit exit");
 	}
 
@@ -57,11 +59,12 @@ export async function showFocusSelector(
 ): Promise<FocusName | typeof BASE_FOCUS | undefined> {
 	const focuses = registry.list();
 	const manualFocuses = focuses.filter(
-		(focus) => focus.transition === "manual",
+		(focus) => focus.transition === FOCUS_TRANSITION.MANUAL,
 	);
 	const explicitFocuses = focuses.filter(
 		(focus) =>
-			focus.transition !== "manual" && getFocusExitMode(focus) === "explicit",
+			focus.transition !== FOCUS_TRANSITION.MANUAL &&
+			getFocusExitMode(focus) === FOCUS_EXIT_MODE.EXPLICIT,
 	);
 	const recommendedItems = [
 		...manualFocuses.map((focus) => focusItem(focus)),


### PR DESCRIPTION
## Summary

- hide focus management tools while a manual focus is active
- mark confirmation-required focuses in routing prompts so enter_focus includes a reason
- centralize focus transition and exit mode values as shared constants

## Background

This makes focus behavior easier to reason about by defining management-tool exposure per transition and exit mode instead of layering ad hoc conditionals.