### PR TITLE
Fix pi focus confirmation notifications

### DIFF
--- a/files/pi/agent/extensions/user/features/exit-confirm.ts
+++ b/files/pi/agent/extensions/user/features/exit-confirm.ts
@@ -8,6 +8,7 @@ import {
 import type { EditorTheme, TUI } from "@earendil-works/pi-tui";
 import type { Feature } from "../feature";
 import { FOOTER_NOTICE_DEFAULT_MS, FOOTER_NOTICE_EVENT } from "../lib/status";
+import { notifyUserInputNeeded } from "../lib/tmux-notice";
 import { defaultEditorOptions } from "../lib/ui";
 
 const CONFIRM_WINDOW_MS = FOOTER_NOTICE_DEFAULT_MS;
@@ -85,11 +86,13 @@ const installConfirmExitEditor =
 		ctx.ui.setEditorComponent(
 			(tui, theme, keybindings) =>
 				new ConfirmExitEditor(tui, theme, keybindings, {
-					show: (message) =>
+					show: (message) => {
+						void notifyUserInputNeeded();
 						pi.events.emit(FOOTER_NOTICE_EVENT, {
 							message,
 							durationMs: CONFIRM_WINDOW_MS,
-						}),
+						});
+					},
 					clear: () => pi.events.emit(FOOTER_NOTICE_EVENT, {}),
 				}),
 		);

--- a/files/pi/agent/extensions/user/features/tmux-notice.ts
+++ b/files/pi/agent/extensions/user/features/tmux-notice.ts
@@ -1,22 +1,31 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { Feature } from "../feature";
+import { notifyUserInputNeeded } from "../lib/tmux-notice";
 
