### PR TITLE
Add target line ranges to apply_patch replaces

### DIFF
--- a/files/pi/agent/extensions/user/lib/file/apply-patch.ts
+++ b/files/pi/agent/extensions/user/lib/file/apply-patch.ts
@@ -93,18 +93,6 @@ export const applyPatchSchema = Type.Object({
 			},
 		),
 	),
-	replaceLineRanges: Type.Optional(
-		Type.Array(
-			Type.Object({
-				startLineNo: lineNoSchema,
-				endLineNo: lineNoSchema,
-				contentLines: Type.Array(Type.String()),
-			}),
-			{
-				description: "Replace inclusive 1-based line ranges with contentLines.",
-			},
-		),
-	),
 });
 
 export type ApplyPatchToolInput = Static<typeof applyPatchSchema>;
@@ -118,8 +106,7 @@ function operationCount(params: ApplyPatchToolInput): number {
 	return (
 		(params.replaces?.length ?? 0) +
 		(params.removeLineRanges?.length ?? 0) +
-		(params.insertLines?.length ?? 0) +
-		(params.replaceLineRanges?.length ?? 0)
+		(params.insertLines?.length ?? 0)
 	);
 }
 
@@ -309,22 +296,6 @@ function createEdits(text: string, params: ApplyPatchToolInput): TextEdit[] {
 		edits.push({ ...chars, replacement: "", label: `removeLineRanges[${i}]` });
 	}
 
