### PR TITLE
feat(claude): show usage limits and trim status line

### DIFF
--- a/files/claude/statusline.sh
+++ b/files/claude/statusline.sh
@@ -85,7 +85,6 @@ fi
 
 if [[ "$TOTAL_USED" != "0" ]]; then
 	USED_FMT=$(format_tokens "$TOTAL_USED")
-	SIZE_FMT=$(format_tokens "$CONTEXT_SIZE")
 	# Color based on remaining context percentage
 	if awk -v r="$REMAINING" 'BEGIN { exit !(r >= 50) }'; then
 		CTX_COLOR="$GREEN"
@@ -94,7 +93,7 @@ if [[ "$TOTAL_USED" != "0" ]]; then
 	else
 		CTX_COLOR="$RED"
 	fi
-	OUTPUT+=" ${CTX_COLOR}${USED_FMT}/${SIZE_FMT} (${REMAINING}%)${RESET}"
+	OUTPUT+=" ${CTX_COLOR}${USED_FMT} (${REMAINING}%)${RESET}"
 fi
 
 FIVE_SEG=$(usage_seg "$FIVE_HOUR_USED" "5h ")

--- a/files/claude/statusline.sh
+++ b/files/claude/statusline.sh
@@ -59,9 +59,6 @@ REMAINING=$(awk -v used="$TOTAL_USED" -v size="$CONTEXT_SIZE" 'BEGIN { printf "%
 INPUT_K=$(format_k "$TOTAL_INPUT_TOKENS")
 OUTPUT_K=$(format_k "$TOTAL_OUTPUT_TOKENS")
 
-LINES_ADDED=$(echo "$input" | jq -r '.cost.total_lines_added // 0')
-LINES_REMOVED=$(echo "$input" | jq -r '.cost.total_lines_removed // 0')
-
 # Usage limits (Pro/Max subscribers only, after the first API response)
 FIVE_HOUR_USED=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
 SEVEN_DAY_USED=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
@@ -98,10 +95,6 @@ if [[ "$TOTAL_USED" != "0" ]]; then
 		CTX_COLOR="$RED"
 	fi
 	OUTPUT+=" ${CTX_COLOR}${USED_FMT}/${SIZE_FMT} (${REMAINING}%)${RESET}"
-fi
-
-if [[ "$LINES_ADDED" != "0" || "$LINES_REMOVED" != "0" ]]; then
-	OUTPUT+=" ${DIM}|${RESET} ${GREEN}+${LINES_ADDED}${RESET} ${RED}-${LINES_REMOVED}${RESET}"
 fi
 
 FIVE_SEG=$(usage_seg "$FIVE_HOUR_USED" "5h ")

--- a/files/claude/statusline.sh
+++ b/files/claude/statusline.sh
@@ -23,6 +23,22 @@ format_tokens() {
   }'
 }
 
+# Render a usage-limit segment as "<label><remaining>%", colored by remaining.
+# Prints nothing when the percentage is absent (non-subscribers / pre-first-call).
+usage_seg() {
+	local used="$1" label="$2" remain color
+	[[ -z "$used" ]] && return
+	remain=$(awk -v u="$used" 'BEGIN { printf "%.0f", 100 - u }')
+	if awk -v r="$remain" 'BEGIN { exit !(r >= 50) }'; then
+		color="$GREEN"
+	elif awk -v r="$remain" 'BEGIN { exit !(r >= 20) }'; then
+		color="$YELLOW"
+	else
+		color="$RED"
+	fi
+	printf '%b' "${DIM}${label}${RESET}${color}${remain}%${RESET}"
+}
+
 MODEL=$(echo "$input" | jq -r '.model.display_name // "Unknown"')
 EFFORT=$(echo "$input" | jq -r '.effort.level // empty')
 CWD=$(echo "$input" | jq -r '.workspace.current_dir // "."')
@@ -45,6 +61,10 @@ OUTPUT_K=$(format_k "$TOTAL_OUTPUT_TOKENS")
 
 LINES_ADDED=$(echo "$input" | jq -r '.cost.total_lines_added // 0')
 LINES_REMOVED=$(echo "$input" | jq -r '.cost.total_lines_removed // 0')
+
+# Usage limits (Pro/Max subscribers only, after the first API response)
+FIVE_HOUR_USED=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
+SEVEN_DAY_USED=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
 
 # Git branch
 GIT_BRANCH=""
@@ -82,6 +102,14 @@ fi
 
 if [[ "$LINES_ADDED" != "0" || "$LINES_REMOVED" != "0" ]]; then
 	OUTPUT+=" ${DIM}|${RESET} ${GREEN}+${LINES_ADDED}${RESET} ${RED}-${LINES_REMOVED}${RESET}"
+fi
+
+FIVE_SEG=$(usage_seg "$FIVE_HOUR_USED" "5h ")
+SEVEN_SEG=$(usage_seg "$SEVEN_DAY_USED" "7d ")
+if [[ -n "$FIVE_SEG" || -n "$SEVEN_SEG" ]]; then
+	OUTPUT+=" ${DIM}|${RESET}"
+	[[ -n "$FIVE_SEG" ]] && OUTPUT+=" ${FIVE_SEG}"
+	[[ -n "$SEVEN_SEG" ]] && OUTPUT+=" ${SEVEN_SEG}"
 fi
 
 echo -e "$OUTPUT"


### PR DESCRIPTION

## Summary

Refocus the Claude Code status line on usage limits and drop info that I rarely look at.

- **Add** 5-hour / 7-day usage-limit **remaining** percentages (`5h <n>% 7d <n>%`), mirroring `/usage`.
- **Drop** the lines added/removed segment (`+12 -3`).
- **Drop** the context window size denominator: `48K/1M (95.2%)` → `48K (95.2%)`.

## Details

- Reads `rate_limits.five_hour.used_percentage` / `rate_limits.seven_day.used_percentage` from the status line JSON.
- New `usage_seg` helper computes remaining (`100 - used`) and color-codes it with the existing thresholds (>=50 green / >=20 yellow / <20 red).
- Fields are read with `// empty`, so the segment is omitted entirely when absent — `rate_limits` only appears for Pro/Max subscribers after the first API response, and each window can be independently missing.