-const execFileAsync = promisify(execFile);
-const TMUX_NOTICE = process.env.TMUX_NOTICE ?? "tmux-notice";
-
-async function tmuxNotice(args: readonly string[]): Promise<void> {
-	try {
-		await execFileAsync(TMUX_NOTICE, [...args]);
-	} catch {
-		// Ignore: tmux-notice is best-effort and may be unavailable outside tmux.
-	}
+function isTerminatingFocusResult(result: unknown): boolean {
+	return (
+		typeof result === "object" &&
+		result !== null &&
+		"terminate" in result &&
+		result.terminate === true
+	);
 }
 
 function register(pi: ExtensionAPI): void {
+	let suppressNextAgentEndNotice = false;
+
+	pi.on("tool_execution_end", async (event) => {
+		if (event.toolName !== "enter_focus") return;
+		suppressNextAgentEndNotice = isTerminatingFocusResult(event.result);
+	});
+
 	pi.on("agent_end", async () => {
-		await tmuxNotice(["on", "pi-wait"]);
+		if (suppressNextAgentEndNotice) {
+			suppressNextAgentEndNotice = false;
+			return;
+		}
+
+		await notifyUserInputNeeded();
 	});
 }
 

--- a/files/pi/agent/extensions/user/features/tmux-notice.ts
+++ b/files/pi/agent/extensions/user/features/tmux-notice.ts
@@ -1,21 +1,13 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { Feature } from "../feature";
+import { ENTER_FOCUS_TOOL, isTerminatingFocusResult } from "../lib/focus";
 import { notifyUserInputNeeded } from "../lib/tmux-notice";
-
-function isTerminatingFocusResult(result: unknown): boolean {
-	return (
-		typeof result === "object" &&
-		result !== null &&
-		"terminate" in result &&
-		result.terminate === true
-	);
-}
 
 function register(pi: ExtensionAPI): void {
 	let suppressNextAgentEndNotice = false;
 
 	pi.on("tool_execution_end", async (event) => {
-		if (event.toolName !== "enter_focus") return;
+		if (event.toolName !== ENTER_FOCUS_TOOL) return;
 		suppressNextAgentEndNotice = isTerminatingFocusResult(event.result);
 	});
 

--- a/files/pi/agent/extensions/user/features/turn-metrics.ts
+++ b/files/pi/agent/extensions/user/features/turn-metrics.ts
@@ -3,6 +3,7 @@ import type {
 	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
 import type { Feature } from "../feature";
+import { ENTER_FOCUS_TOOL, isTerminatingFocusResult } from "../lib/focus";
 
 const WIDGET_KEY = "turn-metrics";
 const TICK_MS = 1000;
@@ -19,7 +20,6 @@ const DEFAULT_INDICATOR_FRAMES = [
 	"⠏",
 ] as const;
 const DEFAULT_INDICATOR_INTERVAL_MS = 80;
-const ENTER_FOCUS_TOOL = "enter_focus";
 
 type WorkPhase = "Thinking" | "Working";
 type PhaseColor = "accent" | "warning";
@@ -103,14 +103,6 @@ function formatWorkingMessage(
 		metrics,
 		ctx.ui.theme.fg("dim", ")"),
 	].join("");
-}
-function isTerminatingFocusResult(result: unknown): boolean {
-	return (
-		typeof result === "object" &&
-		result !== null &&
-		"terminate" in result &&
-		result.terminate === true
-	);
 }
 
 function register(pi: ExtensionAPI): void {

--- a/files/pi/agent/extensions/user/features/turn-metrics.ts
+++ b/files/pi/agent/extensions/user/features/turn-metrics.ts
@@ -19,6 +19,7 @@ const DEFAULT_INDICATOR_FRAMES = [
 	"⠏",
 ] as const;
 const DEFAULT_INDICATOR_INTERVAL_MS = 80;
+const ENTER_FOCUS_TOOL = "enter_focus";
 
 type WorkPhase = "Thinking" | "Working";
 type PhaseColor = "accent" | "warning";
@@ -103,6 +104,14 @@ function formatWorkingMessage(
 		ctx.ui.theme.fg("dim", ")"),
 	].join("");
 }
+function isTerminatingFocusResult(result: unknown): boolean {
+	return (
+		typeof result === "object" &&
+		result !== null &&
+		"terminate" in result &&
+		result.terminate === true
+	);
+}
 
 function register(pi: ExtensionAPI): void {
 	let startedAt: number | undefined;
@@ -114,6 +123,7 @@ function register(pi: ExtensionAPI): void {
 	let currentInputTokens = 0;
 	let currentOutputTokens = 0;
 	let toolCalls = 0;
+	let preserveWorkingAfterAgentEnd = false;
 
 	function stopTickTimer(): void {
 		if (!tickTimer) return;
@@ -234,6 +244,10 @@ function register(pi: ExtensionAPI): void {
 		toolCalls++;
 		updateWorkingMessage(ctx);
 	});
+	pi.on("tool_execution_end", async (event) => {
+		if (event.toolName !== ENTER_FOCUS_TOOL) return;
+		preserveWorkingAfterAgentEnd = isTerminatingFocusResult(event.result);
+	});
 
 	pi.on("message_end", async (event, ctx) => {
 		if (event.message.role !== "assistant" || startedAt === undefined) return;
@@ -248,8 +262,13 @@ function register(pi: ExtensionAPI): void {
 		setWidgetLine(ctx, buildLine(ctx, true));
 		startedAt = undefined;
 	});
-
 	pi.on("agent_end", async (_event, ctx) => {
+		if (preserveWorkingAfterAgentEnd) {
+			preserveWorkingAfterAgentEnd = false;
+			updateWorkingMessage(ctx);
+			return;
+		}
+
 		stopTickTimer();
 		startedAt = undefined;
 		clearWorking(ctx);

--- a/files/pi/agent/extensions/user/lib/file/chunk.ts
+++ b/files/pi/agent/extensions/user/lib/file/chunk.ts
@@ -56,13 +56,13 @@ const chunkEditSchema = Type.Object(
 	{
 		old_range: Type.Array(anchorSchema, {
 			description:
-				"Inclusive [start_anchor, end_anchor] range using read_chunk anchors, not line numbers. Copy the 3-character value after @ from read_chunk output (for example, from '12 @abc | text', use 'abc'). Use the same anchor twice for a single-line edit.",
+				"Inclusive whole-line [start_anchor, end_anchor] range using read_chunk anchors, not line numbers. The complete start-anchor line, complete end-anchor line, and every line between them are replaced by new_lines. Copy the 3-character value after @ from read_chunk output (for example, from '12 @abc | text', use 'abc'). Use the same anchor twice to replace one entire line.",
 			minItems: 2,
 			maxItems: 2,
 		}),
 		new_lines: Type.Array(Type.String(), {
 			description:
-				"Replacement lines for the inclusive old_range. Use [] to delete exactly that range. Blank lines are significant; use empty strings for intentional blank lines. Do not include trailing newline characters.",
+				"Exact replacement lines for the inclusive old_range. Nothing inside old_range is preserved unless you copy it into new_lines. To insert before or after a line, replace a nearby existing line and include that original line plus inserted lines here. Use [] to delete exactly old_range. Blank lines are significant; use empty strings for intentional blank lines. Do not include trailing newline characters.",
 		}),
 	},
 	{ additionalProperties: false },

--- a/files/pi/agent/extensions/user/lib/focus/confirmation.ts
+++ b/files/pi/agent/extensions/user/lib/focus/confirmation.ts
@@ -12,15 +12,26 @@ import {
 	decodePrintableInput,
 } from "../ui";
 import { type KeyedPanelItem, renderKeyedPanelItem } from "../ui/keyed-panel";
+import { notifyUserInputNeeded } from "../tmux-notice";
 
-export type FocusConfirmDecision =
+type FocusConfirmChoice =
 	| "allow-once"
 	| "deny-once"
 	| "allow-session"
 	| "deny-session";
 
+export type FocusConfirmDecision = {
+	choice: FocusConfirmChoice;
+	rejectReason?: string;
+};
+
+type FocusConfirmAction =
+	| FocusConfirmChoice
+	| "deny-with-reason"
+	| "reason-input";
+
 type FocusConfirmItem = KeyedPanelItem & {
-	value: FocusConfirmDecision;
+	value: Exclude<FocusConfirmAction, "reason-input">;
 };
 
 export type ExitFocusDecision =
@@ -121,6 +132,12 @@ function focusConfirmItems(): readonly FocusConfirmItem[] {
 			description: "Decline this request only.",
 		},
 		{
+			key: "r",
+			value: "deny-with-reason",
+			label: "Deny with reason",
+			description: "Decline this request and write a reject reason.",
+		},
+		{
 			key: "a",
 			value: "allow-session",
 			label: "Allow this session only",
@@ -158,79 +175,149 @@ function exitFocusItems(): readonly ExitFocusItem[] {
 	];
 }
 
+async function chooseFocusTransitionAction(
+	ctx: ExtensionContext,
+	name: string,
+	reason: string,
+	initialIndex: number,
+): Promise<{ action: FocusConfirmAction; index: number } | undefined> {
+	const items = focusConfirmItems();
+	void notifyUserInputNeeded();
+	return ctx.ui.custom<
+		{ action: FocusConfirmAction; index: number } | undefined
+	>((tui, theme, keybindings, done) => {
+		const border = new DynamicBorder((text) => theme.fg("accent", text));
+		let selectedIndex = Math.min(initialIndex, items.length - 1);
+		const move = (delta: -1 | 1): void => {
+			selectedIndex = (selectedIndex + delta + items.length) % items.length;
+		};
+		const finish = (action: FocusConfirmAction): void => {
+			done({ action, index: selectedIndex });
+		};
+		const select = (item: FocusConfirmItem): void => finish(item.value);
+		return {
+			render(width: number) {
+				const contentWidth = dialogContentWidth(width);
+				return [
+					...border.render(width),
+					padDialogLine(
+						theme.fg("accent", theme.bold(`Enter focus: ${name}`)),
+						width,
+					),
+					...renderReasonLines(theme, reason, width),
+					...items.map((item, index) =>
+						padDialogLine(
+							renderKeyedPanelItem(theme, item, {
+								width: contentWidth,
+								selected: index === selectedIndex,
+								labelWidth: 26,
+							}),
+							width,
+						),
+					),
+					padDialogLine(
+						theme.fg(
+							"dim",
+							"y/n/r/a/d select • ↑↓ navigate • Enter select • Tab write reject reason • Esc cancel",
+						),
+						width,
+					),
+					...border.render(width),
+				];
+			},
+			invalidate: () => border.invalidate(),
+			handleInput(data: string) {
+				if (keybindings.matches(data, "tui.select.up")) {
+					move(-1);
+					tui.requestRender();
+					return;
+				}
+				if (keybindings.matches(data, "tui.select.down")) {
+					move(1);
+					tui.requestRender();
+					return;
+				}
+				if (keybindings.matches(data, "tui.select.confirm")) {
+					select(items[selectedIndex]);
+					return;
+				}
+				if (keybindings.matches(data, "tui.select.cancel")) {
+					done(undefined);
+					return;
+				}
+				if (matchesKey(data, "tab")) {
+					finish("reason-input");
+					return;
+				}
+				const input = decodePrintableInput(data);
+				if (!input) return;
+				const key = input.toLowerCase();
+				const item = items.find((entry) => entry.key === key);
+				if (item) select(item);
+			},
+		};
+	});
+}
+
+async function editEnterRejectReason(
+	ctx: ExtensionContext,
+	name: string,
+	reason: string,
+	initialValue: string | undefined,
+): Promise<string | undefined> {
+	const title = [
+		"Provide Reject Reason",
+		"",
+		`Focus: ${name}`,
+		reason.trim() ? `Enter reason: ${reason.trim()}` : undefined,
+	]
+		.filter((line): line is string => line !== undefined)
+		.join("\n");
+	void notifyUserInputNeeded();
+	return ctx.ui.custom<string | undefined>((tui, _theme, keybindings, done) =>
+		createRefinableExtensionEditorComponent(
+			ctx,
+			tui,
+			keybindings,
+			title,
+			initialValue ?? "",
+			(value) => done(value),
+			() => done(undefined),
+			{},
+			{ notifyLabel: "a reject reason" },
+		),
+	);
+}
+
 export async function confirmFocusTransition(
 	ctx: ExtensionContext,
 	name: string,
 	reason: string,
 ): Promise<FocusConfirmDecision | undefined> {
-	const items = focusConfirmItems();
-	return ctx.ui.custom<FocusConfirmDecision | undefined>(
-		(tui, theme, keybindings, done) => {
-			const border = new DynamicBorder((text) => theme.fg("accent", text));
-			let selectedIndex = 0;
-			const move = (delta: -1 | 1): void => {
-				selectedIndex = (selectedIndex + delta + items.length) % items.length;
-			};
-			const select = (item: FocusConfirmItem): void => done(item.value);
-			return {
-				render(width: number) {
-					const contentWidth = dialogContentWidth(width);
-					return [
-						...border.render(width),
-						padDialogLine(
-							theme.fg("accent", theme.bold(`Enter focus: ${name}`)),
-							width,
-						),
-						...renderReasonLines(theme, reason, width),
-						...items.map((item, index) =>
-							padDialogLine(
-								renderKeyedPanelItem(theme, item, {
-									width: contentWidth,
-									selected: index === selectedIndex,
-									labelWidth: 30,
-								}),
-								width,
-							),
-						),
-						padDialogLine(
-							theme.fg(
-								"dim",
-								"y/n/a/d select • ↑↓ navigate • enter select • esc cancel",
-							),
-							width,
-						),
-						...border.render(width),
-					];
-				},
-				invalidate: () => border.invalidate(),
-				handleInput(data: string) {
-					if (keybindings.matches(data, "tui.select.up")) {
-						move(-1);
-						tui.requestRender();
-						return;
-					}
-					if (keybindings.matches(data, "tui.select.down")) {
-						move(1);
-						tui.requestRender();
-						return;
-					}
-					if (keybindings.matches(data, "tui.select.confirm")) {
-						select(items[selectedIndex]);
-						return;
-					}
-					if (keybindings.matches(data, "tui.select.cancel")) {
-						done(undefined);
-						return;
-					}
-					const input = decodePrintableInput(data);
-					if (!input) return;
-					const key = input.toLowerCase();
-					const item = items.find((entry) => entry.key === key);
-					if (item) select(item);
-				},
-			};
-		},
-	);
+	let selectedIndex = 0;
+	let rejectReason: string | undefined;
+	while (true) {
+		// oxlint-disable-next-line no-await-in-loop -- reason editing may return to the same confirmation.
+		const result = await chooseFocusTransitionAction(
+			ctx,
+			name,
+			reason,
+			selectedIndex,
+		);
+		if (!result) return undefined;
+		selectedIndex = result.index;
+		if (
+			result.action !== "deny-with-reason" &&
+			result.action !== "reason-input"
+		) {
+			return { choice: result.action };
+		}
+		// oxlint-disable-next-line no-await-in-loop -- reason editing is part of the confirmation flow.
+		const input = await editEnterRejectReason(ctx, name, reason, rejectReason);
+		if (input === undefined) continue;
+		rejectReason = input.trim() || undefined;
+		if (rejectReason) return { choice: "deny-once", rejectReason };
+	}
 }
 
 async function editExitRejectReason(
@@ -247,6 +334,7 @@ async function editExitRejectReason(
 	]
 		.filter((line): line is string => line !== undefined)
 		.join("\n");
+	void notifyUserInputNeeded();
 	return ctx.ui.custom<string | undefined>((tui, _theme, keybindings, done) =>
 		createRefinableExtensionEditorComponent(
 			ctx,
@@ -269,6 +357,7 @@ async function chooseExitFocusAction(
 	initialIndex: number,
 ): Promise<{ action: ExitFocusAction; index: number } | undefined> {
 	const items = exitFocusItems();
+	void notifyUserInputNeeded();
 	return ctx.ui.custom<{ action: ExitFocusAction; index: number } | undefined>(
 		(tui, theme, keybindings, done) => {
 			const border = new DynamicBorder((text) => theme.fg("accent", text));
@@ -376,11 +465,11 @@ export function rememberFocusTransitionDecision(
 	name: string,
 	decision: FocusConfirmDecision,
 ): void {
-	if (decision === "allow-session") {
+	if (decision.choice === "allow-session") {
 		sessionDeniedConfirmFocuses.delete(name);
 		sessionAllowedConfirmFocuses.add(name);
 	}
-	if (decision === "deny-session") {
+	if (decision.choice === "deny-session") {
 		sessionAllowedConfirmFocuses.delete(name);
 		sessionDeniedConfirmFocuses.add(name);
 	}

--- a/files/pi/agent/extensions/user/lib/focus/definitions.ts
+++ b/files/pi/agent/extensions/user/lib/focus/definitions.ts
@@ -160,3 +160,12 @@ export function isFocusExitMode(value: unknown): value is FocusExitMode {
 		value === FOCUS_EXIT_MODE.SINGLE_TURN || value === FOCUS_EXIT_MODE.EXPLICIT
 	);
 }
+
+export function isTerminatingFocusResult(result: unknown): boolean {
+	return (
+		typeof result === "object" &&
+		result !== null &&
+		"terminate" in result &&
+		result.terminate === true
+	);
+}

--- a/files/pi/agent/extensions/user/lib/focus/index.ts
+++ b/files/pi/agent/extensions/user/lib/focus/index.ts
@@ -6,6 +6,7 @@ export {
 	type FocusDefinition,
 	type FocusName,
 	type FocusTransition,
+	isTerminatingFocusResult,
 } from "./definitions";
 export {
 	buildFocusRestorePrompt,

--- a/files/pi/agent/extensions/user/lib/focus/tool.ts
+++ b/files/pi/agent/extensions/user/lib/focus/tool.ts
@@ -69,7 +69,15 @@ function renderEnterFocusResult(
 	options: ToolRenderResultOptions,
 	theme: Theme,
 ): Text {
-	const text = options.expanded ? resultText(result) : firstResultLine(result);
+	const rejectReason =
+		typeof result.details.rejectReason === "string"
+			? result.details.rejectReason
+			: undefined;
+	const text = options.expanded
+		? resultText(result)
+		: rejectReason
+			? `${firstResultLine(result)}\nReject reason: ${rejectReason}`
+			: firstResultLine(result);
 	const color = isOkResult(result) ? "success" : "error";
 	return new Text(theme.fg(color, text), 0, 0);
 }
@@ -220,17 +228,28 @@ export function registerEnterFocusTool(
 							definition.name,
 							confirmationReason,
 						);
-						if (!decision || decision.startsWith("deny")) {
+						if (!decision || decision.choice.startsWith("deny")) {
 							if (decision)
 								rememberFocusTransitionDecision(definition.name, decision);
+							const rejectReason = decision?.rejectReason;
+							const text = rejectReason
+								? [
+										`User rejected entering focus '${definition.name}' for this request. Do not request this focus again or route through another focus to request it. Use currently available tools if they can satisfy the request. If not, ask the user how to proceed.`,
+										`Reject reason: ${rejectReason}`,
+									].join("\n\n")
+								: `User rejected entering focus '${definition.name}' for this request. Do not request this focus again or route through another focus to request it. Use currently available tools if they can satisfy the request. If not, ask the user how to proceed.`;
 							return {
 								content: [
 									{
 										type: "text" as const,
-										text: `User rejected entering focus '${definition.name}' for this request. Do not request this focus again or route through another focus to request it. Use currently available tools if they can satisfy the request. If not, ask the user how to proceed.`,
+										text,
 									},
 								],
-								details: { ok: false, reason: "declined" } as FocusToolDetails,
+								details: {
+									ok: false,
+									reason: "declined",
+									...(rejectReason ? { rejectReason } : {}),
+								} as FocusToolDetails,
 							};
 						}
 						rememberFocusTransitionDecision(definition.name, decision);

--- a/files/pi/agent/extensions/user/lib/focus/tool.ts
+++ b/files/pi/agent/extensions/user/lib/focus/tool.ts
@@ -46,6 +46,20 @@ function isOkResult(result: AgentToolResult<FocusToolDetails>): boolean {
 	return result.details.ok !== false;
 }
 
+function resultDisplayText(
+	result: AgentToolResult<FocusToolDetails>,
+	options: ToolRenderResultOptions,
+): string {
+	if (options.expanded) return resultText(result);
+	const rejectReason =
+		typeof result.details.rejectReason === "string"
+			? result.details.rejectReason
+			: undefined;
+	return rejectReason
+		? `${firstResultLine(result)}\nReject reason: ${rejectReason}`
+		: firstResultLine(result);
+}
+
 function getEnterableFocusNames(focus: FocusController): readonly string[] {
 	return focus.registry
 		.list()
@@ -69,15 +83,7 @@ function renderEnterFocusResult(
 	options: ToolRenderResultOptions,
 	theme: Theme,
 ): Text {
-	const rejectReason =
-		typeof result.details.rejectReason === "string"
-			? result.details.rejectReason
-			: undefined;
-	const text = options.expanded
-		? resultText(result)
-		: rejectReason
-			? `${firstResultLine(result)}\nReject reason: ${rejectReason}`
-			: firstResultLine(result);
+	const text = resultDisplayText(result, options);
 	const color = isOkResult(result) ? "success" : "error";
 	return new Text(theme.fg(color, text), 0, 0);
 }
@@ -232,12 +238,10 @@ export function registerEnterFocusTool(
 							if (decision)
 								rememberFocusTransitionDecision(definition.name, decision);
 							const rejectReason = decision?.rejectReason;
+							const baseText = `User rejected entering focus '${definition.name}' for this request. Do not request this focus again or route through another focus to request it. Use currently available tools if they can satisfy the request. If not, ask the user how to proceed.`;
 							const text = rejectReason
-								? [
-										`User rejected entering focus '${definition.name}' for this request. Do not request this focus again or route through another focus to request it. Use currently available tools if they can satisfy the request. If not, ask the user how to proceed.`,
-										`Reject reason: ${rejectReason}`,
-									].join("\n\n")
-								: `User rejected entering focus '${definition.name}' for this request. Do not request this focus again or route through another focus to request it. Use currently available tools if they can satisfy the request. If not, ask the user how to proceed.`;
+								? `${baseText}\n\nReject reason: ${rejectReason}`
+								: baseText;
 							return {
 								content: [
 									{
@@ -296,15 +300,7 @@ function renderExitFocusResult(
 	options: ToolRenderResultOptions,
 	theme: Theme,
 ): Text {
-	const rejectReason =
-		typeof result.details.rejectReason === "string"
-			? result.details.rejectReason
-			: undefined;
-	const text = options.expanded
-		? resultText(result)
-		: rejectReason
-			? `${firstResultLine(result)}\nReject reason: ${rejectReason}`
-			: firstResultLine(result);
+	const text = resultDisplayText(result, options);
 	const color = isOkResult(result) ? "muted" : "error";
 	return new Text(theme.fg(color, text), 0, 0);
 }

--- a/files/pi/agent/extensions/user/lib/tmux-notice.ts
+++ b/files/pi/agent/extensions/user/lib/tmux-notice.ts
@@ -1,0 +1,17 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const TMUX_NOTICE = process.env.TMUX_NOTICE ?? "tmux-notice";
+
+export async function tmuxNotice(args: readonly string[]): Promise<void> {
+	try {
+		await execFileAsync(TMUX_NOTICE, [...args]);
+	} catch {
+		// Ignore: tmux-notice is best-effort and may be unavailable outside tmux.
+	}
+}
+
+export async function notifyUserInputNeeded(): Promise<void> {
+	await tmuxNotice(["on", "pi-wait"]);
+}

--- a/files/pi/agent/extensions/user/lib/tool/builtin.ts
+++ b/files/pi/agent/extensions/user/lib/tool/builtin.ts
@@ -75,11 +75,12 @@ function registerFileTools(catalog: ToolCatalog): void {
 				name: "edit_chunk",
 				label: "edit_chunk",
 				description:
-					"Edit a file by replacing anchor-delimited line chunks produced by read_chunk. Whitespace and blank lines are part of the edit: choose old_range and new_lines so the file has correct spacing after this single edit, without requiring a follow-up cleanup edit. Fails without modifying files when anchors are missing, ambiguous, reversed, or overlapping.",
+					"Edit a file by replacing anchor-delimited whole-line ranges produced by read_chunk. Each old_range endpoint is included: the complete start-anchor line, complete end-anchor line, and every line between them are replaced by new_lines. Anchors are not insertion points; to insert before or after a line, replace an adjacent line and include that original line plus the inserted lines in new_lines. Whitespace and blank lines are part of the edit: choose old_range and new_lines so the file has correct spacing after this single edit, without requiring a follow-up cleanup edit. Fails without modifying files when anchors are missing, ambiguous, reversed, or overlapping.",
 				promptSnippet: "Replace line chunks using anchors from read_chunk",
 				promptGuidelines: [
-					"Use anchors copied from read_chunk; use the same anchor twice for a single-line edit.",
-					"old_range is inclusive, and new_lines is its exact replacement. For deletions, use []; include only the lines intended for removal in old_range.",
+					"Use anchors copied from read_chunk; use the same anchor twice to replace that one entire line.",
+					"old_range is an inclusive whole-line range, and new_lines is its exact replacement. Nothing inside old_range is preserved unless you copy it into new_lines. For deletions, use []; include only the lines intended for removal in old_range.",
+					"To insert new lines, replace a nearby existing line and include that original line plus the inserted lines in new_lines.",
 					"Use only visible unique anchors. If needed anchors are hidden as @--- or stale, run read_chunk again on a smaller relevant area.",
 				],
 				parameters: editChunkSchema,

--- a/files/pi/agent/extensions/user/lib/tool/interview.ts
+++ b/files/pi/agent/extensions/user/lib/tool/interview.ts
@@ -13,6 +13,7 @@ import {
 } from "@earendil-works/pi-tui";
 import { type Static, Type } from "typebox";
 import type { ToolPolicy } from "../policy";
+import { notifyUserInputNeeded } from "../tmux-notice";
 import {
 	createRefinableExtensionEditorComponent,
 	decodePrintableInput,
@@ -462,6 +463,7 @@ async function showQuestion(
 		options.otherText,
 		options.otherSelected ?? Boolean(options.otherText),
 	);
+	void notifyUserInputNeeded();
 	const action = await ctx.ui.custom<QuestionResult>(
 		(tui, theme, keybindings, done) => {
 			const border = new DynamicBorder((value) => theme.fg("accent", value));
@@ -562,6 +564,7 @@ async function showOtherInput(
 	]
 		.filter((line): line is string => line !== undefined)
 		.join("\n");
+	void notifyUserInputNeeded();
 	return ctx.ui.custom<string | undefined>((tui, _theme, keybindings, done) =>
 		createRefinableExtensionEditorComponent(
 			ctx,

--- a/tests/pi/agent/extensions/user/lib/focus/confirmation.test.ts
+++ b/tests/pi/agent/extensions/user/lib/focus/confirmation.test.ts
@@ -82,11 +82,11 @@ describe("focus confirmation", () => {
 		assert.equal(isFocusAllowedForSession("edit"), false);
 		assert.equal(isFocusDeniedForSession("edit"), false);
 
-		rememberFocusTransitionDecision("edit", "allow-session");
+		rememberFocusTransitionDecision("edit", { choice: "allow-session" });
 		assert.equal(isFocusAllowedForSession("edit"), true);
 		assert.equal(isFocusDeniedForSession("edit"), false);
 
-		rememberFocusTransitionDecision("edit", "deny-session");
+		rememberFocusTransitionDecision("edit", { choice: "deny-session" });
 		assert.equal(isFocusAllowedForSession("edit"), false);
 		assert.equal(isFocusDeniedForSession("edit"), true);
 
@@ -96,13 +96,13 @@ describe("focus confirmation", () => {
 	});
 
 	it("selects enter-focus decisions from printable shortcuts and cancel keys", async () => {
-		assert.equal(
+		assert.deepEqual(
 			await confirmFocusTransition(
 				context({ inputs: ["a"] }),
 				"edit",
 				"Need changes",
 			),
-			"allow-session",
+			{ choice: "allow-session" },
 		);
 		assert.equal(
 			await confirmFocusTransition(
@@ -157,7 +157,7 @@ describe("focus confirmation", () => {
 		]);
 
 		const enterLines: Array<readonly string[]> = [];
-		assert.equal(
+		assert.deepEqual(
 			await confirmFocusTransition(
 				context({
 					inputs: ["a"],
@@ -167,7 +167,7 @@ describe("focus confirmation", () => {
 				"edit",
 				"need focused edits before running checks",
 			),
-			"allow-session",
+			{ choice: "allow-session" },
 		);
 		assert.deepEqual(enterLines[0]?.slice(2, 4), [
 			" Reason: need focused edits     ",

--- a/tests/pi/agent/extensions/user/lib/focus/tool.test.ts
+++ b/tests/pi/agent/extensions/user/lib/focus/tool.test.ts
@@ -207,7 +207,7 @@ describe("focus management tools", () => {
 			undefined,
 			context(false),
 		);
-		rememberFocusTransitionDecision("edit", "allow-session");
+		rememberFocusTransitionDecision("edit", { choice: "allow-session" });
 		const allowed = await tool.execute(
 			"call",
 			{ name: "edit" },


### PR DESCRIPTION
Fixes focus confirmation behavior around tmux notifications, enter-focus rejection reasons, and edit_chunk guidance.

Notes:
- Suppresses tmux wait notifications immediately after terminating enter_focus.
- Preserves custom working/thinking status through enter_focus transitions.
- Notifies when interactive user input is requested.
- Supports reject reasons when denying enter_focus.