-	for (const [i, range] of (params.replaceLineRanges ?? []).entries()) {
-		assertLineRange(
-			index,
-			range.startLineNo,
-			range.endLineNo,
-			`replaceLineRanges[${i}]`,
-		);
-		collectLineRangeUsage(usedLines, range.startLineNo, range.endLineNo);
-		const chars = lineRangeToChars(index, range.startLineNo, range.endLineNo);
-		edits.push({
-			...chars,
-			replacement: lineText(range.contentLines),
-			label: `replaceLineRanges[${i}]`,
-		});
-	}
-
 	for (const [i, insert] of (params.insertLines ?? []).entries()) {
 		const hasAfter = insert.insertAfterLineNo !== undefined;
 		const hasBefore = insert.insertBeforeLineNo !== undefined;
@@ -453,12 +424,7 @@ function renderApplyPatchParams(args: unknown, theme: Theme): string[] {
 	if (typeof input.path === "string") {
 		lines.push(theme.fg("toolOutput", `path: ${JSON.stringify(input.path)}`));
 	}
-	for (const key of [
-		"replaces",
-		"removeLineRanges",
-		"insertLines",
-		"replaceLineRanges",
-	] as const) {
+	for (const key of ["replaces", "removeLineRanges", "insertLines"] as const) {
 		if (!Array.isArray(input[key]) || input[key].length === 0) continue;
 		lines.push(theme.fg("toolOutput", `${key}: ${JSON.stringify(input[key])}`));
 	}

--- a/files/pi/agent/extensions/user/lib/file/apply-patch.ts
+++ b/files/pi/agent/extensions/user/lib/file/apply-patch.ts
@@ -351,7 +351,9 @@ function createEdits(text: string, params: ApplyPatchToolInput): TextEdit[] {
 					chars.start,
 				);
 				if (positions.length === 0) {
-					throw new Error(`${label} oldText was not found.`);
+					throw new Error(
+						`${label} oldText did not match within the target line range.`,
+					);
 				}
 				assertNoSameLineMatches(index, positions, label);
 				for (const start of positions) {

--- a/files/pi/agent/extensions/user/lib/file/apply-patch.ts
+++ b/files/pi/agent/extensions/user/lib/file/apply-patch.ts
@@ -44,11 +44,22 @@ type ApplyPatchDetails = {
 
 const lineNoSchema = Type.Integer({ minimum: 1 });
 
+const targetLineNoRangeSchema = Type.Object({
+	start: lineNoSchema,
+	end: lineNoSchema,
+});
+
 const replaceSchema = Type.Object({
 	oldText: Type.String(),
 	newText: Type.String(),
 	startLineNo: Type.Optional(lineNoSchema),
 	endLineNo: Type.Optional(lineNoSchema),
+	targetLineNoRanges: Type.Optional(
+		Type.Array(targetLineNoRangeSchema, {
+			description:
+				"Optional target 1-based line number ranges where oldText may match and be replaced. When omitted, the whole file is searched.",
+		}),
+	),
 });
 
 const lineRangeSchema = Type.Object({
@@ -61,7 +72,7 @@ export const applyPatchSchema = Type.Object({
 	replaces: Type.Optional(
 		Type.Array(replaceSchema, {
 			description:
-				"Replace oldText with newText. If oldText matches multiple locations, startLineNo/endLineNo must disambiguate the range.",
+				"Replace oldText with newText. If oldText matches multiple locations, startLineNo/endLineNo or targetLineNoRanges must disambiguate where replacements are allowed.",
 		}),
 	),
 	removeLineRanges: Type.Optional(
@@ -229,6 +240,58 @@ function collectLineRangeUsage(
 	}
 }
 
+function assertTargetLineNoRange(
+	index: LineIndex,
+	start: number,
+	end: number,
+	label: string,
+): void {
+	assertLineNo(index, start, `${label} start`);
+	assertLineNo(index, end, `${label} end`);
+	if (start > end) {
+		throw new Error(`${label} start must be <= end.`);
+	}
+}
+
+function targetLineNoRangeCandidate(
+	index: LineIndex,
+	position: number,
+	length: number,
+): string {
+	const start = lineNoAtOffset(index, position);
+	const end = lineNoAtOffset(index, position + length);
+	return `{ start: ${start}, end: ${end} }`;
+}
+
+function candidateTargetLineNoRanges(
+	index: LineIndex,
+	positions: readonly number[],
+	length: number,
+): string {
+	return `[${positions
+		.map((position) => targetLineNoRangeCandidate(index, position, length))
+		.join(", ")}]`;
+}
+
+function assertNoSameLineMatches(
+	index: LineIndex,
+	positions: readonly number[],
+	label: string,
+): void {
+	const counts = new Map<number, number>();
+	for (const position of positions) {
+		const lineNo = lineNoAtOffset(index, position);
+		counts.set(lineNo, (counts.get(lineNo) ?? 0) + 1);
+	}
+	for (const [lineNo, count] of counts) {
+		if (count > 1) {
+			throw new Error(
+				`${label} oldText matched multiple locations on line ${lineNo}. Line ranges cannot disambiguate multiple matches on the same line. Use a more specific oldText.`,
+			);
+		}
+	}
+}
+
 function createEdits(text: string, params: ApplyPatchToolInput): TextEdit[] {
 	const index = createLineIndex(text);
 	const edits: TextEdit[] = [];
@@ -299,6 +362,40 @@ function createEdits(text: string, params: ApplyPatchToolInput): TextEdit[] {
 				`replaces[${i}] must specify both startLineNo and endLineNo, or neither.`,
 			);
 		}
+		if ((replace.targetLineNoRanges?.length ?? 0) > 0) {
+			if (hasStart || hasEnd) {
+				throw new Error(
+					`replaces[${i}] must specify either startLineNo/endLineNo or targetLineNoRanges, not both.`,
+				);
+			}
+			for (const [rangeIndex, range] of (
+				replace.targetLineNoRanges ?? []
+			).entries()) {
+				const label = `replaces[${i}].targetLineNoRanges[${rangeIndex}]`;
+				assertTargetLineNoRange(index, range.start, range.end, label);
+				const chars = rangeContentChars(index, range.start, range.end);
+				const positions = findOccurrences(
+					text.slice(chars.start, chars.end),
+					replace.oldText,
+					chars.start,
+				);
+				if (positions.length === 0) {
+					throw new Error(`${label} oldText was not found.`);
+				}
+				assertNoSameLineMatches(index, positions, label);
+				for (const start of positions) {
+					collectLineUsage(usedLines, lineNoAtOffset(index, start));
+					edits.push({
+						start,
+						end: start + replace.oldText.length,
+						replacement: replace.newText,
+						label,
+					});
+				}
+			}
+			continue;
+		}
+
 		let searchText = text;
 		let baseOffset = 0;
 		if (hasStart && hasEnd) {
@@ -314,18 +411,8 @@ function createEdits(text: string, params: ApplyPatchToolInput): TextEdit[] {
 		if (positions.length === 0)
 			throw new Error(`replaces[${i}] oldText was not found.`);
 		if (positions.length > 1) {
-			const candidates = positions
-				.map((position) => {
-					const startLineNo = lineNoAtOffset(index, position);
-					const endLineNo = lineNoAtOffset(
-						index,
-						position + replace.oldText.length,
-					);
-					return `${startLineNo}-${endLineNo}`;
-				})
-				.join(", ");
 			throw new Error(
-				`replaces[${i}] oldText matched multiple ranges. Specify startLineNo/endLineNo. Candidate ranges: ${candidates}.`,
+				`replaces[${i}] oldText matched multiple locations. Specify targetLineNoRanges. Candidate targetLineNoRanges: ${candidateTargetLineNoRanges(index, positions, replace.oldText.length)}.`,
 			);
 		}
 		const start = positions[0] ?? 0;

--- a/files/pi/agent/extensions/user/lib/tool/builtin.ts
+++ b/files/pi/agent/extensions/user/lib/tool/builtin.ts
@@ -51,12 +51,14 @@ function registerFileTools(catalog: ToolCatalog): void {
 				name: "apply_patch",
 				label: "apply_patch",
 				description:
-					"Apply one or more edits to a single file using pre-edit 1-based line numbers and/or text replacement. Supports replaces, removeLineRanges, insertLines, and replaceLineRanges in one call.",
+					"Apply one or more edits to a single file using pre-edit 1-based line numbers and/or text replacement. Supports replaces, removeLineRanges, and insertLines in one call.",
 				promptSnippet: "Apply multiple edits to one file",
 				promptGuidelines: [
-					"Use path plus one or more operation arrays: replaces, removeLineRanges, insertLines, replaceLineRanges.",
+					"Use path plus one or more operation arrays: replaces, removeLineRanges, insertLines.",
+					"Choose the smallest operation that directly matches the intent: insertLines for pure insertion, removeLineRanges for pure deletion, and replaces for changing existing text.",
+					"Do not use replaces to simulate simple insertion or deletion when insertLines or removeLineRanges expresses the edit directly.",
 					"All line numbers are 1-based and refer to the file before any edits in this call are applied.",
-					"Read the target file immediately before using line-number based edits (insertLines, removeLineRanges, replaceLineRanges); after applying one, read again before another line-number based edit because line numbers may have shifted.",
+					"Read the target file immediately before using line-number based edits (insertLines, removeLineRanges); after applying one, read again before another line-number based edit because line numbers may have shifted.",
 					"Do not target the same line with multiple operations; overlapping line targets fail to avoid ambiguous edits.",
 					"For insertLines, specify exactly one of insertAfterLineNo or insertBeforeLineNo.",
 					"If replaces.oldText matches multiple locations, specify startLineNo/endLineNo or targetLineNoRanges to disambiguate.",

--- a/files/pi/agent/extensions/user/lib/tool/builtin.ts
+++ b/files/pi/agent/extensions/user/lib/tool/builtin.ts
@@ -56,9 +56,10 @@ function registerFileTools(catalog: ToolCatalog): void {
 				promptGuidelines: [
 					"Use path plus one or more operation arrays: replaces, removeLineRanges, insertLines, replaceLineRanges.",
 					"All line numbers are 1-based and refer to the file before any edits in this call are applied.",
+					"Read the target file immediately before using line-number based edits (insertLines, removeLineRanges, replaceLineRanges); after applying one, read again before another line-number based edit because line numbers may have shifted.",
 					"Do not target the same line with multiple operations; overlapping line targets fail to avoid ambiguous edits.",
 					"For insertLines, specify exactly one of insertAfterLineNo or insertBeforeLineNo.",
-					"If replaces.oldText matches multiple ranges, specify startLineNo and endLineNo to disambiguate.",
+					"If replaces.oldText matches multiple locations, specify startLineNo/endLineNo or targetLineNoRanges to disambiguate.",
 				],
 				parameters: applyPatchSchema,
 				executionMode: "sequential",

--- a/tests/pi/agent/extensions/user/lib/file/apply-patch.test.ts
+++ b/tests/pi/agent/extensions/user/lib/file/apply-patch.test.ts
@@ -197,7 +197,9 @@ describe("apply_patch", () => {
 					},
 				],
 			},
-			["replaces[0].targetLineNoRanges[0] oldText was not found"],
+			[
+				"replaces[0].targetLineNoRanges[0] oldText did not match within the target line range",
+			],
 		);
 		assert.equal(readFileSync(path, "utf8"), "same\nother\nsame\n");
 	});

--- a/tests/pi/agent/extensions/user/lib/file/apply-patch.test.ts
+++ b/tests/pi/agent/extensions/user/lib/file/apply-patch.test.ts
@@ -63,20 +63,17 @@ describe("apply_patch", () => {
 				],
 				removeLineRanges: [{ startLineNo: 4, endLineNo: 4 }],
 				insertLines: [{ insertAfterLineNo: 5, contentLines: ["inserted"] }],
-				replaceLineRanges: [
-					{ startLineNo: 6, endLineNo: 6, contentLines: ["SIX"] },
-				],
 			},
 			undefined,
 		);
 
 		assert.equal(
 			readFileSync(join(root, "src", "example.txt"), "utf8"),
-			["one", "TWO", "three", "five", "inserted", "SIX", ""].join("\n"),
+			["one", "TWO", "three", "five", "inserted", "six", ""].join("\n"),
 		);
 		assert.equal(result.details.operation, "apply_patch");
 		assert.equal(result.details.path, "src/example.txt");
-		assert.equal(result.details.edits, 4);
+		assert.equal(result.details.edits, 3);
 		assert.ok(typeof result.details.diff === "string");
 		assert.ok(typeof result.details.patch === "string");
 	});
@@ -293,9 +290,7 @@ describe("apply_patch", () => {
 				{
 					path: "src/example.txt",
 					removeLineRanges: [{ startLineNo: 2, endLineNo: 2 }],
-					replaceLineRanges: [
-						{ startLineNo: 2, endLineNo: 3, contentLines: ["changed"] },
-					],
+					insertLines: [{ insertBeforeLineNo: 2, contentLines: ["changed"] }],
 				},
 				undefined,
 			),

--- a/tests/pi/agent/extensions/user/lib/file/apply-patch.test.ts
+++ b/tests/pi/agent/extensions/user/lib/file/apply-patch.test.ts
@@ -29,6 +29,23 @@ function tempRepo(): string {
 	return root;
 }
 
+async function expectApplyPatchError(
+	root: string,
+	params: Parameters<typeof executeApplyPatch>[1],
+	messageIncludes: readonly string[],
+): Promise<void> {
+	await assert.rejects(executeApplyPatch(root, params, undefined), (error) => {
+		assert(error instanceof Error);
+		for (const text of messageIncludes) {
+			assert.ok(
+				error.message.includes(text),
+				`Expected error message to include ${JSON.stringify(text)}, got ${JSON.stringify(error.message)}`,
+			);
+		}
+		return true;
+	});
+}
+
 describe("apply_patch", () => {
 	it("applies multiple operation kinds using pre-edit line numbers", async () => {
 		const root = tempRepo();
@@ -64,21 +81,150 @@ describe("apply_patch", () => {
 		assert.ok(typeof result.details.patch === "string");
 	});
 
-	it("reports candidate ranges when text replacement is ambiguous", async () => {
+	it("reports candidate target line number ranges when text replacement is ambiguous", async () => {
 		const root = tempRepo();
 		writeFileSync(join(root, "src", "example.txt"), "same\nother\nsame\n");
 
-		await assert.rejects(
-			executeApplyPatch(
-				root,
-				{
-					path: "src/example.txt",
-					replaces: [{ oldText: "same", newText: "changed" }],
-				},
-				undefined,
-			),
-			/Candidate ranges: 1-1, 3-3/u,
+		await expectApplyPatchError(
+			root,
+			{
+				path: "src/example.txt",
+				replaces: [{ oldText: "same", newText: "changed" }],
+			},
+			[
+				"replaces[0] oldText matched multiple locations",
+				"Specify targetLineNoRanges",
+				"Candidate targetLineNoRanges: [{ start: 1, end: 1 }, { start: 3, end: 3 }]",
+			],
 		);
+	});
+
+	it("replaces all matching text within the target line number ranges", async () => {
+		const root = tempRepo();
+		const path = join(root, "src", "example.txt");
+		writeFileSync(
+			path,
+			["same", "keep", "same", "keep", "same", ""].join("\n"),
+		);
+
+		const result = await executeApplyPatch(
+			root,
+			{
+				path: "src/example.txt",
+				replaces: [
+					{
+						oldText: "same",
+						newText: "changed",
+						targetLineNoRanges: [{ start: 1, end: 3 }],
+					},
+				],
+			},
+			undefined,
+		);
+
+		assert.equal(
+			readFileSync(path, "utf8"),
+			["changed", "keep", "changed", "keep", "same", ""].join("\n"),
+		);
+		assert.equal(result.details.edits, 2);
+	});
+
+	it("uses target line number ranges to disambiguate globally ambiguous text", async () => {
+		const root = tempRepo();
+		const path = join(root, "src", "example.txt");
+		writeFileSync(
+			path,
+			["same", "keep", "same", "keep", "same", ""].join("\n"),
+		);
+
+		await executeApplyPatch(
+			root,
+			{
+				path: "src/example.txt",
+				replaces: [
+					{
+						oldText: "same",
+						newText: "changed",
+						targetLineNoRanges: [{ start: 3, end: 3 }],
+					},
+				],
+			},
+			undefined,
+		);
+
+		assert.equal(
+			readFileSync(path, "utf8"),
+			["same", "keep", "changed", "keep", "same", ""].join("\n"),
+		);
+	});
+
+	it("rejects multiple matches on the same line within a target line number range", async () => {
+		const root = tempRepo();
+		const path = join(root, "src", "example.txt");
+		writeFileSync(path, "same same\n");
+
+		await expectApplyPatchError(
+			root,
+			{
+				path: "src/example.txt",
+				replaces: [
+					{
+						oldText: "same",
+						newText: "changed",
+						targetLineNoRanges: [{ start: 1, end: 1 }],
+					},
+				],
+			},
+			[
+				"replaces[0].targetLineNoRanges[0] oldText matched multiple locations on line 1",
+				"Use a more specific oldText",
+			],
+		);
+		assert.equal(readFileSync(path, "utf8"), "same same\n");
+	});
+
+	it("rejects a target line number range that contains no match", async () => {
+		const root = tempRepo();
+		const path = join(root, "src", "example.txt");
+		writeFileSync(path, "same\nother\nsame\n");
+
+		await expectApplyPatchError(
+			root,
+			{
+				path: "src/example.txt",
+				replaces: [
+					{
+						oldText: "same",
+						newText: "changed",
+						targetLineNoRanges: [{ start: 2, end: 2 }],
+					},
+				],
+			},
+			["replaces[0].targetLineNoRanges[0] oldText was not found"],
+		);
+		assert.equal(readFileSync(path, "utf8"), "same\nother\nsame\n");
+	});
+
+	it("rejects target line number ranges with start after end", async () => {
+		const root = tempRepo();
+		const path = join(root, "src", "example.txt");
+		writeFileSync(path, "same\nother\n");
+
+		await expectApplyPatchError(
+			root,
+			{
+				path: "src/example.txt",
+				replaces: [
+					{
+						oldText: "same",
+						newText: "changed",
+						targetLineNoRanges: [{ start: 2, end: 1 }],
+					},
+				],
+			},
+			["replaces[0].targetLineNoRanges[0] start must be <= end"],
+		);
+		assert.equal(readFileSync(path, "utf8"), "same\nother\n");
 	});
 
 	it("inserts after the last line when the file ends with a newline", async () => {


### PR DESCRIPTION
## Summary

- Adds `targetLineNoRanges` for `apply_patch` text replacements so repeated matches can be constrained to explicit line ranges.
- Improves ambiguity and no-match error messages to guide more specific replacement targets.
- Updates `apply_patch` guidance to prefer the smallest operation for the edit intent.
- Removes `replaceLineRanges` to avoid line-range replacement mistakes.

## Background

`apply_patch` replacement edits can be ambiguous when the same `oldText` appears multiple times. This change lets callers provide explicit target line ranges for replacement matching while keeping simple insertions and deletions on `insertLines` and `removeLineRanges`.

The previous line-range replacement operation was removed because it was easy to misuse for broad code edits. The updated guidance keeps line-number based edits available for insertion and deletion, and recommends re-reading before subsequent line-number based edits because line numbers may shift.