### PR TITLE
Add Pi prompt refinement quick action

### DIFF
--- a/files/pi/agent/extensions/user/features/prompt-refine.ts
+++ b/files/pi/agent/extensions/user/features/prompt-refine.ts
@@ -12,6 +12,8 @@ Rewrite the user's draft prompt so it is clearer, more actionable, and easier fo
 
 Rules:
 - Preserve the user's intent and language.
+- Correct obvious typos, dictation mistakes, speech-recognition errors, and wrong homophones from voice input when the intended wording is clear.
+- Do not over-correct domain terms, code identifiers, file paths, commands, URLs, or proper nouns unless they are clearly mistaken.
 - Do not add requirements that are not implied by the draft.
 - Make ambiguity explicit only when helpful.
 - Prefer concise structure with bullets when it improves readability.
@@ -25,14 +27,6 @@ function extractText(response: Awaited<ReturnType<typeof complete>>): string {
 		.map((part) => part.text)
 		.join("\n")
 		.trim();
-}
-
-function escapeHtmlComment(text: string): string {
-	return text.replaceAll("--", "- -");
-}
-
-function formatRefinedPrompt(refined: string, original: string): string {
-	return `${refined.trim()}\n\n<!-- original prompt\n${escapeHtmlComment(original.trim())}\n-->`;
 }
 
 async function generateRefinedPrompt(
@@ -104,7 +98,7 @@ async function refineEditorPrompt(ctx: ExtensionContext): Promise<void> {
 		return;
 	}
 
-	ctx.ui.setEditorText(formatRefinedPrompt(refined, original));
+	ctx.ui.setEditorText(refined);
 	ctx.ui.notify("Prompt refined", "info");
 }
 

--- a/files/pi/agent/extensions/user/features/prompt-refine.ts
+++ b/files/pi/agent/extensions/user/features/prompt-refine.ts
@@ -1,0 +1,119 @@
+import { type Message, complete } from "@earendil-works/pi-ai";
+import {
+	BorderedLoader,
+	type ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import type { Feature } from "../feature";
+import { registerQuickActionHandler } from "../lib/quick-actions";
+
+const SYSTEM_PROMPT = `You refine prompts for a coding agent.
+
+Rewrite the user's draft prompt so it is clearer, more actionable, and easier for the agent to execute.
+
+Rules:
+- Preserve the user's intent and language.
+- Do not add requirements that are not implied by the draft.
+- Make ambiguity explicit only when helpful.
+- Prefer concise structure with bullets when it improves readability.
+- Output only the refined prompt text. Do not include explanations, prefaces, or markdown fences.`;
+
+function extractText(response: Awaited<ReturnType<typeof complete>>): string {
+	return response.content
+		.filter(
+			(part): part is { type: "text"; text: string } => part.type === "text",
+		)
+		.map((part) => part.text)
+		.join("\n")
+		.trim();
+}
+
+function escapeHtmlComment(text: string): string {
+	return text.replaceAll("--", "- -");
+}
+
+function formatRefinedPrompt(refined: string, original: string): string {
+	return `${refined.trim()}\n\n<!-- original prompt\n${escapeHtmlComment(original.trim())}\n-->`;
+}
+
+async function generateRefinedPrompt(
+	ctx: ExtensionContext,
+	prompt: string,
+): Promise<string | null> {
+	if (!ctx.model) {
+		ctx.ui.notify("Select a model before refining prompts", "warning");
+		return null;
+	}
+
+	return ctx.ui.custom<string | null>((tui, theme, _keybindings, done) => {
+		const loader = new BorderedLoader(tui, theme, "Refining prompt...");
+		loader.onAbort = () => done(null);
+
+		const run = async (): Promise<string | null> => {
+			const auth = await ctx.modelRegistry.getApiKeyAndHeaders(ctx.model!);
+			if (!auth.ok || !auth.apiKey) {
+				throw new Error(
+					auth.ok ? `No API key for ${ctx.model!.provider}` : auth.error,
+				);
+			}
+
+			const userMessage: Message = {
+				role: "user",
+				content: [{ type: "text", text: prompt }],
+				timestamp: Date.now(),
+			};
+			const response = await complete(
+				ctx.model!,
+				{ systemPrompt: SYSTEM_PROMPT, messages: [userMessage] },
+				{
+					apiKey: auth.apiKey,
+					headers: auth.headers,
+					reasoning: "low",
+					signal: loader.signal,
+				},
+			);
+
+			if (response.stopReason === "aborted") return null;
+			const refined = extractText(response);
+			if (!refined) throw new Error("Refined prompt was empty");
+			return refined;
+		};
+
+		void (async () => {
+			try {
+				done(await run());
+			} catch (error) {
+				console.error("Prompt refinement failed:", error);
+				done(null);
+			}
+		})();
+
+		return loader;
+	});
+}
+
+async function refineEditorPrompt(ctx: ExtensionContext): Promise<void> {
+	const original = ctx.ui.getEditorText().trim();
+	if (!original) {
+		ctx.ui.notify("Write a prompt before refining it", "warning");
+		return;
+	}
+
+	const refined = await generateRefinedPrompt(ctx, original);
+	if (refined === null) {
+		ctx.ui.notify("Prompt refinement cancelled", "info");
+		return;
+	}
+
+	ctx.ui.setEditorText(formatRefinedPrompt(refined, original));
+	ctx.ui.notify("Prompt refined", "info");
+}
+
+function register(): void {
+	registerQuickActionHandler("refinePrompt", refineEditorPrompt);
+}
+
+export function createPromptRefineFeature(): Feature {
+	return { name: "prompt-refine", dependsOn: ["quick-actions"], register };
+}
+
+export default createPromptRefineFeature();

--- a/files/pi/agent/extensions/user/features/quick-actions.ts
+++ b/files/pi/agent/extensions/user/features/quick-actions.ts
@@ -21,6 +21,9 @@ const openQuickActions =
 			case "model":
 				await showModelSelector(pi, ctx);
 				break;
+			case "refinePrompt":
+				await runQuickAction("refinePrompt", ctx);
+				break;
 		}
 	};
 

