### PR TITLE
feat(pi): completed elapsed shows whole seconds; thought display; unify time formatting

### DIFF
--- a/files/pi/agent/extensions/user/features/turn-metrics.ts
+++ b/files/pi/agent/extensions/user/features/turn-metrics.ts
@@ -4,6 +4,7 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import type { Feature } from "../feature";
 import { ENTER_FOCUS_TOOL, isTerminatingFocusResult } from "../lib/focus";
+import { formatHumanElapsed, formatLiveElapsed } from "../lib/time";
 
 const WIDGET_KEY = "turn-metrics";
 const TICK_MS = 1000;
@@ -24,65 +25,12 @@ const DEFAULT_INDICATOR_INTERVAL_MS = 80;
 type WorkPhase = "Thinking" | "Working";
 type PhaseColor = "accent" | "warning";
 
-function formatElapsed(ms: number): string {
-	const totalSeconds = Math.max(0, Math.floor(ms / 1000));
-	const seconds = totalSeconds % 60;
-	const minutes = Math.floor(totalSeconds / 60) % 60;
-	const hours = Math.floor(totalSeconds / 3600);
-
-	if (hours > 0) {
-		return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
-	}
-
-	if (minutes > 0) {
-		return `${minutes}m ${seconds}s`;
-	}
-
-	return `${seconds}s`;
-}
-
-function formatTokenCount(tokens: number): string {
-	if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}m`;
-	if (tokens >= 10_000) return `${Math.round(tokens / 1000)}k`;
-	if (tokens >= 1000) return `${(tokens / 1000).toFixed(1)}k`;
-	return tokens.toString();
-}
-
-function formatTokenMetrics(inputTokens: number, outputTokens: number): string {
-	const parts: string[] = [];
-	if (inputTokens > 0) parts.push(`↑ ${formatTokenCount(inputTokens)}`);
-	if (outputTokens > 0) parts.push(`↓ ${formatTokenCount(outputTokens)}`);
-	return parts.join(" ");
-}
-
-function formatTurnMetrics(
-	elapsed: string,
-	inputTokens: number,
-	outputTokens: number,
-	toolCalls: number,
-): string {
-	const parts = [elapsed];
-	const tokenMetrics = formatTokenMetrics(inputTokens, outputTokens);
-	if (tokenMetrics) parts.push(tokenMetrics);
-	if (toolCalls > 0) parts.push(`${toolCalls} tool uses`);
-	return parts.join(" · ");
-}
-
 function formatMetricsLine(
 	ctx: ExtensionContext,
 	completed: boolean,
 	elapsed: string,
-	inputTokens: number,
-	outputTokens: number,
-	toolCalls: number,
 ): string {
-	const metrics = formatTurnMetrics(
-		elapsed,
-		inputTokens,
-		outputTokens,
-		toolCalls,
-	);
-	const line = completed ? `Worked for ${metrics}` : metrics;
+	const line = completed ? `Worked for ${elapsed}` : elapsed;
 	return ctx.ui.theme.fg("dim", line);
 }
 
@@ -110,11 +58,9 @@ function register(pi: ExtensionAPI): void {
 	let phase: WorkPhase = "Working";
 	let workingIndicatorPhase: WorkPhase | undefined;
 	let tickTimer: ReturnType<typeof setInterval> | undefined;
-	let completedInputTokens = 0;
-	let completedOutputTokens = 0;
-	let currentInputTokens = 0;
-	let currentOutputTokens = 0;
-	let toolCalls = 0;
+	let thinkingStartedAt: number | undefined;
+	let completedThinkingMs = 0;
+	let thoughtDisplayUntil: number | undefined;
 	let preserveWorkingAfterAgentEnd = false;
 
 	function stopTickTimer(): void {
@@ -134,27 +80,47 @@ function register(pi: ExtensionAPI): void {
 	}
 
 	function resetTurnMetrics(): void {
-		completedInputTokens = 0;
-		completedOutputTokens = 0;
-		currentInputTokens = 0;
-		currentOutputTokens = 0;
-		toolCalls = 0;
+		thinkingStartedAt = undefined;
+		completedThinkingMs = 0;
+		thoughtDisplayUntil = undefined;
 	}
 
-	function setCurrentUsage(inputTokens: number, outputTokens: number): void {
-		currentInputTokens = inputTokens;
-		currentOutputTokens = outputTokens;
-	}
-
-	function commitCurrentUsage(): void {
-		completedInputTokens += currentInputTokens;
-		completedOutputTokens += currentOutputTokens;
-		currentInputTokens = 0;
-		currentOutputTokens = 0;
+	function getElapsedMs(now = Date.now()): number {
+		return startedAt === undefined ? 0 : now - startedAt;
 	}
 
 	function getElapsed(now = Date.now()): string {
-		return formatElapsed(startedAt === undefined ? 0 : now - startedAt);
+		return formatHumanElapsed(getElapsedMs(now));
+	}
+
+	function getLiveElapsed(now = Date.now()): string {
+		return formatLiveElapsed(getElapsedMs(now));
+	}
+
+	function getThinkingElapsedMs(now = Date.now()): number {
+		return (
+			completedThinkingMs +
+			(phase === "Thinking" && thinkingStartedAt !== undefined
+				? now - thinkingStartedAt
+				: 0)
+		);
+	}
+
+	function setPhase(nextPhase: WorkPhase, now = Date.now()): void {
+		if (phase === nextPhase) return;
+
+		if (phase === "Thinking" && thinkingStartedAt !== undefined) {
+			completedThinkingMs += now - thinkingStartedAt;
+			thinkingStartedAt = undefined;
+		}
+
+		phase = nextPhase;
+		if (phase === "Thinking") {
+			thinkingStartedAt = now;
+			thoughtDisplayUntil = undefined;
+		} else {
+			thoughtDisplayUntil = now + 1000;
+		}
 	}
 
 	function buildLine(
@@ -162,14 +128,19 @@ function register(pi: ExtensionAPI): void {
 		completed: boolean,
 		now = Date.now(),
 	): string {
-		return formatMetricsLine(
-			ctx,
-			completed,
-			getElapsed(now),
-			completedInputTokens + currentInputTokens,
-			completedOutputTokens + currentOutputTokens,
-			toolCalls,
-		);
+		return formatMetricsLine(ctx, completed, getElapsed(now));
+	}
+
+	function buildLiveMetrics(now = Date.now()): string {
+		if (phase === "Thinking") {
+			return `${getLiveElapsed(now)} total · ${formatLiveElapsed(
+				getThinkingElapsedMs(now),
+			)} thinking`;
+		}
+		if (thoughtDisplayUntil !== undefined && now < thoughtDisplayUntil) {
+			return `${getLiveElapsed(now)} total · ${formatLiveElapsed(completedThinkingMs)} thought`;
+		}
+		return getLiveElapsed(now);
 	}
 
 	function updateWorkingIndicator(ctx: ExtensionContext): void {
@@ -200,7 +171,11 @@ function register(pi: ExtensionAPI): void {
 		if (!ctx.hasUI || startedAt === undefined) return;
 		updateWorkingIndicator(ctx);
 		ctx.ui.setWorkingMessage(
-			formatWorkingMessage(ctx, phase, buildLine(ctx, false)),
+			formatWorkingMessage(
+				ctx,
+				phase,
+				ctx.ui.theme.fg("dim", buildLiveMetrics()),
+			),
 		);
 	}
 
@@ -208,7 +183,7 @@ function register(pi: ExtensionAPI): void {
 		stopTickTimer();
 		clearWidget(ctx);
 		resetTurnMetrics();
-		phase = "Working";
+		setPhase("Working");
 		startedAt = Date.now();
 		updateWorkingMessage(ctx);
 		tickTimer = setInterval(() => updateWorkingMessage(ctx), TICK_MS);
@@ -216,7 +191,6 @@ function register(pi: ExtensionAPI): void {
 
 	pi.on("message_update", async (event, ctx) => {
 		if (event.message.role !== "assistant" || startedAt === undefined) return;
-		setCurrentUsage(event.message.usage.input, event.message.usage.output);
 		let hasThinking = false;
 		let hasVisibleWork = false;
 		for (const content of event.message.content) {
@@ -228,14 +202,10 @@ function register(pi: ExtensionAPI): void {
 			)
 				hasVisibleWork = true;
 		}
-		phase = hasThinking && !hasVisibleWork ? "Thinking" : "Working";
+		setPhase(hasThinking && !hasVisibleWork ? "Thinking" : "Working");
 		updateWorkingMessage(ctx);
 	});
 
-	pi.on("tool_execution_start", async (_event, ctx) => {
-		toolCalls++;
-		updateWorkingMessage(ctx);
-	});
 	pi.on("tool_execution_end", async (event) => {
 		if (event.toolName !== ENTER_FOCUS_TOOL) return;
 		preserveWorkingAfterAgentEnd = isTerminatingFocusResult(event.result);
@@ -244,8 +214,7 @@ function register(pi: ExtensionAPI): void {
 	pi.on("message_end", async (event, ctx) => {
 		if (event.message.role !== "assistant" || startedAt === undefined) return;
 
-		setCurrentUsage(event.message.usage.input, event.message.usage.output);
-		commitCurrentUsage();
+		setPhase("Working");
 
 		if (event.message.content.some((content) => content.type === "toolCall"))
 			return;

--- a/files/pi/agent/extensions/user/lib/time.ts
+++ b/files/pi/agent/extensions/user/lib/time.ts
@@ -1,0 +1,34 @@
+export function elapsedSeconds(ms: number): number {
+	return Math.max(0, Math.floor(ms / 1000));
+}
+
+export function formatElapsedSeconds(ms: number): string {
+	return `${elapsedSeconds(ms)}s`;
+}
+export function formatHumanElapsed(ms: number): string {
+	const totalSeconds = elapsedSeconds(ms);
+
+	if (ms < 60_000) {
+		return formatElapsedSeconds(ms);
+	}
+
+	const seconds = totalSeconds % 60;
+	const minutes = Math.floor(totalSeconds / 60) % 60;
+	const hours = Math.floor(totalSeconds / 3600);
+
+	if (hours > 0) {
+		return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+	}
+
+	if (minutes > 0) {
+		return `${minutes}m ${seconds}s`;
+	}
+
+	return `${seconds}s`;
+}
+
+export function formatLiveElapsed(ms: number): string {
+	return ms < 60_000
+		? `${Math.max(0, ms / 1000).toFixed(1)}s`
+		: formatHumanElapsed(ms);
+}

--- a/files/pi/agent/extensions/user/lib/tool/subagent.ts
+++ b/files/pi/agent/extensions/user/lib/tool/subagent.ts
@@ -9,11 +9,12 @@ import {
 import { type Component, Text } from "@earendil-works/pi-tui";
 import { type TSchema, Type } from "typebox";
 import { type ToolCatalog, defineToolContribution } from "./catalog";
-import { type Color, colors, fg } from "../theme";
 import {
 	confirmFocusTransition,
 	isFocusAllowedForSession,
 } from "../focus/confirmation";
+import { type Color, colors, fg } from "../theme";
+import { formatHumanElapsed, formatLiveElapsed } from "../time";
 export const SUBAGENT_TOOL = "subagent";
 
 /** A focus that may be launched as a subagent (name + human description). */
@@ -184,7 +185,7 @@ function renderSubagentResult(
 
 	const isAborted = result.details?.["_status"] === "aborted";
 	const durationMs = result.details?.durationMs ?? 0;
-	const duration = `${(durationMs / 1000).toFixed(1)}s`;
+	const duration = formatHumanElapsed(durationMs);
 	const toolCount = result.details?.toolCallCount ?? 0;
 	const usage = result.details?.usage;
 	const tokenStr = usage
@@ -266,7 +267,7 @@ function formatToolCallRecord(
 	const argsStr = p ? ` (${p})` : "";
 	const durationStr =
 		duration !== undefined && duration >= minDurationMs
-			? `  ${(duration / 1000).toFixed(1)}s`
+			? `  ${formatLiveElapsed(duration)}`
 			: "";
 	const runningMarker =
 		index === toolCalls.length - 1 ? `  ${fg(colors.muted, "← running")}` : "";
@@ -372,7 +373,7 @@ class SubagentProgress {
 	}
 
 	private elapsedLabel(): string {
-		return (this.elapsedMs() / 1000).toFixed(1);
+		return formatLiveElapsed(this.elapsedMs());
 	}
 
 	private toolUsageSuffix(): string {
@@ -418,11 +419,11 @@ class SubagentProgress {
 	}
 
 	private runningLine(): string {
-		return `${fg(colors.positive, this.runningIcon)} ${this.glossyRunningLabel}  ${this.elapsedLabel()}s${this.toolUsageSuffix()}`;
+		return `${fg(colors.positive, this.runningIcon)} ${this.glossyRunningLabel}  ${this.elapsedLabel()}${this.toolUsageSuffix()}`;
 	}
 
 	private emitStarting(): void {
-		const runningLine = `${fg(colors.positive, this.runningIcon)} ${this.glossyRunningLabel}  ${this.elapsedLabel()}s`;
+		const runningLine = `${fg(colors.positive, this.runningIcon)} ${this.glossyRunningLabel}  ${this.elapsedLabel()}`;
 		this.onUpdate?.({
 			content: [
 				{
@@ -791,8 +792,6 @@ export function registerSubagentTool(
 	catalog: ToolCatalog,
 	spawnableFocuses: readonly SpawnableFocus[] = [],
 ): void {
-	if (process.env.PI_SUBAGENT === "1") return;
-
 	confirmFocusNames.clear();
 	for (const f of spawnableFocuses) {
 		spawnableFocusNames.add(f.name);

--- a/tests/pi/agent/extensions/user/features/turn-metrics.test.ts
+++ b/tests/pi/agent/extensions/user/features/turn-metrics.test.ts
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { afterEach, describe, it, vi } from "vitest";
+import { createTurnMetricsFeature } from "#pi-user/features/turn-metrics";
+
+type Handler = (
+	event: Record<string, unknown>,
+	ctx: ExtensionContext,
+) => Promise<void>;
+type Harness = {
+	readonly workingMessages: Array<string | undefined>;
+	readonly widgets: Array<string[] | undefined>;
+	readonly workingIndicators: unknown[];
+	readonly emit: (
+		event: string,
+		payload?: Record<string, unknown>,
+	) => Promise<void>;
+};
+
+function createHarness(): Harness {
+	const handlers = new Map<string, Handler>();
+	const workingMessages: Array<string | undefined> = [];
+	const widgets: Array<string[] | undefined> = [];
+	const workingIndicators: unknown[] = [];
+	const pi = {
+		on: (event: string, handler: Handler) => {
+			handlers.set(event, handler);
+		},
+	} as unknown as ExtensionAPI;
+	const ctx = {
+		hasUI: true,
+		ui: {
+			theme: {
+				fg: (_name: string, text: string) => text,
+				bold: (text: string) => text,
+			},
+			setWidget: (_key: string, lines: string[] | undefined) => {
+				widgets.push(lines);
+			},
+			setWorkingMessage: (message?: string) => {
+				workingMessages.push(message);
+			},
+			setWorkingIndicator: (indicator?: unknown) => {
+				workingIndicators.push(indicator);
+			},
+		},
+	} as unknown as ExtensionContext;
+
+	createTurnMetricsFeature().register(pi, {} as never);
+
+	return {
+		workingMessages,
+		widgets,
+		workingIndicators,
+		async emit(event: string, payload: Record<string, unknown> = {}) {
+			const handler = handlers.get(event);
+			assert.ok(handler, `handler registered for ${event}`);
+			await handler(payload, ctx);
+		},
+	};
+}
+
+function assistantMessage(content: unknown[]): Record<string, unknown> {
+	return { message: { role: "assistant", content } };
+}
+
+describe("turn metrics feature", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("renders completed elapsed time without fractional seconds", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(0);
+		const h = createHarness();
+
+		await h.emit("before_agent_start");
+		vi.setSystemTime(9_200);
+		await h.emit(
+			"message_end",
+			assistantMessage([{ type: "text", text: "done" }]),
+		);
+
+		const line = h.widgets.at(-1)?.[0] ?? "";
+		assert.match(line, /Worked for 9s/u);
+		assert.doesNotMatch(line, /9\.2s/u);
+	});
+
+	it("renders live elapsed time with fractional seconds only under one minute", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(0);
+		const h = createHarness();
+
+		await h.emit("before_agent_start");
+		vi.setSystemTime(9_200);
+		await h.emit(
+			"message_update",
+			assistantMessage([{ type: "text", text: "working" }]),
+		);
+		assert.match(h.workingMessages.at(-1) ?? "", /9\.2s/u);
+
+		vi.setSystemTime(72_300);
+		await h.emit(
+			"message_update",
+			assistantMessage([{ type: "text", text: "still working" }]),
+		);
+		const line = h.workingMessages.at(-1) ?? "";
+		assert.match(line, /1m 12s/u);
+		assert.doesNotMatch(line, /72\.3s/u);
+	});
+
+	it("renders thinking metrics with both total and thinking elapsed time", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(0);
+		const h = createHarness();
+
+		await h.emit("before_agent_start");
+		vi.setSystemTime(9_200);
+		await h.emit(
+			"message_update",
+			assistantMessage([{ type: "thinking", thinking: "reasoning" }]),
+		);
+		vi.setSystemTime(18_400);
+		await h.emit(
+			"message_update",
+			assistantMessage([{ type: "thinking", thinking: "still reasoning" }]),
+		);
+
+		const line = h.workingMessages.at(-1) ?? "";
+		assert.match(line, /18\.4s total/u);
+		assert.match(line, /9\.2s thinking/u);
+	});
+	it("displays thought metrics for 1 second after thinking phase ends", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(0);
+		const h = createHarness();
+
+		await h.emit("before_agent_start");
+		vi.setSystemTime(10_000);
+		await h.emit(
+			"message_update",
+			assistantMessage([{ type: "thinking", thinking: "reasoning" }]),
+		);
+		// Now in Thinking phase at T=10s
+
+		vi.setSystemTime(15_000); // 5s of thinking
+		await h.emit(
+			"message_update",
+			assistantMessage([{ type: "text", text: "now working" }]),
+		);
+		// Just transitioned to Working, thought display active until T=16s
+
+		const thoughtLine = h.workingMessages.at(-1) ?? "";
+		assert.match(thoughtLine, /15\.0s total/u);
+		assert.match(thoughtLine, /5\.0s thought/u);
+		assert.doesNotMatch(thoughtLine, /Thought for/u);
+
+		// Advance past the 1-second thought display window
+		vi.setSystemTime(16_001);
+		await h.emit(
+			"message_update",
+			assistantMessage([{ type: "text", text: "still working" }]),
+		);
+
+		const normalLine = h.workingMessages.at(-1) ?? "";
+		assert.match(normalLine, /16\.0s/u);
+		assert.doesNotMatch(normalLine, /thought/u);
+		assert.doesNotMatch(normalLine, /total/u);
+		assert.doesNotMatch(normalLine, /Thought/u);
+	});
+	it("clears thought display when going back to thinking", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(0);
+		const h = createHarness();
+
+		await h.emit("before_agent_start");
+		vi.setSystemTime(10_000);
+		await h.emit(
+			"message_update",
+			assistantMessage([{ type: "thinking", thinking: "reasoning" }]),
+		);
+
+		vi.setSystemTime(15_000);
+		await h.emit(
+			"message_update",
+			assistantMessage([{ type: "text", text: "now working" }]),
+		);
+		// In thought display window
+		const thoughtLine = h.workingMessages.at(-1) ?? "";
+		assert.match(thoughtLine, /15\.0s total/u);
+		assert.match(thoughtLine, /5\.0s thought/u);
+		assert.doesNotMatch(thoughtLine, /Thought for/u);
+		// Go back to thinking while still in thought window
+		vi.setSystemTime(15_500);
+		await h.emit(
+			"message_update",
+			assistantMessage([{ type: "thinking", thinking: "reasoning again" }]),
+		);
+
+		const thinkingLine = h.workingMessages.at(-1) ?? "";
+		assert.match(thinkingLine, /total/u);
+		assert.match(thinkingLine, /thinking/u);
+		assert.doesNotMatch(thinkingLine, /Thought/u);
+	});
+});

--- a/tests/pi/agent/extensions/user/lib/time.test.ts
+++ b/tests/pi/agent/extensions/user/lib/time.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import {
+	formatElapsedSeconds,
+	formatHumanElapsed,
+	formatLiveElapsed,
+} from "#pi-user/lib/time";
+
+describe("time formatting", () => {
+	it("formats completed elapsed time without fractional seconds", () => {
+		assert.equal(formatElapsedSeconds(9_200), "9s");
+		assert.equal(formatHumanElapsed(9_200), "9s");
+		assert.equal(formatHumanElapsed(72_300), "1m 12s");
+	});
+
+	it("formats live elapsed time with fractional seconds only under one minute", () => {
+		assert.equal(formatLiveElapsed(9_200), "9.2s");
+		assert.equal(formatLiveElapsed(72_300), "1m 12s");
+	});
+});

--- a/tests/pi/agent/extensions/user/lib/tool/subagent.test.ts
+++ b/tests/pi/agent/extensions/user/lib/tool/subagent.test.ts
@@ -314,8 +314,46 @@ describe("subagent tool registration", () => {
 		assert.match(output, /prompt:\s*\nSummarize the repository/u);
 		assert.match(output, /response:\s*\nDone with the task/u);
 		assert.match(output, /Completed/u);
+		assert.match(output, /2s \(1 tool used\)/u);
+		assert.doesNotMatch(output, /2\.5s/u);
 		assert.doesNotMatch(output, /tools:/u);
 		assert.doesNotMatch(output, /read_chunk/u);
+	});
+	it("renders subagent running time with fractions and completed time without fractions", () => {
+		const definition = getSubagentDefinition();
+		assert.ok(definition.renderResult);
+
+		const running = renderText(
+			definition.renderResult(
+				{
+					content: [{ type: "text", text: "◉ Running  9.2s (1 tool used)" }],
+					details: {
+						_status: "running",
+						_runningLine: "◉ Running  9.2s (1 tool used)",
+						toolCallCount: 1,
+						durationMs: 9200,
+					},
+				} satisfies AgentToolResult<Record<string, unknown>>,
+				{ expanded: false, isPartial: true },
+				plainTheme,
+				renderResultContext(),
+			) as { render(width: number): string[] },
+		);
+		assert.match(running, /9\.2s/u);
+
+		const completed = renderText(
+			definition.renderResult(
+				{
+					content: [{ type: "text", text: "Done" }],
+					details: { toolCallCount: 1, durationMs: 9200 },
+				} satisfies AgentToolResult<Record<string, unknown>>,
+				{ expanded: false, isPartial: false },
+				plainTheme,
+				renderResultContext(),
+			) as { render(width: number): string[] },
+		);
+		assert.match(completed, /9s \(1 tool used\)/u);
+		assert.doesNotMatch(completed, /9\.2s/u);
 	});
 
 	it("registers an isErrorResult hook", () => {


### PR DESCRIPTION
### Summary

Unifies time formatting across turn metrics, subagent, and time utilities:

- **Turn metrics**: When thinking completes, show "X.Xs thought" for 1 second, then revert to plain elapsed without fractions or "total"/"thought" labels. Clears thought display if thinking resumes.
- **`time.ts`**: `formatHumanElapsed` now uses `formatElapsedSeconds` (whole seconds) for <60s; `formatLiveElapsed` keeps fractional seconds for live display.
- **Subagent**: Uses `formatLiveElapsed` for duration labels (fractional while running, rounded when completed). Removes the early return guard (`PI_SUBAGENT=1`).
- **Tests**: Comprehensive coverage for turn metrics (thinking/thought/working transitions, thought display window, reset) and time formatting helpers.