### PR TITLE
Add chunk-based file tools

### DIFF
--- a/files/pi/agent/extensions/user/lib/file/chunk.test.ts
+++ b/files/pi/agent/extensions/user/lib/file/chunk.test.ts
@@ -1,0 +1,146 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { executeEditChunk, executeReadChunk } from "./chunk";
+
+function tempRepo(): string {
+	const root = mkdtempSync(join(tmpdir(), "pi-file-chunk-"));
+	execFileSync("git", ["init"], { cwd: root, stdio: "ignore" });
+	writeFileSync(join(root, ".gitignore"), "ignored.txt\n");
+	mkdirSync(join(root, "src"), { recursive: true });
+	writeFileSync(
+		join(root, "src", "demo.txt"),
+		["alpha", "beta", "gamma", "delta", "epsilon", ""].join("\n"),
+	);
+	writeFileSync(join(root, "ignored.txt"), "ignored\n");
+	return root;
+}
+
+function resultText(
+	result: Awaited<ReturnType<typeof executeReadChunk>>,
+): string {
+	const content = result.content[0];
+	return content?.type === "text" ? content.text : "";
+}
+
+function anchorsByLine(output: string): string[] {
+	return output
+		.split("\n")
+		.map((line) => line.match(/^\s*\d+ @([A-Za-z0-9]{3}|---) \| /u)?.[1])
+		.filter((anchor): anchor is string => anchor !== undefined);
+}
+
+describe("chunk file tools", () => {
+	it("reads file-wide unique anchors and edits multiple chunks", async () => {
+		const root = tempRepo();
+		const readResult = await executeReadChunk(
+			root,
+			{ path: "src/demo.txt" },
+			undefined,
+		);
+		const anchors = anchorsByLine(resultText(readResult));
+
+		assert.equal(anchors.length, 5);
+		assert.ok(anchors.every((anchor) => anchor !== "---"));
+
+		await executeEditChunk(
+			root,
+			{
+				path: "src/demo.txt",
+				edits: [
+					{ old_range: [anchors[1], anchors[1]], new_lines: ["BETA"] },
+					{ old_range: [anchors[3], anchors[4]], new_lines: ["tail"] },
+				],
+			},
+			undefined,
+		);
+
+		assert.equal(
+			readFileSync(join(root, "src", "demo.txt"), "utf8"),
+			["alpha", "BETA", "gamma", "tail", ""].join("\n"),
+		);
+	});
+
+	it("fails without modifying files when anchors are stale, reversed, or overlapping", async () => {
+		const root = tempRepo();
+		const readResult = await executeReadChunk(
+			root,
+			{ path: "src/demo.txt" },
+			undefined,
+		);
+		const anchors = anchorsByLine(resultText(readResult));
+		const original = readFileSync(join(root, "src", "demo.txt"), "utf8");
+
+		await assert.rejects(
+			executeEditChunk(
+				root,
+				{
+					path: "src/demo.txt",
+					edits: [{ old_range: ["zzz", "zzz"], new_lines: ["nope"] }],
+				},
+				undefined,
+			),
+			/Anchor 'zzz' is unavailable/u,
+		);
+		await assert.rejects(
+			executeEditChunk(
+				root,
+				{
+					path: "src/demo.txt",
+					edits: [{ old_range: [anchors[2], anchors[1]], new_lines: ["nope"] }],
+				},
+				undefined,
+			),
+			/appears after end anchor/u,
+		);
+		await assert.rejects(
+			executeEditChunk(
+				root,
+				{
+					path: "src/demo.txt",
+					edits: [
+						{ old_range: [anchors[1], anchors[3]], new_lines: ["one"] },
+						{ old_range: [anchors[2], anchors[4]], new_lines: ["two"] },
+					],
+				},
+				undefined,
+			),
+			/ranges must not overlap/u,
+		);
+
+		assert.equal(readFileSync(join(root, "src", "demo.txt"), "utf8"), original);
+	});
+
+	it("hides ambiguous anchors and rejects unsafe paths", async () => {
+		const root = tempRepo();
+		writeFileSync(
+			join(root, "src", "ambiguous.txt"),
+			["same", "else:", "return", "same", "else:", "return", ""].join("\n"),
+		);
+
+		const readResult = await executeReadChunk(
+			root,
+			{ path: "src/ambiguous.txt" },
+			undefined,
+		);
+		const output = resultText(readResult);
+
+		assert.match(output, /\d+ @--- \| else:/u);
+		assert.ok(readResult.details.ambiguousLines > 0);
+		await assert.rejects(
+			executeReadChunk(root, { path: "ignored.txt" }, undefined),
+			/Reading chunk from ignored files is not allowed/u,
+		);
+		await assert.rejects(
+			executeEditChunk(
+				root,
+				{ path: resolve(root, "..", "outside.txt"), edits: [] },
+				undefined,
+			),
+			/Editing chunk in outside the repository is not allowed/u,
+		);
+	});
+});

