### PR TITLE
fix(pi): clarify edit_chunk anchor handling

### DIFF
--- a/files/pi/agent/extensions/user/lib/file/chunk.ts
+++ b/files/pi/agent/extensions/user/lib/file/chunk.ts
@@ -29,11 +29,11 @@ const DEFAULT_READ_CHUNK_LIMIT = 200;
 const MAX_CONTEXT_RADIUS = 16;
 const LLM_DIFF_OMIT_LINE_THRESHOLD = 50;
 
-const anchorSchema = Type.String({
-	description:
-		"Three-character anchor shown by read_chunk. A leading @ copied from read_chunk output is accepted with a warning.",
-	minLength: ANCHOR_LENGTH,
-	maxLength: ANCHOR_LENGTH + 1,
+const OLD_RANGE_ANCHOR_GUIDANCE =
+	'Use read_chunk anchors, not line numbers: from a read_chunk line like "12 @abc | text", pass "abc" in old_range.';
+
+const anchorSchema = Type.Union([Type.String(), Type.Number()], {
+	description: OLD_RANGE_ANCHOR_GUIDANCE,
 });
 
 export const readChunkSchema = Type.Object({
@@ -56,7 +56,7 @@ const chunkEditSchema = Type.Object(
 	{
 		old_range: Type.Array(anchorSchema, {
 			description:
-				"Inclusive [start_anchor, end_anchor] range from read_chunk output. Use the same anchor twice for a single-line edit.",
+				"Inclusive [start_anchor, end_anchor] range using read_chunk anchors, not line numbers. Copy the 3-character value after @ from read_chunk output (for example, from '12 @abc | text', use 'abc'). Use the same anchor twice for a single-line edit.",
 			minItems: 2,
 			maxItems: 2,
 		}),
@@ -237,9 +237,22 @@ function resolveAnchor(anchorIndex: AnchorIndex, anchor: string): number {
 	return line;
 }
 
-function normalizeAnchor(anchor: string, warnings: string[]): string {
-	if (!anchor.startsWith("@")) return anchor;
+function formatInvalidOldRangeAnchorError(anchor: string | number): string {
+	return `Invalid old_range anchor '${anchor}'. ${OLD_RANGE_ANCHOR_GUIDANCE}`;
+}
+
+function normalizeAnchor(anchor: string | number, warnings: string[]): string {
+	if (typeof anchor === "number") {
+		throw new Error(formatInvalidOldRangeAnchorError(anchor));
+	}
+	if (!anchor.startsWith("@")) {
+		if (anchor.length === ANCHOR_LENGTH) return anchor;
+		throw new Error(formatInvalidOldRangeAnchorError(anchor));
+	}
 	const normalized = anchor.slice(1);
+	if (normalized.length !== ANCHOR_LENGTH) {
+		throw new Error(formatInvalidOldRangeAnchorError(anchor));
+	}
 	const warning = `Removed leading @ from edit_chunk anchor '${anchor}'. Use '${normalized}' in old_range next time.`;
 	if (!warnings.includes(warning)) warnings.push(warning);
 	return normalized;
@@ -298,7 +311,10 @@ async function readAllowedTextFile(
 	path: string,
 	operation: string,
 	mode: number,
-	options?: { readonly allowOutsideRepoWithoutAnchors?: boolean },
+	options?: {
+		readonly allowOutsideRepoWithoutAnchors?: boolean;
+		readonly allowIgnoredDependencies?: boolean;
+	},
 ): Promise<{
 	absolutePath: string;
 	displayPath: string;
@@ -314,7 +330,7 @@ async function readAllowedTextFile(
 
 	const insideRepo = isRepoPath(guardContext, absolutePath);
 	if (insideRepo || options?.allowOutsideRepoWithoutAnchors !== true) {
-		await assertRepoPathAllowed(guardContext, absolutePath, operation);
+		await assertRepoPathAllowed(guardContext, absolutePath, operation, options);
 	}
 	await access(absolutePath, mode);
 	return {
@@ -499,7 +515,7 @@ export async function executeReadChunk(
 		params.path,
 		READ_CHUNK_OPERATION,
 		constants.R_OK,
-		{ allowOutsideRepoWithoutAnchors: true },
+		{ allowOutsideRepoWithoutAnchors: true, allowIgnoredDependencies: true },
 	);
 	checkAbort(signal, READ_CHUNK_OPERATION);
 
@@ -525,7 +541,7 @@ export async function executeReadChunk(
 		anchorsEnabled
 			? `Anchors are ${ANCHOR_LENGTH}-character tokens shown after line numbers. Only file-wide unique anchors are shown; @--- lines cannot be used as old_range endpoints.`
 			: "Anchors are disabled for files outside the repository; edit_chunk cannot use this output.",
-		`Use edit_chunk with edits: [{ old_range: ["start", "end"], new_lines: [...] }]. Use the same anchor twice for one line.`,
+		`Use edit_chunk with edits: [{ old_range: ["abc", "def"], new_lines: [...] }]. Copy anchors from the @ column, not line numbers; use the same anchor twice for one line.`,
 		`Showing ${lines.length} of ${document.lines.length} line(s).`,
 	];
 	const continuation =

--- a/files/pi/agent/extensions/user/lib/file/guard.ts
+++ b/files/pi/agent/extensions/user/lib/file/guard.ts
@@ -47,12 +47,17 @@ export function isRepoPath(ctx: FsGuardContext, absolutePath: string): boolean {
 	return isInside(ctx.repoRoot, absolutePath);
 }
 
+export type FsGuardOptions = {
+	readonly allowIgnoredDependencies?: boolean;
+};
+
 export async function assertRepoPathAllowed(
 	ctx: FsGuardContext,
 	absolutePath: string,
 	operation: string,
+	options?: FsGuardOptions,
 ): Promise<void> {
-	await assertRepoPathAllowedInRoot(ctx, absolutePath, operation);
+	await assertRepoPathAllowedInRoot(ctx, absolutePath, operation, options);
 }
 
 export async function assertNoIgnoredDescendants(
@@ -67,6 +72,7 @@ async function assertRepoPathAllowedInRoot(
 	ctx: FsGuardContext,
 	absolutePath: string,
 	operation: string,
+	options?: FsGuardOptions,
 ): Promise<void> {
 	const displayPath = displayRepoPath(ctx.cwd, absolutePath);
 
@@ -79,7 +85,10 @@ async function assertRepoPathAllowedInRoot(
 		throw new ToolError("inside_git", operation, relPath);
 	}
 
-	if (await isIgnoredByGitignore(ctx, absolutePath)) {
+	if (
+		!(options?.allowIgnoredDependencies && isDependencyPath(relPath)) &&
+		(await isIgnoredByGitignore(ctx, absolutePath))
+	) {
 		throw new ToolError("ignored", operation, displayPath);
 	}
 }
@@ -148,6 +157,27 @@ function isRelativeOutside(rel: string): boolean {
 
 function toPosix(path: string): string {
 	return path.split(sep).join("/");
+}
+const DEPENDENCY_PATH_PREFIXES = [
+	"node_modules",
+	"bower_components",
+	"Pods",
+	"Carthage/Checkouts",
+	"vendor/bundle",
+	"vendor/ruby",
+] as const;
+
+function isDependencyPath(relPath: string): boolean {
+	if (
+		DEPENDENCY_PATH_PREFIXES.some(
+			(p) => relPath === p || relPath.startsWith(`${p}/`),
+		)
+	) {
+		return true;
+	}
+	return /^(?:\.venv|venv)\/lib\/python[^/]+\/site-packages(?:\/|$)/u.test(
+		relPath,
+	);
 }
 
 async function isIgnoredByGitignore(

--- a/files/pi/agent/extensions/user/lib/file/index.ts
+++ b/files/pi/agent/extensions/user/lib/file/index.ts
@@ -13,6 +13,7 @@ export {
 export { ToolError, type ToolErrorCode, isErrnoCode } from "./errors";
 export {
 	type FsGuardContext,
+	type FsGuardOptions,
 	assertNoIgnoredDescendants,
 	assertRepoPathAllowed,
 	createFsGuardContext,

--- a/files/pi/agent/extensions/user/lib/tool/builtin.ts
+++ b/files/pi/agent/extensions/user/lib/tool/builtin.ts
@@ -79,7 +79,7 @@ function registerFileTools(catalog: ToolCatalog): void {
 				promptSnippet: "Replace line chunks using anchors from read_chunk",
 				promptGuidelines: [
 					"Use edit_chunk with anchors copied from read_chunk when normal edit oldText matching is likely ambiguous.",
-					"For edit_chunk, pass edits: [{ old_range: [startAnchor, endAnchor], new_lines: [...] }]. Use the same anchor twice for a single-line edit.",
+					"For edit_chunk, pass read_chunk anchors in old_range, not line numbers: from a line like '12 @abc | text', use 'abc'. Use the same anchor twice for a single-line edit.",
 					"Whitespace and blank lines are part of the edit. Choose old_range and new_lines so the final file has correct spacing in the same edit.",
 					"When deleting a whole block such as a function, type, const/var block, import group, or test case, include the adjacent blank line in old_range when needed so the remaining code keeps normal spacing.",
 					"Do not leave doubled blank lines, and do not remove all separation between adjacent top-level declarations. Prefer deleting the trailing blank line after the removed block; if the block is at the end of a section/file, delete the preceding blank line instead.",

--- a/tests/pi/agent/extensions/user/lib/file/chunk.test.ts
+++ b/tests/pi/agent/extensions/user/lib/file/chunk.test.ts
@@ -194,6 +194,28 @@ describe("chunk file tools", () => {
 				root,
 				{
 					path: "src/demo.txt",
+					edits: [{ old_range: [12, 12], new_lines: ["nope"] }],
+				},
+				undefined,
+			),
+			/Use read_chunk anchors, not line numbers/u,
+		);
+		await assert.rejects(
+			executeEditChunk(
+				root,
+				{
+					path: "src/demo.txt",
+					edits: [{ old_range: ["12", "12"], new_lines: ["nope"] }],
+				},
+				undefined,
+			),
+			/Use read_chunk anchors, not line numbers/u,
+		);
+		await assert.rejects(
+			executeEditChunk(
+				root,
+				{
+					path: "src/demo.txt",
 					edits: [{ old_range: ["zzz", "zzz"], new_lines: ["nope"] }],
 				},
 				undefined,


### PR DESCRIPTION
## Summary

- Clarify `edit_chunk` anchor handling so line numbers are rejected with actionable guidance.
- Update tool prompt/examples to emphasize copying anchors from `read_chunk`.
- Keep `read_chunk` read-only access to ignored dependency paths for dependency-code context.

## Background

- Agents can mistake `read_chunk` line numbers for `edit_chunk` anchors.
- Invalid `old_range` values should fail with clearer errors while anchors copied with a leading `@` remain accepted.