--- a/files/pi/agent/extensions/user/lib/quick-actions.ts
+++ b/files/pi/agent/extensions/user/lib/quick-actions.ts
@@ -11,7 +11,7 @@ import {
 	renderKeyedPanelItem,
 } from "./ui/keyed-panel";
 
-export type QuickActionId = "focus" | "effort" | "model";
+export type QuickActionId = "focus" | "effort" | "model" | "refinePrompt";
 
 type QuickAction = KeyedPanelItem & {
 	id: QuickActionId;
@@ -37,6 +37,12 @@ const QUICK_ACTIONS: readonly QuickAction[] = [
 		key: "l",
 		label: "Model",
 		description: "Select model",
+	},
+	{
+		id: "refinePrompt",
+		key: "r",
+		label: "Refine Prompt",
+		description: "Improve the editor prompt with AI",
 	},
 ];
 

--- a/files/pi/agent/extensions/user/main.ts
+++ b/files/pi/agent/extensions/user/main.ts
@@ -4,6 +4,7 @@ import { isUserExtensionEnabled } from "./lib/project-settings";
 import { createUserExtensionServices } from "./lib/services";
 import { createExitConfirmFeature } from "./features/exit-confirm";
 import { createFocusFeature } from "./features/focus";
+import { createPromptRefineFeature } from "./features/prompt-refine";
 import { createQuickActionsFeature } from "./features/quick-actions";
 import { createStatusFeature } from "./features/status";
 import { createSystemRemindersFeature } from "./features/system-reminders";
@@ -20,6 +21,7 @@ function createFeatures(): readonly Feature[] {
 		createSystemRemindersFeature(),
 		createFocusFeature(),
 		createQuickActionsFeature(),
+		createPromptRefineFeature(),
 		createThinkingFeature(),
 		createTmuxNoticeFeature(),
 		createToolFeature(),


### PR DESCRIPTION
## Summary

Add a Pi quick action that refines the current editor prompt with the selected model and writes the improved prompt back into the editor.

## Background

Prompt drafts often need a quick pass to make intent, constraints, and execution details clearer before sending them to the agent. This keeps that workflow inside the existing quick-actions menu, uses a dedicated refinement prompt, and preserves the original draft in an HTML comment below the refined prompt.