### PR TITLE
feat(pi): include file-wide fingerprint in read_chunk anchors

### DIFF
--- a/files/pi/agent/extensions/user/lib/file/chunk.ts
+++ b/files/pi/agent/extensions/user/lib/file/chunk.ts
@@ -146,10 +146,11 @@ function lineAnchorInput(
 	lines: readonly string[],
 	index: number,
 	radius: number,
+	fileFingerprint: string,
 ): string {
 	const start = Math.max(0, index - radius);
 	const end = Math.min(lines.length, index + radius + 1);
-	const parts = [`radius:${radius}`];
+	const parts = [`radius:${radius}`, `file:${fileFingerprint}`];
 	for (let lineIndex = start; lineIndex < end; lineIndex += 1) {
 		if (lineIndex === index) parts.push("current-line");
 		parts.push(lines[lineIndex] ?? "");
@@ -161,13 +162,14 @@ function anchorForLine(
 	lines: readonly string[],
 	index: number,
 	radius: number,
+	fileFingerprint: string,
 ): string {
 	const alphabet =
 		"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 	const space = alphabet.length ** ANCHOR_LENGTH;
 	let value =
 		createHash("sha256")
-			.update(lineAnchorInput(lines, index, radius))
+			.update(lineAnchorInput(lines, index, radius, fileFingerprint))
 			.digest()
 			.readUInt32BE(0) % space;
 	let anchor = "";
@@ -179,6 +181,12 @@ function anchorForLine(
 }
 
 function buildAnchorIndex(lines: readonly string[]): AnchorIndex {
+	// File-wide fingerprint so any edit changes all anchors, forcing re-read_chunk
+	const fileFingerprint = createHash("sha256")
+		.update(lines.join("\n"))
+		.digest("hex")
+		.slice(0, 8);
+
 	const perLine = Array<string | undefined>(lines.length).fill(undefined);
 	const unique = new Map<string, number>();
 	const usedAnchors = new Set<string>();
@@ -189,7 +197,7 @@ function buildAnchorIndex(lines: readonly string[]): AnchorIndex {
 		const candidates = new Map<number, string>();
 		const counts = new Map<string, number>();
 		for (const index of unresolved) {
-			const anchor = anchorForLine(lines, index, radius);
+			const anchor = anchorForLine(lines, index, radius, fileFingerprint);
 			candidates.set(index, anchor);
 			counts.set(anchor, (counts.get(anchor) ?? 0) + 1);
 		}

--- a/tests/pi/agent/extensions/user/lib/file/chunk.test.ts
+++ b/tests/pi/agent/extensions/user/lib/file/chunk.test.ts
@@ -251,6 +251,60 @@ describe("chunk file tools", () => {
 		assert.equal(readFileSync(join(root, "src", "demo.txt"), "utf8"), original);
 	});
 
+	it("changes all anchors after editing a distant line", async () => {
+		const root = tempRepo();
+		// 40 lines so lines 1 and 40 are far apart (> MAX_CONTEXT_RADIUS)
+		writeFileSync(
+			join(root, "src", "distant.txt"),
+			[
+				...Array.from({ length: 40 }, (_, index) => `line ${index + 1}`),
+				"",
+			].join("\n"),
+		);
+
+		// Read anchors before edit
+		const readBefore = await executeReadChunk(
+			root,
+			{ path: "src/distant.txt" },
+			undefined,
+		);
+		const anchorsBefore = anchorsByLine(resultText(readBefore));
+		assert.equal(anchorsBefore.length, 40);
+
+		const line1AnchorBefore = anchorsBefore[0];
+		const line40AnchorBefore = anchorsBefore[39];
+		// Sanity: line 1 and line 40 should have different anchors
+		assert.notEqual(line1AnchorBefore, line40AnchorBefore);
+
+		// Edit line 1 (far away from line 40 — distance 39 > MAX_CONTEXT_RADIUS)
+		await executeEditChunk(
+			root,
+			{
+				path: "src/distant.txt",
+				edits: [
+					{
+						old_range: [line1AnchorBefore, line1AnchorBefore],
+						new_lines: ["line 1 modified"],
+					},
+				],
+			},
+			undefined,
+		);
+
+		// Read anchors after edit
+		const readAfter = await executeReadChunk(
+			root,
+			{ path: "src/distant.txt" },
+			undefined,
+		);
+		const anchorsAfter = anchorsByLine(resultText(readAfter));
+		assert.equal(anchorsAfter.length, 40);
+
+		// Line 40's anchor must have changed despite being far from line 1,
+		// because the file-wide fingerprint changed
+		assert.notEqual(anchorsAfter[39], line40AnchorBefore);
+	});
+
 	it("hides ambiguous anchors and rejects unsafe paths", async () => {
 		const root = tempRepo();
 		writeFileSync(


### PR DESCRIPTION
## Summary

Include a SHA-256 fingerprint of the entire file content in `read_chunk` anchor hash input. Now any change to the file — no matter how far from a given line — invalidates all anchors, forcing a fresh `read_chunk` before the next `edit_chunk`.

## Background

Previously, `read_chunk` anchors were computed from only a local sliding window (radius 1–16) of lines. Editing a line far away from another line left the distant line's anchor unchanged, allowing stale anchors to be reused accidentally — risking edits targeting the wrong line after an intervening edit.