### PR TITLE
Fix interview other input padding

### DIFF
--- a/files/pi/agent/extensions/user/lib/tool/interview.ts
+++ b/files/pi/agent/extensions/user/lib/tool/interview.ts
@@ -4,7 +4,10 @@ import type {
 	Theme,
 	ThemeColor,
 } from "@earendil-works/pi-coding-agent";
-import { DynamicBorder } from "@earendil-works/pi-coding-agent";
+import {
+	DynamicBorder,
+	ExtensionEditorComponent,
+} from "@earendil-works/pi-coding-agent";
 import {
 	Text,
 	matchesKey,
@@ -108,6 +111,7 @@ type QuestionRow = {
 };
 
 const PROMPT_PADDING_X = 2;
+const OTHER_INPUT_PADDING_X = 1;
 const OTHER_PREVIEW_MAX_LINES = 3;
 const OTHER_LABEL = "Other";
 const OTHER_INPUT_TITLE = "Provide Other Answer";
@@ -559,7 +563,18 @@ async function showOtherInput(
 	]
 		.filter((line): line is string => line !== undefined)
 		.join("\n");
-	return ctx.ui.editor(title, initialValue ?? "");
+	return ctx.ui.custom<string | undefined>(
+		(tui, _theme, keybindings, done) =>
+			new ExtensionEditorComponent(
+				tui,
+				keybindings,
+				title,
+				initialValue ?? "",
+				(value) => done(value),
+				() => done(undefined),
+				{ paddingX: OTHER_INPUT_PADDING_X },
+			),
+	);
 }
 
 async function askSingle(


### PR DESCRIPTION
## Summary

Adds horizontal padding to the structured interview tool's Other free-text input so typed text no longer touches the input border.

## Background

The Other input should keep using the extension editor UI, but it needs the editor padding option applied for better visual spacing.
