### PR TITLE
Improve subagent running render details

### DIFF
--- a/files/pi/agent/extensions/user/lib/tool/subagent.ts
+++ b/files/pi/agent/extensions/user/lib/tool/subagent.ts
@@ -99,8 +99,11 @@ export type SubagentDetails = {
 	readonly toolCallCount: number;
 	readonly durationMs: number;
 	readonly stderr?: string;
+	readonly toolCalls?: readonly ToolCallRecord[];
 	/** @internal */
 	readonly _status?: string;
+	/** @internal */
+	readonly _runningLine?: string;
 	/** @internal */
 	readonly currentTool?: string;
 	/** Original prompt that was passed to the subagent. */
@@ -110,7 +113,6 @@ export type SubagentDetails = {
 	/** Focus the subagent runs in. */
 	readonly focus?: string;
 };
-
 type SubagentResult = AgentToolResult<SubagentDetails>;
 /** A result flagged as an error (the `isError` flag is an extension of the base shape). */
 type SubagentErrorResult = SubagentResult & { isError: true };
@@ -161,12 +163,23 @@ function renderSubagentResult(
 	theme: Theme,
 ): Component {
 	if (options.isPartial) {
-		// Content already includes state line at bottom (from onUpdate)
 		const text = result.content
 			.filter((c) => c.type === "text")
 			.map((c) => c.text)
 			.join("\n");
-		return new Text(text, 0, 0);
+		if (!options.expanded) return new Text(text, 0, 0);
+
+		const promptText = result.details?.prompt?.trim();
+		const toolCalls = result.details?.toolCalls ?? [];
+		const toolText = formatToolCallRecords(toolCalls);
+		const runningLine = result.details?.["_runningLine"];
+		const statusText = runningLine ?? text.trim();
+		const runningParts = [
+			promptText ? `${theme.fg("dim", "prompt:")}\n${promptText}` : undefined,
+			toolText ? `${theme.fg("dim", "tools:")}\n${toolText}` : undefined,
+			statusText,
+		].filter((part): part is string => part !== undefined && part.length > 0);
+		return new Text(runningParts.join("\n\n"), 0, 0);
 	}
 
 	const isAborted = result.details?.["_status"] === "aborted";
@@ -205,18 +218,62 @@ function renderSubagentResult(
 	const promptText = result.details?.prompt?.trim();
 	const stateDisplay = getStateDisplay(result.details, theme);
 	const expandedText = isAborted
-		? `${stateDisplay} ${theme.fg("dim", stats)}`
-		: `${theme.fg("dim", "prompt:")}\n${promptText ?? ""}\n\n${theme.fg("dim", "response:")}\n${contentText}\n\n${stateDisplay} ${theme.fg("dim", stats)}`;
+		? `${promptText ? `${theme.fg("dim", "prompt:")}\n${promptText}\n\n` : ""}${stateDisplay} ${theme.fg("dim", stats)}`
+		: [
+				promptText ? `${theme.fg("dim", "prompt:")}\n${promptText}` : undefined,
+				`${theme.fg("dim", "response:")}\n${contentText}`,
+				`${stateDisplay} ${theme.fg("dim", stats)}`,
+			]
+				.filter((part): part is string => part !== undefined)
+				.join("\n\n");
 	return new Text(expandedText, 0, 0);
 }
 
 /** Format a single tool-call argument value for display. */
 function formatArg(v: unknown): string {
 	if (typeof v === "string") {
-		return v.length > 50 ? `"${v.slice(0, 50)}…"` : `"${v}"`;
+		return v.length > 80 ? `"${v.slice(0, 80)}…"` : `"${v}"`;
 	}
-	if (Array.isArray(v)) return `[${v.join(", ")}]`;
-	return String(v);
+	if (typeof v === "number" || typeof v === "boolean" || v == null) {
+		return String(v);
+	}
+	try {
+		const json = JSON.stringify(v);
+		if (!json) return String(v);
+		return json.length > 120 ? `${json.slice(0, 120)}…` : json;
+	} catch {
+		return Object.prototype.toString.call(v);
+	}
+}
+function formatToolCallRecords(toolCalls: readonly ToolCallRecord[]): string {
+	return toolCalls
+		.map((_, index) => formatToolCallRecord(toolCalls, index))
+		.join("\n");
+}
+
+function formatToolCallRecord(
+	toolCalls: readonly ToolCallRecord[],
+	index: number,
+): string {
+	const minDurationMs = 1000;
+	const tc = toolCalls[index];
+	const next = toolCalls[index + 1];
+	const duration = next ? next.startTime - tc.startTime : undefined;
+	const p = Object.entries(tc.args)
+		.filter(([, v]) => v !== undefined)
+		.map(([k, v]) => `${k}=${formatArg(v)}`)
+		.join(", ");
+	const argsStr = p ? ` (${p})` : "";
+	const durationStr =
+		duration !== undefined && duration >= minDurationMs
+			? `  ${(duration / 1000).toFixed(1)}s`
+			: "";
+	const runningMarker =
+		index === toolCalls.length - 1 ? `  ${fg(colors.muted, "← running")}` : "";
+	return fg(
+		colors.muted,
+		`${String(index + 1).padStart(2)}. ${tc.name}${argsStr}${durationStr}${runningMarker}`,
+	);
 }
 
 /** Resolve the pi CLI entry point so RpcClient can spawn a child process. */
@@ -253,6 +310,7 @@ class SubagentProgress {
 		private readonly startedAt: number,
 		private readonly title: string | undefined,
 		private readonly focus: string,
+		private readonly prompt: string,
 		private readonly onUpdate:
 			| AgentToolUpdateCallback<SubagentDetails>
 			| undefined,
@@ -273,23 +331,35 @@ class SubagentProgress {
 	/** Record a `tool_execution_start` event and refresh the live display. */
 	recordToolStart(toolName: string, args: Record<string, unknown>): void {
 		this.toolCalls.push({ name: toolName, args, startTime: Date.now() });
-		this.lastTail = this.buildTail();
+		this.lastTail = this.buildTail(false);
 		if (this.onUpdate) {
+			const runningLine = this.runningLine();
 			this.onUpdate({
 				content: [
-					{ type: "text", text: `${this.lastTail}\n${this.runningLine()}` },
+					{
+						type: "text",
+						text: `${this.lastTail}\n${runningLine}`,
+					},
 				],
 				details: {
 					_status: "running",
+					_runningLine: runningLine,
 					currentTool: toolName,
 					toolCallCount: this.count,
+					toolCalls: this.toolCalls,
 					durationMs: this.elapsedMs(),
 					title: this.title,
 					focus: this.focus,
+					prompt: this.prompt,
 				},
 			});
 		}
 		this.restartRunningTimer();
+	}
+
+	/** Snapshot the observed tool calls for terminal rendering. */
+	snapshot(): readonly ToolCallRecord[] {
+		return [...this.toolCalls];
 	}
 
 	/** Stop the heartbeat timer (idempotent). */
@@ -352,19 +422,23 @@ class SubagentProgress {
 	}
 
 	private emitStarting(): void {
+		const runningLine = `${fg(colors.positive, this.runningIcon)} ${this.glossyRunningLabel}  ${this.elapsedLabel()}s`;
 		this.onUpdate?.({
 			content: [
 				{
 					type: "text",
-					text: `${fg(colors.muted, "(starting...)")}\n${fg(colors.positive, this.runningIcon)} ${this.glossyRunningLabel}  ${this.elapsedLabel()}s`,
+					text: `${fg(colors.muted, "(starting...)")}\n${runningLine}`,
 				},
 			],
 			details: {
 				_status: "starting",
+				_runningLine: runningLine,
 				toolCallCount: 0,
+				toolCalls: this.toolCalls,
 				durationMs: this.elapsedMs(),
 				title: this.title,
 				focus: this.focus,
+				prompt: this.prompt,
 			},
 		});
 	}
@@ -373,41 +447,35 @@ class SubagentProgress {
 		clearInterval(this.timer);
 		if (!this.onUpdate) return;
 		this.timer = setInterval(() => {
+			const runningLine = this.runningLine();
 			this.onUpdate?.({
 				content: [
-					{ type: "text", text: `${this.lastTail}\n${this.runningLine()}` },
+					{
+						type: "text",
+						text: `${this.lastTail}\n${runningLine}`,
+					},
 				],
 				details: {
 					_status: "running",
+					_runningLine: runningLine,
 					toolCallCount: this.count,
+					toolCalls: this.toolCalls,
 					durationMs: this.elapsedMs(),
 					title: this.title,
 					focus: this.focus,
+					prompt: this.prompt,
 				},
 			});
 		}, 120);
 	}
 
-	/**
-	 * Per-tool own run time: the time until the next tool started. The running
-	 * (latest) tool has no successor yet, so it has no duration. This is always a
-	 * single tool's elapsed time, never a cumulative total across tools.
-	 */
-	private ownDurationMs(index: number): number | undefined {
-		const lastIndex = this.toolCalls.length - 1;
-		if (index >= lastIndex) return undefined;
-		return (
-			this.toolCalls[index + 1].startTime - this.toolCalls[index].startTime
-		);
+	private promptBlock(): string {
+		return `${fg(colors.muted, "prompt:")}\n${this.prompt.trim()}`;
 	}
 
-	/** Build the rolling tail: latest 3 tools shown, older ones summarized. */
-	private buildTail(): string {
-		const maxVisible = 3;
-		// Durations shorter than this are too quick to be meaningful (e.g. they
-		// would render as 0.0s), so the tool is still shown but its seconds are
-		// omitted.
-		const minDurationMs = 1000;
+	/** Build the tool list. Collapsed views show the latest 3; expanded views show all. */
+	private buildTail(expanded: boolean): string {
+		const maxVisible = expanded ? this.toolCalls.length : 3;
 		const lines: string[] = [];
 		const lastIndex = this.toolCalls.length - 1;
 		const firstVisible = Math.max(0, this.toolCalls.length - maxVisible);
@@ -423,26 +491,7 @@ class SubagentProgress {
 		}
 
 		for (let index = firstVisible; index <= lastIndex; index++) {
-			const tc = this.toolCalls[index];
-			const duration = this.ownDurationMs(index);
-			const p = Object.entries(tc.args)
-				.filter(([, v]) => v !== undefined)
-				.map(([k, v]) => `${k}=${formatArg(v)}`)
-				.join(", ");
-			const argsStr = p ? ` (${p})` : "";
-			// Show the tool regardless; only hide the seconds when too short.
-			const durationStr =
-				duration !== undefined && duration >= minDurationMs
-					? `  ${(duration / 1000).toFixed(1)}s`
-					: "";
-			const runningMarker =
-				index === lastIndex ? `  ${fg(colors.muted, "← running")}` : "";
-			lines.push(
-				fg(
-					colors.muted,
-					`${String(index + 1).padStart(2)}. ${tc.name}${argsStr}${durationStr}${runningMarker}`,
-				),
-			);
+			lines.push(formatToolCallRecord(this.toolCalls, index));
 		}
 		return lines.join("\n");
 	}
@@ -598,7 +647,13 @@ const createSubagentExecute =
 		const { focus, prompt, title } = input;
 		const header = `${truncateTitle(title ?? focus)} (focus=${focus})`;
 		const startedAt = Date.now();
-		const progress = new SubagentProgress(startedAt, title, focus, onUpdate);
+		const progress = new SubagentProgress(
+			startedAt,
+			title,
+			focus,
+			prompt,
+			onUpdate,
+		);
 
 		const client = new RpcClient({
 			cliPath,
@@ -621,6 +676,7 @@ const createSubagentExecute =
 				prompt,
 				title,
 				focus,
+				toolCalls: progress.snapshot(),
 				_status: "aborted",
 			};
 			onUpdate?.({
@@ -652,6 +708,7 @@ const createSubagentExecute =
 				prompt,
 				title,
 				focus,
+				toolCalls: progress.snapshot(),
 				usage: buildUsage(stats),
 			},
 		});
@@ -667,7 +724,11 @@ const createSubagentExecute =
 					_status: "error",
 					stderr: stderr || undefined,
 					toolCallCount: progress.count,
+					toolCalls: progress.snapshot(),
 					durationMs,
+					prompt,
+					title,
+					focus,
 				},
 			});
 			return {
@@ -680,6 +741,7 @@ const createSubagentExecute =
 					prompt,
 					title,
 					focus,
+					toolCalls: progress.snapshot(),
 					stderr: stderr || undefined,
 				},
 				isError: true,

--- a/tests/pi/agent/extensions/user/lib/tool/subagent.test.ts
+++ b/tests/pi/agent/extensions/user/lib/tool/subagent.test.ts
@@ -1,5 +1,9 @@
 import assert from "node:assert/strict";
-import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import type {
+	AgentToolResult,
+	Theme,
+	ToolDefinition,
+} from "@earendil-works/pi-coding-agent";
 import { describe, it } from "vitest";
 import {
 	type FocusDefinition,
@@ -11,6 +15,27 @@ import {
 	registerSubagentTool,
 } from "#pi-user/lib/tool/subagent";
 
+const plainTheme = {
+	fg: (_name: string, text: string) => text,
+	bold: (text: string) => text,
+} as Theme;
+
+function renderText(component: { render(width: number): string[] }): string {
+	return component
+		.render(200)
+		.map((line) => line.replace(/[ \t]+$/u, ""))
+		.join("\n");
+}
+
+function getSubagentDefinition(): ToolDefinition {
+	const catalog = createToolCatalog();
+	registerSubagentTool(catalog);
+	const subagent = catalog
+		.list()
+		.find((t) => t.definition.name === SUBAGENT_TOOL);
+	assert.ok(subagent);
+	return subagent.definition as ToolDefinition;
+}
 function makeFocus(overrides: Partial<FocusDefinition>): FocusDefinition {
 	return {
 		name: "x",
@@ -151,6 +176,135 @@ describe("subagent tool registration", () => {
 			hasNestingWarning,
 			"guidelines should warn about single-level nesting",
 		);
+	});
+	it("renders collapsed running updates without prompt and with latest tool tail", () => {
+		const definition = getSubagentDefinition();
+		assert.ok(definition.renderResult);
+
+		const result = {
+			content: [
+				{
+					type: "text" as const,
+					text: [
+						"── (other 2 tools...) ──",
+						' 3. grep (pattern={"raw":"TODO"})',
+						' 4. read_chunk (path="src/b.ts")',
+						' 5. lint (options={"fix":false})  ← running',
+						"◉ Running  1.2s (5 tools used)",
+					].join("\n"),
+				},
+			],
+			details: {
+				_status: "running",
+				_runningLine: "◉ Running  1.2s (5 tools used)",
+				toolCallCount: 5,
+				durationMs: 1200,
+				prompt: "Investigate the failing tests",
+				toolCalls: [
+					{ name: "read_chunk", args: { path: "src/a.ts" }, startTime: 0 },
+					{ name: "find", args: { pattern: "*.ts" }, startTime: 500 },
+					{
+						name: "grep",
+						args: { pattern: { raw: "TODO" } },
+						startTime: 1000,
+					},
+					{ name: "read_chunk", args: { path: "src/b.ts" }, startTime: 1500 },
+					{ name: "lint", args: { options: { fix: false } }, startTime: 2000 },
+				],
+			},
+		} satisfies AgentToolResult<Record<string, unknown>>;
+
+		const output = renderText(
+			definition.renderResult(
+				result,
+				{ expanded: false, isPartial: true },
+				plainTheme,
+			) as { render(width: number): string[] },
+		);
+
+		assert.doesNotMatch(output, /prompt:/u);
+		assert.doesNotMatch(output, /Investigate the failing tests/u);
+		assert.doesNotMatch(output, /1\. read_chunk/u);
+		assert.doesNotMatch(output, /2\. find/u);
+		assert.match(output, /other 2 tools/u);
+		assert.match(output, /3\. grep/u);
+		assert.match(output, /5\. lint/u);
+		assert.match(output, /options=\{"fix":false\}/u);
+		assert.doesNotMatch(output, /\[object Object\]/u);
+	});
+
+	it("renders expanded running updates with prompt and all tools", () => {
+		const definition = getSubagentDefinition();
+		assert.ok(definition.renderResult);
+
+		const result = {
+			content: [{ type: "text" as const, text: "latest tail only" }],
+			details: {
+				_status: "running",
+				_runningLine: "◉ Running  1.2s (5 tools used)",
+				toolCallCount: 5,
+				durationMs: 1200,
+				prompt: "Investigate the failing tests",
+				toolCalls: [
+					{ name: "read_chunk", args: { path: "src/a.ts" }, startTime: 0 },
+					{ name: "find", args: { pattern: "*.ts" }, startTime: 500 },
+					{
+						name: "grep",
+						args: { pattern: { raw: "TODO" } },
+						startTime: 1000,
+					},
+					{ name: "read_chunk", args: { path: "src/b.ts" }, startTime: 1500 },
+					{ name: "lint", args: { options: { fix: false } }, startTime: 2000 },
+				],
+			},
+		} satisfies AgentToolResult<Record<string, unknown>>;
+
+		const output = renderText(
+			definition.renderResult(
+				result,
+				{ expanded: true, isPartial: true },
+				plainTheme,
+			) as { render(width: number): string[] },
+		);
+
+		assert.match(output, /prompt:\s*\nInvestigate the failing tests/u);
+		assert.match(output, /tools:\s*\n[\s\S]*1\. read_chunk/u);
+		assert.match(output, /2\. find/u);
+		assert.match(output, /5\. lint/u);
+		assert.match(output, /pattern=\{"raw":"TODO"\}/u);
+		assert.match(output, /◉ Running\s+1\.2s/u);
+		assert.doesNotMatch(output, /\[object Object\]/u);
+	});
+
+	it("omits tool history from completed expanded output", () => {
+		const definition = getSubagentDefinition();
+		assert.ok(definition.renderResult);
+
+		const result = {
+			content: [{ type: "text" as const, text: "Done with the task" }],
+			details: {
+				toolCallCount: 1,
+				durationMs: 2500,
+				prompt: "Summarize the repository",
+				toolCalls: [
+					{ name: "read_chunk", args: { path: "README.md" }, startTime: 0 },
+				],
+			},
+		} satisfies AgentToolResult<Record<string, unknown>>;
+
+		const output = renderText(
+			definition.renderResult(
+				result,
+				{ expanded: true, isPartial: false },
+				plainTheme,
+			) as { render(width: number): string[] },
+		);
+
+		assert.match(output, /prompt:\s*\nSummarize the repository/u);
+		assert.match(output, /response:\s*\nDone with the task/u);
+		assert.match(output, /Completed/u);
+		assert.doesNotMatch(output, /tools:/u);
+		assert.doesNotMatch(output, /read_chunk/u);
 	});
 
 	it("registers an isErrorResult hook", () => {

--- a/tests/pi/agent/extensions/user/lib/tool/subagent.test.ts
+++ b/tests/pi/agent/extensions/user/lib/tool/subagent.test.ts
@@ -27,6 +27,14 @@ function renderText(component: { render(width: number): string[] }): string {
 		.join("\n");
 }
 
+function renderResultContext(): Parameters<
+	NonNullable<ToolDefinition["renderResult"]>
+>[3] {
+	return { state: {}, invalidate: () => undefined } as Parameters<
+		NonNullable<ToolDefinition["renderResult"]>
+	>[3];
+}
+
 function getSubagentDefinition(): ToolDefinition {
 	const catalog = createToolCatalog();
 	registerSubagentTool(catalog);
@@ -219,6 +227,7 @@ describe("subagent tool registration", () => {
 				result,
 				{ expanded: false, isPartial: true },
 				plainTheme,
+				renderResultContext(),
 			) as { render(width: number): string[] },
 		);
 
@@ -264,6 +273,7 @@ describe("subagent tool registration", () => {
 				result,
 				{ expanded: true, isPartial: true },
 				plainTheme,
+				renderResultContext(),
 			) as { render(width: number): string[] },
 		);
 
@@ -297,6 +307,7 @@ describe("subagent tool registration", () => {
 				result,
 				{ expanded: true, isPartial: false },
 				plainTheme,
+				renderResultContext(),
 			) as { render(width: number): string[] },
 		);
 


### PR DESCRIPTION
## Summary

- Improve expanded rendering for in-progress subagent results so it includes the original prompt, full tool-call history, and current running status.
- Preserve compact collapsed rendering by keeping only the existing live tail/status text.
- Reuse tool-call formatting for both live updates and expanded output, including JSON formatting for object/array arguments.

## Background

When a subagent is still running, the collapsed view should stay concise, but the expanded view needs enough context to inspect what the subagent was asked to do and which tools it has used. This PR records that progress metadata in subagent updates/results and adds tests for the running and completed render behavior.