--- a/files/pi/agent/extensions/user/lib/file/chunk.test.ts
+++ b/files/pi/agent/extensions/user/lib/file/chunk.test.ts
@@ -134,6 +134,25 @@ describe("chunk file tools", () => {
 			executeReadChunk(root, { path: "ignored.txt" }, undefined),
 			/Reading chunk from ignored files is not allowed/u,
 		);
+		writeFileSync(join(root, ".envrc"), "SECRET=value\n");
+		await assert.rejects(
+			executeReadChunk(root, { path: ".envrc" }, undefined),
+			/Reading chunk from secret files is not allowed/u,
+		);
+		const outsideDir = mkdtempSync(join(tmpdir(), "pi-file-chunk-outside-"));
+		const outsidePath = join(outsideDir, "outside.txt");
+		writeFileSync(outsidePath, ["outside", "file", ""].join("\n"));
+		const outsideResult = await executeReadChunk(
+			root,
+			{ path: outsidePath },
+			undefined,
+		);
+		const outsideOutput = resultText(outsideResult);
+		assert.equal(outsideResult.details.visibleAnchors, 0);
+		assert.match(outsideOutput, /Anchors are disabled/u);
+		assert.match(outsideOutput, /1 \| outside/u);
+		assert.doesNotMatch(outsideOutput, /@[A-Za-z0-9]{3} \|/u);
+		assert.doesNotMatch(outsideOutput, /@--- \|/u);
 		await assert.rejects(
 			executeEditChunk(
 				root,

--- a/files/pi/agent/extensions/user/lib/file/chunk.test.ts
+++ b/files/pi/agent/extensions/user/lib/file/chunk.test.ts
@@ -46,7 +46,7 @@ describe("chunk file tools", () => {
 		assert.equal(anchors.length, 5);
 		assert.ok(anchors.every((anchor) => anchor !== "---"));
 
-		await executeEditChunk(
+		const editResult = await executeEditChunk(
 			root,
 			{
 				path: "src/demo.txt",
@@ -62,6 +62,62 @@ describe("chunk file tools", () => {
 			readFileSync(join(root, "src", "demo.txt"), "utf8"),
 			["alpha", "BETA", "gamma", "tail", ""].join("\n"),
 		);
+		const editContent = editResult.content[0];
+		assert.equal(editContent?.type, "text");
+		assert.match(editContent.text, /^Diff:\n/u);
+		assert.match(editContent.text, /-2 beta/u);
+		assert.match(editContent.text, /\+2 BETA/u);
+		assert.match(editContent.text, /Applied 2 chunk edits\.$/u);
+		assert.equal(editResult.details.path, "src/demo.txt");
+		assert.equal(editResult.details.replacements, 2);
+		assert.equal(editResult.details.firstChangedLine, 2);
+		assert.match(editResult.details.diff, /-2 beta/u);
+		assert.match(editResult.details.diff, /\+2 BETA/u);
+		assert.match(editResult.details.diff, /-5 epsilon/u);
+		assert.match(editResult.details.diff, /\+4 tail/u);
+		assert.match(editResult.details.patch, /--- src\/demo\.txt/u);
+	});
+
+	it("omits large diffs from the LLM-facing edit result content", async () => {
+		const root = tempRepo();
+		writeFileSync(
+			join(root, "src", "large.txt"),
+			[
+				...Array.from({ length: 60 }, (_, index) => `old ${index + 1}`),
+				"",
+			].join("\n"),
+		);
+
+		const readResult = await executeReadChunk(
+			root,
+			{ path: "src/large.txt" },
+			undefined,
+		);
+		const anchors = anchorsByLine(resultText(readResult));
+		const editResult = await executeEditChunk(
+			root,
+			{
+				path: "src/large.txt",
+				edits: [
+					{
+						old_range: [anchors[0], anchors[59]],
+						new_lines: Array.from(
+							{ length: 60 },
+							(_, index) => `new ${index + 1}`,
+						),
+					},
+				],
+			},
+			undefined,
+		);
+
+		const editContent = editResult.content[0];
+		assert.equal(editContent?.type, "text");
+		assert.match(editContent.text, /^Diff omitted from tool result/u);
+		assert.doesNotMatch(editContent.text, /Diff:\n/u);
+		assert.match(editContent.text, /Applied 1 chunk edits\.$/u);
+		assert.match(editResult.details.diff, /- 1 old 1/u);
+		assert.match(editResult.details.diff, /\+ 1 new 1/u);
 	});
 
 	it("shows continuation offset when more lines remain", async () => {

--- a/files/pi/agent/extensions/user/lib/file/chunk.test.ts
+++ b/files/pi/agent/extensions/user/lib/file/chunk.test.ts
@@ -118,7 +118,7 @@ describe("chunk file tools", () => {
 		const root = tempRepo();
 		writeFileSync(
 			join(root, "src", "ambiguous.txt"),
-			["same", "else:", "return", "same", "else:", "return", ""].join("\n"),
+			[...Array.from({ length: 40 }, () => "else:"), ""].join("\n"),
 		);
 
 		const readResult = await executeReadChunk(

--- a/files/pi/agent/extensions/user/lib/file/chunk.test.ts
+++ b/files/pi/agent/extensions/user/lib/file/chunk.test.ts
@@ -64,6 +64,30 @@ describe("chunk file tools", () => {
 		);
 	});
 
+	it("shows continuation offset when more lines remain", async () => {
+		const root = tempRepo();
+		writeFileSync(
+			join(root, "src", "long.txt"),
+			[
+				...Array.from({ length: 205 }, (_, index) => `line ${index + 1}`),
+				"",
+			].join("\n"),
+		);
+
+		const readResult = await executeReadChunk(
+			root,
+			{ path: "src/long.txt" },
+			undefined,
+		);
+		const output = resultText(readResult);
+
+		assert.match(output, /Showing 200 of 205 line\(s\)\./u);
+		assert.match(
+			output,
+			/\[5 more lines in file\. Use offset=201 to continue, or use grep to find the relevant lines first\.\]/u,
+		);
+	});
+
 	it("fails without modifying files when anchors are stale, reversed, or overlapping", async () => {
 		const root = tempRepo();
 		const readResult = await executeReadChunk(

--- a/files/pi/agent/extensions/user/lib/file/chunk.ts
+++ b/files/pi/agent/extensions/user/lib/file/chunk.ts
@@ -1,0 +1,469 @@
+import { constants } from "node:fs";
+import { access, readFile, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import type { AgentToolResult, Theme } from "@earendil-works/pi-coding-agent";
+import {
+	keyHint,
+	withFileMutationQueue,
+} from "@earendil-works/pi-coding-agent";
+import { type Component, Text } from "@earendil-works/pi-tui";
+import { type Static, Type } from "typebox";
+import { ToolError } from "./errors";
+import {
+	assertRepoPathAllowed,
+	createFsGuardContext,
+	displayRepoPath,
+	resolveRepoPath,
+} from "./guard";
+
+const READ_CHUNK_OPERATION = "Reading chunk from";
+const EDIT_CHUNK_OPERATION = "Editing chunk in";
+const ANCHOR_LENGTH = 3;
+const MAX_CONTEXT_RADIUS = 16;
+
+const anchorSchema = Type.String({
+	description:
+		"Three-character anchor shown by read_chunk. Anchors are only emitted when unique in the file.",
+	minLength: ANCHOR_LENGTH,
+	maxLength: ANCHOR_LENGTH,
+});
+
+export const readChunkSchema = Type.Object({
+	path: Type.String({ description: "Path to the file to read." }),
+	offset: Type.Optional(
+		Type.Number({
+			description: "Line number to start reading from (1-indexed).",
+		}),
+	),
+	limit: Type.Optional(
+		Type.Number({ description: "Maximum number of lines to read." }),
+	),
+});
+
+export type ReadChunkToolInput = Static<typeof readChunkSchema>;
+
+const chunkEditSchema = Type.Object(
+	{
+		old_range: Type.Array(anchorSchema, {
+			description:
+				"Inclusive [start_anchor, end_anchor] range from read_chunk output. Use the same anchor twice for a single-line edit.",
+			minItems: 2,
+			maxItems: 2,
+		}),
+		new_lines: Type.Array(Type.String(), {
+			description:
+				"Replacement lines for the range. Pass an empty array to delete the range. Include intentional blank lines as empty strings, and include surrounding blank lines in old_range when they should be removed. Do not include trailing newline characters.",
+		}),
+	},
+	{ additionalProperties: false },
+);
+
+export const editChunkSchema = Type.Object({
+	path: Type.String({ description: "Path to the file to edit." }),
+	edits: Type.Array(chunkEditSchema, {
+		description:
+			"One or more chunk edits. All old_range anchors are resolved against the original file before any replacements are applied.",
+		minItems: 1,
+	}),
+});
+
+export type EditChunkToolInput = Static<typeof editChunkSchema>;
+
+type ReadChunkDetails = {
+	operation: "read_chunk";
+	path: string;
+	startLine: number;
+	endLine: number;
+	totalLines: number;
+	visibleAnchors: number;
+	ambiguousLines: number;
+};
+
+type EditChunkDetails = {
+	operation: "edit_chunk";
+	path: string;
+	replacements: number;
+};
+
+type TextDocument = {
+	readonly lines: readonly string[];
+	readonly lineEnding: "\n" | "\r\n";
+	readonly finalNewline: boolean;
+};
+
+type AnchorIndex = {
+	readonly perLine: readonly (string | undefined)[];
+	readonly unique: ReadonlyMap<string, number>;
+	readonly ambiguousCount: number;
+};
+
+type ResolvedEdit = {
+	readonly start: number;
+	readonly end: number;
+	readonly newLines: readonly string[];
+};
+
+function checkAbort(signal: AbortSignal | undefined, operation: string): void {
+	if (signal?.aborted) throw new ToolError("aborted", operation, "");
+}
+
+function parseDocument(content: string): TextDocument {
+	const lineEnding = content.includes("\r\n") ? "\r\n" : "\n";
+	const normalized = content.replaceAll("\r\n", "\n");
+	const finalNewline = normalized.endsWith("\n");
+	const body = finalNewline ? normalized.slice(0, -1) : normalized;
+	return {
+		lines: body === "" ? [] : body.split("\n"),
+		lineEnding,
+		finalNewline,
+	};
+}
+
+function serializeDocument(
+	lines: readonly string[],
+	lineEnding: "\n" | "\r\n",
+	finalNewline: boolean,
+): string {
+	const body = lines.join("\n");
+	const normalized = finalNewline && lines.length > 0 ? `${body}\n` : body;
+	return lineEnding === "\n" ? normalized : normalized.replaceAll("\n", "\r\n");
+}
+
+function lineAnchorInput(
+	lines: readonly string[],
+	index: number,
+	radius: number,
+): string {
+	const start = Math.max(0, index - radius);
+	const end = Math.min(lines.length, index + radius + 1);
+	const parts = [`radius:${radius}`];
+	for (let lineIndex = start; lineIndex < end; lineIndex += 1) {
+		if (lineIndex === index) parts.push("current-line");
+		parts.push(lines[lineIndex] ?? "");
+	}
+	return parts.join("\u0000");
+}
+
+function anchorForLine(
+	lines: readonly string[],
+	index: number,
+	radius: number,
+): string {
+	const alphabet =
+		"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+	const space = alphabet.length ** ANCHOR_LENGTH;
+	let value =
+		createHash("sha256")
+			.update(lineAnchorInput(lines, index, radius))
+			.digest()
+			.readUInt32BE(0) % space;
+	let anchor = "";
+	for (let i = 0; i < ANCHOR_LENGTH; i += 1) {
+		anchor = alphabet[value % alphabet.length] + anchor;
+		value = Math.floor(value / alphabet.length);
+	}
+	return anchor;
+}
+
+function buildAnchorIndex(lines: readonly string[]): AnchorIndex {
+	const perLine = Array<string | undefined>(lines.length).fill(undefined);
+	const unique = new Map<string, number>();
+	const usedAnchors = new Set<string>();
+	let unresolved = new Set(lines.map((_, index) => index));
+
+	for (let radius = 1; radius <= MAX_CONTEXT_RADIUS; radius += 1) {
+		if (unresolved.size === 0) break;
+		const candidates = new Map<number, string>();
+		const counts = new Map<string, number>();
+		for (const index of unresolved) {
+			const anchor = anchorForLine(lines, index, radius);
+			candidates.set(index, anchor);
+			counts.set(anchor, (counts.get(anchor) ?? 0) + 1);
+		}
+
+		const nextUnresolved = new Set<number>();
+		for (const index of unresolved) {
+			const anchor = candidates.get(index);
+			if (
+				anchor === undefined ||
+				counts.get(anchor) !== 1 ||
+				usedAnchors.has(anchor)
+			) {
+				nextUnresolved.add(index);
+				continue;
+			}
+			perLine[index] = anchor;
+			unique.set(anchor, index);
+			usedAnchors.add(anchor);
+		}
+		unresolved = nextUnresolved;
+	}
+
+	return { perLine, unique, ambiguousCount: unresolved.size };
+}
+
+function validateRange(
+	offset: number | undefined,
+	limit: number | undefined,
+): void {
+	if (offset !== undefined && (!Number.isInteger(offset) || offset < 1)) {
+		throw new Error("offset must be a positive integer.");
+	}
+	if (limit !== undefined && (!Number.isInteger(limit) || limit < 0)) {
+		throw new Error("limit must be a non-negative integer.");
+	}
+}
+
+function resolveAnchor(anchorIndex: AnchorIndex, anchor: string): number {
+	const line = anchorIndex.unique.get(anchor);
+	if (line === undefined) {
+		throw new Error(
+			`Anchor '${anchor}' is unavailable. It may be stale, ambiguous, or not present in the file. Re-run read_chunk and use displayed anchors only.`,
+		);
+	}
+	return line;
+}
+
+function resolveEdit(
+	anchorIndex: AnchorIndex,
+	edit: EditChunkToolInput["edits"][number],
+): ResolvedEdit {
+	const [startAnchor, endAnchor] = edit.old_range;
+	const start = resolveAnchor(anchorIndex, startAnchor);
+	const end = resolveAnchor(anchorIndex, endAnchor);
+	if (start > end) {
+		throw new Error(
+			`Invalid old_range: start anchor '${startAnchor}' appears after end anchor '${endAnchor}'.`,
+		);
+	}
+	for (const line of edit.new_lines) {
+		if (line.includes("\n") || line.includes("\r")) {
+			throw new Error("new_lines entries must not contain newline characters.");
+		}
+	}
+	return { start, end, newLines: edit.new_lines };
+}
+
+function assertNonOverlapping(edits: readonly ResolvedEdit[]): void {
+	for (let index = 1; index < edits.length; index += 1) {
+		const previous = edits[index - 1];
+		const current = edits[index];
+		if (current.start <= previous.end) {
+			throw new Error("edit_chunk ranges must not overlap.");
+		}
+	}
+}
+
+function applyResolvedEdits(
+	lines: readonly string[],
+	edits: readonly ResolvedEdit[],
+): string[] {
+	const output: string[] = [];
+	let cursor = 0;
+	for (const edit of edits) {
+		output.push(...lines.slice(cursor, edit.start));
+		output.push(...edit.newLines);
+		cursor = edit.end + 1;
+	}
+	output.push(...lines.slice(cursor));
+	return output;
+}
+
+async function readAllowedTextFile(
+	cwd: string,
+	path: string,
+	operation: string,
+	mode: number,
+): Promise<{ absolutePath: string; displayPath: string; content: string }> {
+	const absolutePath = resolveRepoPath(cwd, path, operation);
+	const guardContext = await createFsGuardContext(cwd);
+	await assertRepoPathAllowed(guardContext, absolutePath, operation);
+	await access(absolutePath, mode);
+	return {
+		absolutePath,
+		displayPath: displayRepoPath(cwd, absolutePath),
+		content: await readFile(absolutePath, "utf8"),
+	};
+}
+
+function renderChunkHeaderText(
+	name: string,
+	args: unknown,
+	theme: Theme,
+): string {
+	const input = (args ?? {}) as Record<string, unknown>;
+	const path = typeof input.path === "string" ? input.path : "";
+	let text = theme.fg("toolTitle", theme.bold(name));
+	if (path) text += ` ${theme.fg("accent", path)}`;
+	return text;
+}
+
+function renderChunkHeader(
+	name: string,
+	args: unknown,
+	theme: Theme,
+): Component {
+	return new Text(renderChunkHeaderText(name, args, theme), 0, 0);
+}
+
+export function renderReadChunk(args: unknown, theme: Theme): Component {
+	return renderChunkHeader("read_chunk", args, theme);
+}
+
+export function renderReadChunkResult(
+	result: AgentToolResult<ReadChunkDetails>,
+	options: { expanded: boolean; isPartial: boolean },
+	theme: Theme,
+): Component {
+	if (options.expanded) {
+		const text = result.content
+			.filter((content) => content.type === "text")
+			.map((content) => content.text)
+			.join("\n");
+		return new Text(theme.fg("toolOutput", text || "(no output)"), 0, 0);
+	}
+
+	const details = result.details;
+	const summary = details
+		? [
+				`${details.path}: lines ${details.startLine}-${details.endLine} of ${details.totalLines}`,
+				`${details.visibleAnchors} visible anchor(s), ${details.ambiguousLines} ambiguous line(s)`,
+				keyHint("app.tools.expand", "expand to view lines"),
+			].join(". ")
+		: keyHint("app.tools.expand", "expand to view lines");
+	return new Text(theme.fg("muted", summary), 0, 0);
+}
+
+function renderEditChunkParams(args: unknown, theme: Theme): string[] {
+	const input = (args ?? {}) as Record<string, unknown>;
+	if (!Array.isArray(input.edits)) return [];
+	return input.edits.map((edit) => {
+		const chunkEdit = edit as Record<string, unknown>;
+		return theme.fg(
+			"toolOutput",
+			JSON.stringify({
+				old_range: chunkEdit.old_range,
+				new_lines: chunkEdit.new_lines,
+			}),
+		);
+	});
+}
+
+export function renderEditChunk(
+	args: unknown,
+	theme: Theme,
+	context?: { readonly expanded?: boolean },
+): Component {
+	const header = renderChunkHeaderText("edit_chunk", args, theme);
+	if (!(context?.expanded ?? false)) return new Text(header, 0, 0);
+
+	const params = renderEditChunkParams(args, theme);
+	if (params.length === 0) return new Text(header, 0, 0);
+	return new Text(`${header}\n${params.join("\n")}`, 0, 0);
+}
+
+export async function executeReadChunk(
+	cwd: string,
+	params: ReadChunkToolInput,
+	signal: AbortSignal | undefined,
+): Promise<AgentToolResult<ReadChunkDetails>> {
+	checkAbort(signal, READ_CHUNK_OPERATION);
+	validateRange(params.offset, params.limit);
+	const { displayPath, content } = await readAllowedTextFile(
+		cwd,
+		params.path,
+		READ_CHUNK_OPERATION,
+		constants.R_OK,
+	);
+	checkAbort(signal, READ_CHUNK_OPERATION);
+
+	const document = parseDocument(content);
+	const anchors = buildAnchorIndex(document.lines);
+	const start = Math.min((params.offset ?? 1) - 1, document.lines.length);
+	const endExclusive = Math.min(
+		document.lines.length,
+		params.limit === undefined ? document.lines.length : start + params.limit,
+	);
+	const lines = document.lines.slice(start, endExclusive);
+	const lineNumberWidth = String(document.lines.length).length;
+	const output = lines.map((line, index) => {
+		const lineNumber = String(start + index + 1).padStart(lineNumberWidth);
+		const anchor = anchors.perLine[start + index] ?? "---";
+		return `${lineNumber} @${anchor} | ${line}`;
+	});
+	const visibleAnchors = lines.filter(
+		(_, index) => anchors.perLine[start + index] !== undefined,
+	).length;
+	const header = [
+		`${displayPath}`,
+		`Anchors are ${ANCHOR_LENGTH}-character tokens shown after line numbers. Only file-wide unique anchors are shown; @--- lines cannot be used as old_range endpoints.`,
+		`Use edit_chunk with edits: [{ old_range: ["start", "end"], new_lines: [...] }]. Use the same anchor twice for one line.`,
+		`Showing ${lines.length} of ${document.lines.length} line(s).`,
+	];
+
+	return {
+		content: [{ type: "text", text: [...header, ...output].join("\n") }],
+		details: {
+			operation: "read_chunk",
+			path: displayPath,
+			startLine: start + 1,
+			endLine: endExclusive,
+			totalLines: document.lines.length,
+			visibleAnchors,
+			ambiguousLines: anchors.ambiguousCount,
+		} satisfies ReadChunkDetails,
+	};
+}
+
+export async function executeEditChunk(
+	cwd: string,
+	params: EditChunkToolInput,
+	signal: AbortSignal | undefined,
+): Promise<AgentToolResult<EditChunkDetails>> {
+	checkAbort(signal, EDIT_CHUNK_OPERATION);
+	const { absolutePath, displayPath } = await readAllowedTextFile(
+		cwd,
+		params.path,
+		EDIT_CHUNK_OPERATION,
+		constants.R_OK | constants.W_OK,
+	);
+	if (params.edits.length === 0) {
+		throw new ToolError("missing_input", EDIT_CHUNK_OPERATION, "edit");
+	}
+
+	return withFileMutationQueue(absolutePath, async () => {
+		checkAbort(signal, EDIT_CHUNK_OPERATION);
+		const latestContent = await readFile(absolutePath, "utf8");
+		const document = parseDocument(latestContent);
+		const anchors = buildAnchorIndex(document.lines);
+		const resolved = Array.from(params.edits, (edit) =>
+			resolveEdit(anchors, edit),
+		);
+		resolved.sort((a, b) => a.start - b.start);
+		assertNonOverlapping(resolved);
+		checkAbort(signal, EDIT_CHUNK_OPERATION);
+
+		const nextLines = applyResolvedEdits(document.lines, resolved);
+		const nextContent = serializeDocument(
+			nextLines,
+			document.lineEnding,
+			document.finalNewline,
+		);
+		await writeFile(absolutePath, nextContent, "utf8");
+		checkAbort(signal, EDIT_CHUNK_OPERATION);
+
+		return {
+			content: [
+				{
+					type: "text",
+					text: `Successfully applied ${resolved.length} chunk edit(s) to ${displayPath}.`,
+				},
+			],
+			details: {
+				operation: "edit_chunk",
+				path: displayPath,
+				replacements: resolved.length,
+			} satisfies EditChunkDetails,
+		};
+	});
+}

--- a/files/pi/agent/extensions/user/lib/file/chunk.ts
+++ b/files/pi/agent/extensions/user/lib/file/chunk.ts
@@ -9,10 +9,12 @@ import {
 import { type Component, Text } from "@earendil-works/pi-tui";
 import { type Static, Type } from "typebox";
 import { ToolError } from "./errors";
+import { isSecretPath } from "../secrets";
 import {
 	assertRepoPathAllowed,
 	createFsGuardContext,
 	displayRepoPath,
+	isRepoPath,
 	resolveRepoPath,
 } from "./guard";
 
@@ -277,15 +279,30 @@ async function readAllowedTextFile(
 	path: string,
 	operation: string,
 	mode: number,
-): Promise<{ absolutePath: string; displayPath: string; content: string }> {
+	options?: { readonly allowOutsideRepoWithoutAnchors?: boolean },
+): Promise<{
+	absolutePath: string;
+	displayPath: string;
+	content: string;
+	anchorsEnabled: boolean;
+}> {
 	const absolutePath = resolveRepoPath(cwd, path, operation);
 	const guardContext = await createFsGuardContext(cwd);
-	await assertRepoPathAllowed(guardContext, absolutePath, operation);
+	const displayPath = displayRepoPath(cwd, absolutePath);
+	if (isSecretPath(displayPath) || isSecretPath(absolutePath)) {
+		throw new ToolError("secret", operation, displayPath);
+	}
+
+	const insideRepo = isRepoPath(guardContext, absolutePath);
+	if (insideRepo || options?.allowOutsideRepoWithoutAnchors !== true) {
+		await assertRepoPathAllowed(guardContext, absolutePath, operation);
+	}
 	await access(absolutePath, mode);
 	return {
 		absolutePath,
-		displayPath: displayRepoPath(cwd, absolutePath),
+		displayPath,
 		content: await readFile(absolutePath, "utf8"),
+		anchorsEnabled: insideRepo,
 	};
 }
 
@@ -313,27 +330,40 @@ export function renderReadChunk(args: unknown, theme: Theme): Component {
 	return renderChunkHeader("read_chunk", args, theme);
 }
 
+function renderToolResultText(
+	result: AgentToolResult<ReadChunkDetails>,
+	theme: Theme,
+): Component {
+	const text = result.content
+		.filter((content) => content.type === "text")
+		.map((content) => content.text)
+		.join("\n");
+	return new Text(theme.fg("toolOutput", text || "(no output)"), 0, 0);
+}
+
+function isReadChunkDetails(details: unknown): details is ReadChunkDetails {
+	if (typeof details !== "object" || details === null) return false;
+	const value = details as Record<string, unknown>;
+	return (
+		value.operation === "read_chunk" &&
+		typeof value.path === "string" &&
+		typeof value.startLine === "number" &&
+		typeof value.endLine === "number" &&
+		typeof value.totalLines === "number" &&
+		typeof value.visibleAnchors === "number" &&
+		typeof value.ambiguousLines === "number"
+	);
+}
+
 export function renderReadChunkResult(
 	result: AgentToolResult<ReadChunkDetails>,
 	options: { expanded: boolean; isPartial: boolean },
 	theme: Theme,
 ): Component {
-	if (options.expanded) {
-		const text = result.content
-			.filter((content) => content.type === "text")
-			.map((content) => content.text)
-			.join("\n");
-		return new Text(theme.fg("toolOutput", text || "(no output)"), 0, 0);
-	}
+	if (options.expanded) return renderToolResultText(result, theme);
 
 	const details = result.details;
-	if (!details) {
-		return new Text(
-			theme.fg("muted", keyHint("app.tools.expand", "expand to view lines")),
-			0,
-			0,
-		);
-	}
+	if (!isReadChunkDetails(details)) return renderToolResultText(result, theme);
 
 	const summaryParts = [
 		`${details.path}: lines ${details.startLine}-${details.endLine} of ${details.totalLines}`,
@@ -381,16 +411,17 @@ export async function executeReadChunk(
 ): Promise<AgentToolResult<ReadChunkDetails>> {
 	checkAbort(signal, READ_CHUNK_OPERATION);
 	validateRange(params.offset, params.limit);
-	const { displayPath, content } = await readAllowedTextFile(
+	const { displayPath, content, anchorsEnabled } = await readAllowedTextFile(
 		cwd,
 		params.path,
 		READ_CHUNK_OPERATION,
 		constants.R_OK,
+		{ allowOutsideRepoWithoutAnchors: true },
 	);
 	checkAbort(signal, READ_CHUNK_OPERATION);
 
 	const document = parseDocument(content);
-	const anchors = buildAnchorIndex(document.lines);
+	const anchors = anchorsEnabled ? buildAnchorIndex(document.lines) : undefined;
 	const start = Math.min((params.offset ?? 1) - 1, document.lines.length);
 	const limit = params.limit ?? DEFAULT_READ_CHUNK_LIMIT;
 	const endExclusive = Math.min(document.lines.length, start + limit);
@@ -398,15 +429,19 @@ export async function executeReadChunk(
 	const lineNumberWidth = String(document.lines.length).length;
 	const output = lines.map((line, index) => {
 		const lineNumber = String(start + index + 1).padStart(lineNumberWidth);
-		const anchor = anchors.perLine[start + index] ?? "---";
+		if (!anchorsEnabled) return `${lineNumber} | ${line}`;
+		const anchor = anchors?.perLine[start + index] ?? "---";
 		return `${lineNumber} @${anchor} | ${line}`;
 	});
-	const visibleAnchors = lines.filter(
-		(_, index) => anchors.perLine[start + index] !== undefined,
-	).length;
+	const visibleAnchors = anchorsEnabled
+		? lines.filter((_, index) => anchors?.perLine[start + index] !== undefined)
+				.length
+		: 0;
 	const header = [
 		`${displayPath}`,
-		`Anchors are ${ANCHOR_LENGTH}-character tokens shown after line numbers. Only file-wide unique anchors are shown; @--- lines cannot be used as old_range endpoints.`,
+		anchorsEnabled
+			? `Anchors are ${ANCHOR_LENGTH}-character tokens shown after line numbers. Only file-wide unique anchors are shown; @--- lines cannot be used as old_range endpoints.`
+			: "Anchors are disabled for files outside the repository; edit_chunk cannot use this output.",
 		`Use edit_chunk with edits: [{ old_range: ["start", "end"], new_lines: [...] }]. Use the same anchor twice for one line.`,
 		`Showing ${lines.length} of ${document.lines.length} line(s).`,
 	];
@@ -420,7 +455,7 @@ export async function executeReadChunk(
 			endLine: endExclusive,
 			totalLines: document.lines.length,
 			visibleAnchors,
-			ambiguousLines: anchors.ambiguousCount,
+			ambiguousLines: anchors?.ambiguousCount ?? 0,
 		} satisfies ReadChunkDetails,
 	};
 }

--- a/files/pi/agent/extensions/user/lib/file/chunk.ts
+++ b/files/pi/agent/extensions/user/lib/file/chunk.ts
@@ -2,10 +2,7 @@ import { constants } from "node:fs";
 import { access, readFile, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import type { AgentToolResult, Theme } from "@earendil-works/pi-coding-agent";
-import {
-	keyHint,
-	withFileMutationQueue,
-} from "@earendil-works/pi-coding-agent";
+import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
 import { type Component, Text } from "@earendil-works/pi-tui";
 import { type Static, Type } from "typebox";
 import { ToolError } from "./errors";
@@ -306,10 +303,14 @@ async function readAllowedTextFile(
 	};
 }
 
-function formatReadChunkLineRange(args: Record<string, unknown>, theme: Theme): string {
+function formatReadChunkLineRange(
+	args: Record<string, unknown>,
+	theme: Theme,
+): string {
 	if (args.offset === undefined && args.limit === undefined) return "";
 	const startLine = typeof args.offset === "number" ? args.offset : 1;
-	const limit = typeof args.limit === "number" ? args.limit : DEFAULT_READ_CHUNK_LIMIT;
+	const limit =
+		typeof args.limit === "number" ? args.limit : DEFAULT_READ_CHUNK_LIMIT;
 	const endLine = startLine + limit - 1;
 	return theme.fg("warning", `:${startLine}-${endLine}`);
 }
@@ -461,9 +462,21 @@ export async function executeReadChunk(
 		`Use edit_chunk with edits: [{ old_range: ["start", "end"], new_lines: [...] }]. Use the same anchor twice for one line.`,
 		`Showing ${lines.length} of ${document.lines.length} line(s).`,
 	];
+	const continuation =
+		endExclusive < document.lines.length
+			? [
+					"",
+					`[${document.lines.length - endExclusive} more lines in file. Use offset=${endExclusive + 1} to continue, or use grep to find the relevant lines first.]`,
+				]
+			: [];
 
 	return {
-		content: [{ type: "text", text: [...header, ...output].join("\n") }],
+		content: [
+			{
+				type: "text",
+				text: [...header, ...output, ...continuation].join("\n"),
+			},
+		],
 		details: {
 			operation: "read_chunk",
 			path: displayPath,

--- a/files/pi/agent/extensions/user/lib/file/chunk.ts
+++ b/files/pi/agent/extensions/user/lib/file/chunk.ts
@@ -52,7 +52,7 @@ const chunkEditSchema = Type.Object(
 		}),
 		new_lines: Type.Array(Type.String(), {
 			description:
-				"Replacement lines for the range. Pass an empty array to delete the range. Include intentional blank lines as empty strings, and include surrounding blank lines in old_range when they should be removed. Do not include trailing newline characters.",
+				"Replacement lines for the range. Pass an empty array to delete the range. Blank lines are significant: use empty strings for intentional blank lines, and include adjacent blank lines in old_range when deleting or replacing a block so the final spacing is correct in the same edit. Do not include trailing newline characters.",
 		}),
 	},
 	{ additionalProperties: false },

--- a/files/pi/agent/extensions/user/lib/file/chunk.ts
+++ b/files/pi/agent/extensions/user/lib/file/chunk.ts
@@ -324,14 +324,23 @@ export function renderReadChunkResult(
 	}
 
 	const details = result.details;
-	const summary = details
-		? [
-				`${details.path}: lines ${details.startLine}-${details.endLine} of ${details.totalLines}`,
-				`${details.visibleAnchors} visible anchor(s), ${details.ambiguousLines} ambiguous line(s)`,
-				keyHint("app.tools.expand", "expand to view lines"),
-			].join(". ")
-		: keyHint("app.tools.expand", "expand to view lines");
-	return new Text(theme.fg("muted", summary), 0, 0);
+	if (!details) {
+		return new Text(
+			theme.fg("muted", keyHint("app.tools.expand", "expand to view lines")),
+			0,
+			0,
+		);
+	}
+
+	const summaryParts = [
+		`${details.path}: lines ${details.startLine}-${details.endLine} of ${details.totalLines}`,
+		`${details.visibleAnchors} visible anchor(s)`,
+	];
+	if (details.ambiguousLines > 0) {
+		summaryParts.push(`${details.ambiguousLines} ambiguous line(s)`);
+	}
+	summaryParts.push(keyHint("app.tools.expand", "expand to view lines"));
+	return new Text(theme.fg("muted", summaryParts.join(". ")), 0, 0);
 }
 
 function renderEditChunkParams(args: unknown, theme: Theme): string[] {

--- a/files/pi/agent/extensions/user/lib/file/chunk.ts
+++ b/files/pi/agent/extensions/user/lib/file/chunk.ts
@@ -1,8 +1,15 @@
 import { constants } from "node:fs";
 import { access, readFile, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
-import type { AgentToolResult, Theme } from "@earendil-works/pi-coding-agent";
-import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import {
+	type AgentToolResult,
+	type EditDiffResult,
+	type Theme,
+	generateDiffString,
+	generateUnifiedPatch,
+	renderDiff,
+	withFileMutationQueue,
+} from "@earendil-works/pi-coding-agent";
 import { type Component, Text } from "@earendil-works/pi-tui";
 import { type Static, Type } from "typebox";
 import { ToolError } from "./errors";
@@ -20,6 +27,7 @@ const EDIT_CHUNK_OPERATION = "Editing chunk in";
 const ANCHOR_LENGTH = 3;
 const DEFAULT_READ_CHUNK_LIMIT = 200;
 const MAX_CONTEXT_RADIUS = 16;
+const LLM_DIFF_OMIT_LINE_THRESHOLD = 50;
 
 const anchorSchema = Type.String({
 	description:
@@ -85,8 +93,10 @@ type EditChunkDetails = {
 	operation: "edit_chunk";
 	path: string;
 	replacements: number;
+	diff: string;
+	patch: string;
+	firstChangedLine: number | undefined;
 };
-
 type TextDocument = {
 	readonly lines: readonly string[];
 	readonly lineEnding: "\n" | "\r\n";
@@ -352,7 +362,7 @@ export function renderReadChunk(
 }
 
 function renderToolResultText(
-	result: AgentToolResult<ReadChunkDetails>,
+	result: AgentToolResult<unknown>,
 	theme: Theme,
 ): Component {
 	const text = result.content
@@ -419,6 +429,41 @@ export function renderEditChunk(
 	const params = renderEditChunkParams(args, theme);
 	if (params.length === 0) return new Text(header, 0, 0);
 	return new Text(`${header}\n${params.join("\n")}`, 0, 0);
+}
+
+function isEditChunkDetails(details: unknown): details is EditChunkDetails {
+	if (typeof details !== "object" || details === null) return false;
+	const value = details as Record<string, unknown>;
+	return (
+		value.operation === "edit_chunk" &&
+		typeof value.path === "string" &&
+		typeof value.replacements === "number" &&
+		typeof value.diff === "string" &&
+		typeof value.patch === "string" &&
+		(value.firstChangedLine === undefined ||
+			typeof value.firstChangedLine === "number")
+	);
+}
+
+export function renderEditChunkResult(
+	result: AgentToolResult<EditChunkDetails>,
+	options: { expanded: boolean; isPartial: boolean },
+	theme: Theme,
+): Component {
+	if (options.isPartial) {
+		return new Text(theme.fg("warning", "Applying chunk edit..."), 0, 0);
+	}
+
+	const details = result.details;
+	if (!isEditChunkDetails(details)) return renderToolResultText(result, theme);
+
+	const summary = theme.fg(
+		"success",
+		`Applied ${details.replacements} chunk edits.`,
+	);
+	if (details.diff.length === 0) return new Text(summary, 0, 0);
+
+	return new Text(`${renderDiff(details.diff)}\n${summary}`, 0, 0);
 }
 
 export async function executeReadChunk(
@@ -518,6 +563,21 @@ export async function executeEditChunk(
 		checkAbort(signal, EDIT_CHUNK_OPERATION);
 
 		const nextLines = applyResolvedEdits(document.lines, resolved);
+		const baseContent = serializeDocument(
+			document.lines,
+			"\n",
+			document.finalNewline,
+		);
+		const diffContent = serializeDocument(
+			nextLines,
+			"\n",
+			document.finalNewline,
+		);
+		const diffResult: EditDiffResult = generateDiffString(
+			baseContent,
+			diffContent,
+		);
+		const patch = generateUnifiedPatch(displayPath, baseContent, diffContent);
 		const nextContent = serializeDocument(
 			nextLines,
 			document.lineEnding,
@@ -526,17 +586,29 @@ export async function executeEditChunk(
 		await writeFile(absolutePath, nextContent, "utf8");
 		checkAbort(signal, EDIT_CHUNK_OPERATION);
 
+		const resultSummary = `Applied ${resolved.length} chunk edits.`;
+		const diffLineCount =
+			diffResult.diff === "" ? 0 : diffResult.diff.split("\n").length;
+		const resultMessage = !diffResult.diff
+			? resultSummary
+			: diffLineCount >= LLM_DIFF_OMIT_LINE_THRESHOLD
+				? `Diff omitted from tool result because it is ${diffLineCount} lines (>= ${LLM_DIFF_OMIT_LINE_THRESHOLD}). Use read_chunk only if you need to inspect the changed content.\n${resultSummary}`
+				: `Diff:\n${diffResult.diff}\n${resultSummary}`;
+
 		return {
 			content: [
 				{
 					type: "text",
-					text: `Successfully applied ${resolved.length} chunk edit(s) to ${displayPath}.`,
+					text: resultMessage,
 				},
 			],
 			details: {
 				operation: "edit_chunk",
 				path: displayPath,
 				replacements: resolved.length,
+				diff: diffResult.diff,
+				patch,
+				firstChangedLine: diffResult.firstChangedLine,
 			} satisfies EditChunkDetails,
 		};
 	});

--- a/files/pi/agent/extensions/user/lib/file/chunk.ts
+++ b/files/pi/agent/extensions/user/lib/file/chunk.ts
@@ -306,15 +306,30 @@ async function readAllowedTextFile(
 	};
 }
 
+function formatReadChunkLineRange(args: Record<string, unknown>, theme: Theme): string {
+	if (args.offset === undefined && args.limit === undefined) return "";
+	const startLine = typeof args.offset === "number" ? args.offset : 1;
+	const limit = typeof args.limit === "number" ? args.limit : DEFAULT_READ_CHUNK_LIMIT;
+	const endLine = startLine + limit - 1;
+	return theme.fg("warning", `:${startLine}-${endLine}`);
+}
+
 function renderChunkHeaderText(
 	name: string,
 	args: unknown,
 	theme: Theme,
+	context?: { readonly expanded?: boolean },
 ): string {
 	const input = (args ?? {}) as Record<string, unknown>;
 	const path = typeof input.path === "string" ? input.path : "";
 	let text = theme.fg("toolTitle", theme.bold(name));
 	if (path) text += ` ${theme.fg("accent", path)}`;
+	if (name === "read_chunk") {
+		text += formatReadChunkLineRange(input, theme);
+		if (!(context?.expanded ?? false)) {
+			text += theme.fg("dim", " (ctrl+o to expand)");
+		}
+	}
 	return text;
 }
 
@@ -322,12 +337,17 @@ function renderChunkHeader(
 	name: string,
 	args: unknown,
 	theme: Theme,
+	context?: { readonly expanded?: boolean },
 ): Component {
-	return new Text(renderChunkHeaderText(name, args, theme), 0, 0);
+	return new Text(renderChunkHeaderText(name, args, theme, context), 0, 0);
 }
 
-export function renderReadChunk(args: unknown, theme: Theme): Component {
-	return renderChunkHeader("read_chunk", args, theme);
+export function renderReadChunk(
+	args: unknown,
+	theme: Theme,
+	context?: { readonly expanded?: boolean },
+): Component {
+	return renderChunkHeader("read_chunk", args, theme, context);
 }
 
 function renderToolResultText(
@@ -365,14 +385,10 @@ export function renderReadChunkResult(
 	const details = result.details;
 	if (!isReadChunkDetails(details)) return renderToolResultText(result, theme);
 
-	const summaryParts = [
-		`${details.path}: lines ${details.startLine}-${details.endLine} of ${details.totalLines}`,
-		`${details.visibleAnchors} visible anchor(s)`,
-	];
+	const summaryParts = [`${details.visibleAnchors} visible anchor(s)`];
 	if (details.ambiguousLines > 0) {
 		summaryParts.push(`${details.ambiguousLines} ambiguous line(s)`);
 	}
-	summaryParts.push(keyHint("app.tools.expand", "expand to view lines"));
 	return new Text(theme.fg("muted", summaryParts.join(". ")), 0, 0);
 }
 
@@ -396,7 +412,7 @@ export function renderEditChunk(
 	theme: Theme,
 	context?: { readonly expanded?: boolean },
 ): Component {
-	const header = renderChunkHeaderText("edit_chunk", args, theme);
+	const header = renderChunkHeaderText("edit_chunk", args, theme, context);
 	if (!(context?.expanded ?? false)) return new Text(header, 0, 0);
 
 	const params = renderEditChunkParams(args, theme);

--- a/files/pi/agent/extensions/user/lib/file/chunk.ts
+++ b/files/pi/agent/extensions/user/lib/file/chunk.ts
@@ -19,6 +19,7 @@ import {
 const READ_CHUNK_OPERATION = "Reading chunk from";
 const EDIT_CHUNK_OPERATION = "Editing chunk in";
 const ANCHOR_LENGTH = 3;
+const DEFAULT_READ_CHUNK_LIMIT = 200;
 const MAX_CONTEXT_RADIUS = 16;
 
 const anchorSchema = Type.String({
@@ -36,7 +37,9 @@ export const readChunkSchema = Type.Object({
 		}),
 	),
 	limit: Type.Optional(
-		Type.Number({ description: "Maximum number of lines to read." }),
+		Type.Number({
+			description: `Maximum number of lines to read. Defaults to ${DEFAULT_READ_CHUNK_LIMIT}; pass an explicit limit to read more.`,
+		}),
 	),
 });
 
@@ -389,10 +392,8 @@ export async function executeReadChunk(
 	const document = parseDocument(content);
 	const anchors = buildAnchorIndex(document.lines);
 	const start = Math.min((params.offset ?? 1) - 1, document.lines.length);
-	const endExclusive = Math.min(
-		document.lines.length,
-		params.limit === undefined ? document.lines.length : start + params.limit,
-	);
+	const limit = params.limit ?? DEFAULT_READ_CHUNK_LIMIT;
+	const endExclusive = Math.min(document.lines.length, start + limit);
 	const lines = document.lines.slice(start, endExclusive);
 	const lineNumberWidth = String(document.lines.length).length;
 	const output = lines.map((line, index) => {

--- a/files/pi/agent/extensions/user/lib/file/errors.ts
+++ b/files/pi/agent/extensions/user/lib/file/errors.ts
@@ -6,6 +6,7 @@ export type ToolErrorCode =
 	| "not_found"
 	| "destination_exists"
 	| "destination_not_directory"
+	| "secret"
 	| "aborted"
 	| "missing_input";
 
@@ -40,6 +41,8 @@ function formatToolError(
 			return `Destination already exists: ${context}. Remove it with rm, or move it aside with mv, before retrying.`;
 		case "destination_not_directory":
 			return `Destination must be an existing directory when moving multiple sources: ${context}`;
+		case "secret":
+			return `${operation} secret files is not allowed: ${context}`;
 		case "aborted":
 			return "Tool execution was aborted.";
 		case "missing_input":

--- a/files/pi/agent/extensions/user/lib/file/guard.ts
+++ b/files/pi/agent/extensions/user/lib/file/guard.ts
@@ -3,7 +3,6 @@ import { lstat, readdir } from "node:fs/promises";
 import { dirname, relative, resolve, sep } from "node:path";
 import { promisify } from "node:util";
 import { ToolError, isErrnoCode } from "./errors";
-
 type IgnoreCache = Map<string, boolean>;
 
 export type FsGuardContext = {
@@ -42,6 +41,10 @@ export function displayRepoPath(cwd: string, absolutePath: string): string {
 	const rel = relative(cwd, absolutePath);
 	if (!rel) return ".";
 	return isRelativeOutside(rel) ? absolutePath : rel;
+}
+
+export function isRepoPath(ctx: FsGuardContext, absolutePath: string): boolean {
+	return isInside(ctx.repoRoot, absolutePath);
 }
 
 export async function assertRepoPathAllowed(

--- a/files/pi/agent/extensions/user/lib/file/index.ts
+++ b/files/pi/agent/extensions/user/lib/file/index.ts
@@ -1,3 +1,14 @@
+export {
+	type EditChunkToolInput,
+	type ReadChunkToolInput,
+	editChunkSchema,
+	executeEditChunk,
+	executeReadChunk,
+	readChunkSchema,
+	renderEditChunk,
+	renderReadChunk,
+	renderReadChunkResult,
+} from "./chunk";
 export { ToolError, type ToolErrorCode, isErrnoCode } from "./errors";
 export {
 	type FsGuardContext,

--- a/files/pi/agent/extensions/user/lib/file/index.ts
+++ b/files/pi/agent/extensions/user/lib/file/index.ts
@@ -6,6 +6,7 @@ export {
 	executeReadChunk,
 	readChunkSchema,
 	renderEditChunk,
+	renderEditChunkResult,
 	renderReadChunk,
 	renderReadChunkResult,
 } from "./chunk";

--- a/files/pi/agent/extensions/user/lib/focus/controller.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/controller.test.ts
@@ -23,11 +23,13 @@ function fakePi(): ExtensionAPI & {
 				"enter_focus",
 				"exit_focus",
 				"read",
+				"read_chunk",
 				"grep",
 				"find",
 				"ls",
 				"write",
 				"edit",
+				"edit_chunk",
 				"mv",
 				"rm",
 			].map((name) => ({ name })),
@@ -85,7 +87,7 @@ describe("createFocusController", () => {
 		assert.deepEqual(pi.entries, [
 			{ customType: FOCUS_STATE_TYPE, data: { focus: "explore" } },
 		]);
-		assert.ok(pi.activeTools.includes("read"));
+		assert.ok(pi.activeTools.includes("read_chunk"));
 		assert.equal(typeof ctx.statuses.focus, "string");
 
 		controller.restore(ctx, "edit");

--- a/files/pi/agent/extensions/user/lib/focus/definitions.ts
+++ b/files/pi/agent/extensions/user/lib/focus/definitions.ts
@@ -41,8 +41,8 @@ export function getFocusExitMode(focus: FocusDefinition): FocusExitMode {
 
 export const BUILT_IN_TOOL_SETS: ReadonlyMap<string, readonly string[]> =
 	new Map([
-		["file_read", ["read", "grep", "find", "ls"]],
-		["file_write", ["write", "edit", "mv", "rm"]],
+		["file_read", ["read_chunk", "grep", "find", "ls"]],
+		["file_write", ["write", "edit_chunk", "mv", "rm"]],
 	]);
 
 export const BASE_FOCUS_DEFINITIONS: readonly FocusDefinition[] = [
@@ -62,7 +62,7 @@ export const BASE_FOCUS_DEFINITIONS: readonly FocusDefinition[] = [
 		description:
 			"Use when the user asks for repository file changes, or after investigation establishes that file changes are needed.",
 		prompt:
-			"You are in edit focus. Make focused file changes with read/write/edit/mv/rm. Keep changes minimal.",
+			"You are in edit focus. Make focused file changes with read_chunk/write/edit_chunk/mv/rm. Keep changes minimal.",
 		tools: [],
 		toolSets: ["file_read", "file_write"],
 		transition: FOCUS_TRANSITION.CONFIRM,
@@ -75,7 +75,7 @@ export const BASE_FOCUS_DEFINITIONS: readonly FocusDefinition[] = [
 		prompt: [
 			"You are in interview focus. Clarify the user's real requirements by understanding their goals, background, pain points, constraints, and success criteria before proceeding.",
 			"Do not enter edit focus while requirements are unclear. Treat implementation feasibility and requirement clarity as separate things.",
-			"Before asking, use read, grep, find, or ls when they can answer the question or make the next question sharper. Do not ask the user for information that can be inspected from code or repository state.",
+			"Before asking, use read_chunk, grep, find, or ls when they can answer the question or make the next question sharper. Do not ask the user for information that can be inspected from code or repository state.",
 			"When requirements remain unclear, send a brief normal message summarizing the current understanding, then in the same turn call ask_user_question. Do not stop after the message. Continue this short-message plus ask_user_question loop until the user's intent is clear.",
 			"Use ask_user_question for clarification instead of asking free-form questions in normal chat. Use normal chat only for the brief summary immediately before the structured question, or when the user explicitly asks for discussion instead of answering the question.",
 			"Keep ask_user_question question text focused on the question itself, put rationale in the reason field, and do not stuff long summaries into the question.",

--- a/files/pi/agent/extensions/user/lib/focus/definitions.ts
+++ b/files/pi/agent/extensions/user/lib/focus/definitions.ts
@@ -120,10 +120,10 @@ export const BASE_FOCUS_DEFINITIONS: readonly FocusDefinition[] = [
 	{
 		name: "yolo",
 		description:
-			"Shell-enabled focus for manual use only. Can read, write, edit, and run shell commands.",
+			"Shell-enabled focus for manual use only. Can read chunks, write, edit chunks, and run shell commands.",
 		prompt:
-			"You are in yolo focus. Use read, write, edit, and bash to inspect and modify files and run shell commands. Avoid exposing secrets or credentials. If a command may print secrets, use a safer command or mask sensitive output. Ask for confirmation for gray-area destructive or privacy-sensitive actions.",
-		tools: ["read", "write", "edit", "bash"],
+			"You are in yolo focus. Use read_chunk, write, edit_chunk, and bash to inspect and modify files and run shell commands. Avoid exposing secrets or credentials. If a command may print secrets, use a safer command or mask sensitive output. Ask for confirmation for gray-area destructive or privacy-sensitive actions.",
+		tools: ["read_chunk", "write", "edit_chunk", "bash"],
 		transition: FOCUS_TRANSITION.MANUAL,
 		color: "alert",
 	},

--- a/files/pi/agent/extensions/user/lib/focus/registry.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/registry.test.ts
@@ -45,9 +45,9 @@ describe("loadFocusRegistry", () => {
 			"format",
 		]);
 		for (const tool of [
-			"read",
+			"read_chunk",
 			"write",
-			"edit",
+			"edit_chunk",
 			"lint",
 			"test",
 			"coverage",

--- a/files/pi/agent/extensions/user/lib/focus/session.test.ts
+++ b/files/pi/agent/extensions/user/lib/focus/session.test.ts
@@ -25,11 +25,13 @@ function fakePi(): ExtensionAPI & {
 				"enter_focus",
 				"exit_focus",
 				"read",
+				"read_chunk",
 				"grep",
 				"find",
 				"ls",
 				"write",
 				"edit",
+				"edit_chunk",
 				"mv",
 				"rm",
 			].map((name) => ({ name })),
@@ -84,7 +86,7 @@ describe("focus session lifecycle", () => {
 		assert.deepEqual(pi.entries, []);
 		assert.deepEqual(pi.activeTools, [
 			"multi_tool_use.parallel",
-			"read",
+			"read_chunk",
 			"grep",
 			"find",
 			"ls",

--- a/files/pi/agent/extensions/user/lib/tool/builtin.ts
+++ b/files/pi/agent/extensions/user/lib/tool/builtin.ts
@@ -1,9 +1,16 @@
 import {
+	editChunkSchema,
+	executeEditChunk,
 	executeMove,
+	executeReadChunk,
 	executeRemove,
 	mvSchema,
 	normalizeStringOrArray,
+	readChunkSchema,
+	renderEditChunk,
 	renderMv,
+	renderReadChunk,
+	renderReadChunkResult,
 	renderRm,
 	rmSchema,
 } from "../file";
@@ -26,6 +33,62 @@ export function registerCoreUserTools(catalog: ToolCatalog): void {
 }
 
 function registerFileTools(catalog: ToolCatalog): void {
+	catalog.register(
+		defineToolContribution({
+			policy: {
+				name: "read_chunk",
+				extractSecretPaths: (input) => [input.path],
+				secretBlockReason: makeSecretActionReason("Reading chunk from"),
+			},
+			definition: {
+				name: "read_chunk",
+				label: "read_chunk",
+				description:
+					"Read a file with 3-character per-line anchors for later chunk edits. Ambiguous anchors are hidden as @--- and cannot be used for editing.",
+				promptSnippet:
+					"Read file lines with short unique anchors for edit_chunk",
+				promptGuidelines: [
+					"Use read_chunk before edit_chunk when exact oldText replacement would be ambiguous or wasteful.",
+					"read_chunk shows @--- for ambiguous lines; do not use @--- as an edit_chunk old_range endpoint.",
+				],
+				parameters: readChunkSchema,
+				executionMode: "parallel",
+				renderCall: renderReadChunk,
+				renderResult: renderReadChunkResult,
+				execute: (_toolCallId, params, signal, _onUpdate, ctx) =>
+					executeReadChunk(ctx.cwd, params, signal),
+			},
+		}),
+	);
+
+	catalog.register(
+		defineToolContribution({
+			policy: {
+				name: "edit_chunk",
+				extractSecretPaths: (input) => [input.path],
+				secretBlockReason: makeSecretActionReason("Editing chunk in"),
+			},
+			definition: {
+				name: "edit_chunk",
+				label: "edit_chunk",
+				description:
+					"Edit a file by replacing anchor-delimited line chunks produced by read_chunk, including blank lines when they should be removed or preserved. Fails without modifying files when anchors are missing, ambiguous, reversed, or overlapping.",
+				promptSnippet: "Replace line chunks using anchors from read_chunk",
+				promptGuidelines: [
+					"Use edit_chunk with anchors copied from read_chunk when normal edit oldText matching is likely ambiguous.",
+					"For edit_chunk, pass edits: [{ old_range: [startAnchor, endAnchor], new_lines: [...] }]. Use the same anchor twice for a single-line edit.",
+					"When deleting or replacing a block, include surrounding blank lines in old_range when they should also be removed; do not leave accidental extra blank lines.",
+					"Do not use @--- as an edit_chunk anchor. If needed anchors are hidden or stale, run read_chunk again on a smaller relevant area.",
+				],
+				parameters: editChunkSchema,
+				executionMode: "sequential",
+				renderCall: renderEditChunk,
+				execute: (_toolCallId, params, signal, _onUpdate, ctx) =>
+					executeEditChunk(ctx.cwd, params, signal),
+			},
+		}),
+	);
+
 	catalog.register(
 		defineToolContribution({
 			policy: {

--- a/files/pi/agent/extensions/user/lib/tool/builtin.ts
+++ b/files/pi/agent/extensions/user/lib/tool/builtin.ts
@@ -8,6 +8,7 @@ import {
 	normalizeStringOrArray,
 	readChunkSchema,
 	renderEditChunk,
+	renderEditChunkResult,
 	renderMv,
 	renderReadChunk,
 	renderReadChunkResult,
@@ -86,6 +87,7 @@ function registerFileTools(catalog: ToolCatalog): void {
 				parameters: editChunkSchema,
 				executionMode: "sequential",
 				renderCall: renderEditChunk,
+				renderResult: renderEditChunkResult,
 				execute: (_toolCallId, params, signal, _onUpdate, ctx) =>
 					executeEditChunk(ctx.cwd, params, signal),
 			},

--- a/files/pi/agent/extensions/user/lib/tool/builtin.ts
+++ b/files/pi/agent/extensions/user/lib/tool/builtin.ts
@@ -44,11 +44,12 @@ function registerFileTools(catalog: ToolCatalog): void {
 				name: "read_chunk",
 				label: "read_chunk",
 				description:
-					"Read a file with 3-character per-line anchors for later chunk edits. Ambiguous anchors are hidden as @--- and cannot be used for editing.",
+					"Read up to 200 file lines by default with 3-character per-line anchors for later chunk edits. Pass offset and limit explicitly for large files or other ranges. Ambiguous anchors are hidden as @--- and cannot be used for editing.",
 				promptSnippet:
 					"Read file lines with short unique anchors for edit_chunk",
 				promptGuidelines: [
 					"Use read_chunk before edit_chunk when exact oldText replacement would be ambiguous or wasteful.",
+					"read_chunk defaults to the first 200 lines. For large files, pass offset and limit to read only the relevant range.",
 					"read_chunk shows @--- for ambiguous lines; do not use @--- as an edit_chunk old_range endpoint.",
 				],
 				parameters: readChunkSchema,

--- a/files/pi/agent/extensions/user/lib/tool/builtin.ts
+++ b/files/pi/agent/extensions/user/lib/tool/builtin.ts
@@ -72,12 +72,14 @@ function registerFileTools(catalog: ToolCatalog): void {
 				name: "edit_chunk",
 				label: "edit_chunk",
 				description:
-					"Edit a file by replacing anchor-delimited line chunks produced by read_chunk, including blank lines when they should be removed or preserved. Fails without modifying files when anchors are missing, ambiguous, reversed, or overlapping.",
+					"Edit a file by replacing anchor-delimited line chunks produced by read_chunk. Whitespace and blank lines are part of the edit: choose old_range and new_lines so the file has correct spacing after this single edit, without requiring a follow-up cleanup edit. Fails without modifying files when anchors are missing, ambiguous, reversed, or overlapping.",
 				promptSnippet: "Replace line chunks using anchors from read_chunk",
 				promptGuidelines: [
 					"Use edit_chunk with anchors copied from read_chunk when normal edit oldText matching is likely ambiguous.",
 					"For edit_chunk, pass edits: [{ old_range: [startAnchor, endAnchor], new_lines: [...] }]. Use the same anchor twice for a single-line edit.",
-					"When deleting or replacing a block, include surrounding blank lines in old_range when they should also be removed; do not leave accidental extra blank lines.",
+					"Whitespace and blank lines are part of the edit. Choose old_range and new_lines so the final file has correct spacing in the same edit.",
+					"When deleting a whole block such as a function, type, const/var block, import group, or test case, include the adjacent blank line in old_range when needed so the remaining code keeps normal spacing.",
+					"Do not leave doubled blank lines, and do not remove all separation between adjacent top-level declarations. Prefer deleting the trailing blank line after the removed block; if the block is at the end of a section/file, delete the preceding blank line instead.",
 					"Do not use @--- as an edit_chunk anchor. If needed anchors are hidden or stale, run read_chunk again on a smaller relevant area.",
 				],
 				parameters: editChunkSchema,


### PR DESCRIPTION

## Summary

- Add read_chunk and edit_chunk tools for anchored file reads and chunk-based edits.
- Register the new tools in the user extension catalog and export their file helpers.
- Update focus tool sets and prompts to prefer chunk-based file reads/edits.
- Cover chunk anchor generation, edit validation, and path guard behavior with tests.

## Background

These tools provide a safer editing path for cases where exact text replacement is ambiguous or too large, while preserving existing repository path and ignore-file protections.
