### PR TITLE
feat(claude): show usage limit reset time when remaining < 50%

### DIFF
--- a/files/claude/statusline.sh
+++ b/files/claude/statusline.sh
@@ -3,7 +3,6 @@ input=$(cat)
 
 # Colors
 DIM='\033[2m'
-FAINT='\033[2;90m'
 GREEN='\033[32m'
 YELLOW='\033[33m'
 RED='\033[31m'
@@ -23,10 +22,18 @@ format_tokens() {
   }'
 }
 
+# Format a Unix epoch (seconds) as local HH:MM. Tries BSD date (macOS) first,
+# then GNU date (Linux). Prints nothing if neither understands the input.
+fmt_reset() {
+	date -r "$1" +%H:%M 2>/dev/null || date -d "@$1" +%H:%M 2>/dev/null
+}
+
 # Render a usage-limit segment as "<label><remaining>%", colored by remaining.
+# When not green (remaining < 50%) and a reset epoch is given, append "→HH:MM"
+# so the recovery time is visible exactly when the limit starts to matter.
 # Prints nothing when the percentage is absent (non-subscribers / pre-first-call).
 usage_seg() {
-	local used="$1" label="$2" remain color
+	local used="$1" label="$2" reset="$3" remain color seg at
 	[[ -z "$used" ]] && return
 	remain=$(awk -v u="$used" 'BEGIN { printf "%.0f", 100 - u }')
 	if awk -v r="$remain" 'BEGIN { exit !(r >= 50) }'; then
@@ -36,7 +43,12 @@ usage_seg() {
 	else
 		color="$RED"
 	fi
-	printf '%b' "${DIM}${label}${RESET}${color}${remain}%${RESET}"
+	seg="${DIM}${label}${RESET}${color}${remain}%${RESET}"
+	if [[ "$color" != "$GREEN" && -n "$reset" ]]; then
+		at=$(fmt_reset "$reset")
+		[[ -n "$at" ]] && seg+=" ${color}${at}${RESET}"
+	fi
+	printf '%b' "$seg"
 }
 
 MODEL=$(echo "$input" | jq -r '.model.display_name // "Unknown"')
@@ -62,6 +74,8 @@ OUTPUT_K=$(format_k "$TOTAL_OUTPUT_TOKENS")
 # Usage limits (Pro/Max subscribers only, after the first API response)
 FIVE_HOUR_USED=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
 SEVEN_DAY_USED=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+FIVE_HOUR_RESET=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
+SEVEN_DAY_RESET=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
 
 # Git branch
 GIT_BRANCH=""
@@ -96,8 +110,8 @@ if [[ "$TOTAL_USED" != "0" ]]; then
 	OUTPUT+=" ${CTX_COLOR}${USED_FMT} (${REMAINING}%)${RESET}"
 fi
 
-FIVE_SEG=$(usage_seg "$FIVE_HOUR_USED" "5h ")
-SEVEN_SEG=$(usage_seg "$SEVEN_DAY_USED" "7d ")
+FIVE_SEG=$(usage_seg "$FIVE_HOUR_USED" "5h " "$FIVE_HOUR_RESET")
+SEVEN_SEG=$(usage_seg "$SEVEN_DAY_USED" "7d " "$SEVEN_DAY_RESET")
 if [[ -n "$FIVE_SEG" || -n "$SEVEN_SEG" ]]; then
 	OUTPUT+=" ${DIM}|${RESET}"
 	[[ -n "$FIVE_SEG" ]] && OUTPUT+=" ${FIVE_SEG}"


### PR DESCRIPTION
## Summary

When a usage limit (5-hour or 7-day) drops below 50%, append the reset time (`→HH:MM`) so the recovery time is visible exactly when it starts to matter.

- **Add** `resets_at` field parsing for both usage windows.
- **Add** `fmt_reset()` helper that converts a Unix epoch to local `HH:MM`, with cross-platform `date` handling (BSD/macOS and GNU/Linux).
- **Update** `usage_seg` to accept an optional reset epoch and append `→HH:MM` when the remaining percentage is < 50% (non-green state).
- **Remove** unused `FAINT` color constant.

## Background

- The reset time is only shown when the segment is already non-green (remaining < 50%) — green status doesn't need recovery info.
- Both `resets_at` fields are read with `// empty`, so they're safely omitted for non-subscribers / pre-first-call.
- `fmt_reset` tries `date -r` (BSD) first, falls back to `date -d @` (GNU), and prints nothing if neither works.