### PR TITLE
fix(pi): truncate subagent prompt in focus confirmation dialog to 10 lines

### DIFF
--- a/files/pi/agent/extensions/user/lib/focus/confirmation.ts
+++ b/files/pi/agent/extensions/user/lib/focus/confirmation.ts
@@ -139,9 +139,21 @@ function renderSubagentPromptLines(
 	prompt: string,
 	width: number,
 ): string[] {
-	return wrapPrefixedText("Prompt: ", prompt, dialogContentWidth(width)).map(
-		(line) => padDialogLine(theme.fg("dim", line), width),
+	const maxLines = 10;
+	const contentWidth = dialogContentWidth(width);
+	const lines = wrapPrefixedText("Prompt: ", prompt, contentWidth);
+	const truncated = lines.length > maxLines;
+	const shown = truncated ? lines.slice(0, maxLines) : lines;
+	const result = shown.map((line) =>
+		padDialogLine(theme.fg("dim", line), width),
 	);
+	if (truncated) {
+		const remaining = lines.length - maxLines;
+		result.push(
+			padDialogLine(theme.fg("dim", `… (${remaining} more lines)`), width),
+		);
+	}
+	return result;
 }
 
 function focusConfirmItems(): readonly FocusConfirmItem[] {


### PR DESCRIPTION
## Summary

Limit the subagent prompt displayed in focus confirmation dialogs to 10 lines. Long prompts were causing the dialog to exceed terminal height, resulting in UI flickering.

When truncated, `… (X more lines)` is appended to indicate remaining content.

## Background

When the model delegates a task to a subagent via the `subagent` tool, the full task instruction is passed as the `prompt` parameter. This prompt can be very long (often containing the entire user request). The focus confirmation dialog rendered every wrapped line of this prompt, which could easily overwhelm the terminal height and cause visible flickering during rendering.

The fix caps the displayed prompt at 10 wrapped lines, which is enough to give the user a meaningful preview of the task while keeping the dialog within terminal bounds.