### PR TITLE
fix(pi): avoid staging missing rename/delete paths in github tool

### DIFF
--- a/files/pi/agent/extensions/user/lib/tool/github.ts
+++ b/files/pi/agent/extensions/user/lib/tool/github.ts
@@ -1,4 +1,6 @@
 import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
 import type { AgentToolResult, Theme } from "@earendil-works/pi-coding-agent";
 import { type Component, Text } from "@earendil-works/pi-tui";
 import { type Static, Type } from "typebox";
@@ -176,7 +178,7 @@ const createPullRequestSchema = Type.Object({
 	}),
 	commitFiles: Type.Array(Type.String(), {
 		description:
-			"Explicit list of files to stage and commit. Only these files are staged.",
+			"Explicit list of files to stage and commit. Existing listed files are staged; only listed files are committed.",
 	}),
 	commitMessage: Type.String({
 		description: "Commit message for the new commit.",
@@ -190,7 +192,8 @@ type CreatePullRequestInput = Static<typeof createPullRequestSchema>;
 const updatePullRequestSchema = Type.Object({
 	commitFiles: Type.Optional(
 		Type.Array(Type.String(), {
-			description: "If provided, stage only these files, commit, and push.",
+			description:
+				"If provided, stage existing listed files, commit only listed files, and push.",
 		}),
 	),
 	commitMessage: Type.Optional(
@@ -985,6 +988,39 @@ async function currentBranch(
 	return branch;
 }
 
+function existingWorkingTreeFiles(
+	cwd: string,
+	files: readonly string[],
+): string[] {
+	return files.filter((file) => existsSync(path.resolve(cwd, file)));
+}
+
+async function stageAndCommitFiles(
+	cwd: string,
+	files: readonly string[],
+	commitMessage: string,
+	signal: AbortSignal | undefined,
+	commands: string[],
+): Promise<void> {
+	const existingFiles = existingWorkingTreeFiles(cwd, files);
+	if (existingFiles.length > 0) {
+		await runCommand(
+			"git",
+			cwd,
+			["add", "--", ...existingFiles],
+			signal,
+			commands,
+		);
+	}
+	await runCommand(
+		"git",
+		cwd,
+		["commit", "--only", "-m", commitMessage, "--", ...files],
+		signal,
+		commands,
+	);
+}
+
 async function createPullRequest(
 	params: CreatePullRequestInput,
 	cwd: string,
@@ -1007,17 +1043,10 @@ async function createPullRequest(
 	}
 
 	await runCommand("git", cwd, ["switch", "-c", branchName], signal, commands);
-	await runCommand(
-		"git",
+	await stageAndCommitFiles(
 		cwd,
-		["add", "--", ...params.commitFiles],
-		signal,
-		commands,
-	);
-	await runCommand(
-		"git",
-		cwd,
-		["commit", "--only", "-m", commitMessage, "--", ...params.commitFiles],
+		params.commitFiles,
+		commitMessage,
 		signal,
 		commands,
 	);
@@ -1081,14 +1110,7 @@ async function updatePullRequest(
 			params.commitMessage,
 			"commitMessage",
 		);
-		await runCommand("git", cwd, ["add", "--", ...files], signal, commands);
-		await runCommand(
-			"git",
-			cwd,
-			["commit", "--only", "-m", commitMessage, "--", ...files],
-			signal,
-			commands,
-		);
+		await stageAndCommitFiles(cwd, files, commitMessage, signal, commands);
 		await runCommand("git", cwd, ["push"], signal, commands);
 		lines.push("Pushed new commit to the current branch.");
 	}
@@ -1178,7 +1200,7 @@ function registerGithubTool<TInput extends object>(
 				promptGuidelines: config.write
 					? [
 							`${config.name} performs git and gh write operations directly from explicit inputs. Do not add interactive confirmation prompts.`,
-							"Use explicit commitFiles lists to avoid committing unrelated work. Only the listed files are staged.",
+							"Use explicit commitFiles lists to avoid committing unrelated work. Existing listed files are staged, and only listed files are committed.",
 							"Fail clearly when required inputs are missing, the target branch is the repository default branch, or unsafe conditions are detected.",
 							"Do not force-push, amend, rebase, or rewrite history.",
 						]
@@ -1280,7 +1302,7 @@ export function registerGithubTools(catalog: ToolCatalog): void {
 		name: "create_pull_request",
 		label: "create pull request",
 		description:
-			"Create a new draft pull request from specified commit files. Creates a new branch, stages only the listed files, commits, pushes, and opens a draft PR with gh.",
+			"Create a new draft pull request from specified commit files. Creates a new branch, stages existing listed files, commits only listed files, pushes, and opens a draft PR with gh.",
 		parameters: createPullRequestSchema,
 		promptSnippet: "Create a draft pull request from explicit files",
 		extractSecretPaths: (input) => input.commitFiles,

--- a/tests/pi/agent/extensions/user/lib/tool/github.test.ts
+++ b/tests/pi/agent/extensions/user/lib/tool/github.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { beforeEach, describe, it, vi } from "vitest";
 
@@ -96,6 +99,16 @@ function findTool(name: string): {
 	};
 }
 
+function tempRepo(files: readonly string[]): string {
+	const cwd = mkdtempSync(path.join(tmpdir(), "pi-github-test-"));
+	for (const file of files) {
+		const target = path.join(cwd, file);
+		mkdirSync(path.dirname(target), { recursive: true });
+		writeFileSync(target, "test\n");
+	}
+	return cwd;
+}
+
 async function reject(promise: Promise<unknown>): Promise<Error> {
 	try {
 		await promise;
@@ -161,55 +174,51 @@ describe("create_pull_request", () => {
 		assert.ok(!calls.some((c) => c.bin === "git" && c.args[0] === "switch"));
 	});
 
-	it("stages files with git add then commits only those files via git commit --only", async () => {
-		const calls: Call[] = [];
-		setupExec({
-			calls,
-			stdout: {
-				...defaultArgs("git", [
-					"symbolic-ref",
-					"--short",
-					"refs/remotes/origin/HEAD",
-				]),
-				"gh pr create --draft --title Add a and b --body ## Summary\n- adds a and b":
-					"https://github.com/owner/repo/pull/1\n",
-			},
-		});
-		const create = findTool("create_pull_request");
-		const result = (await invoke(create, validCreateInput, "/repo")) as {
-			readonly content: readonly { readonly text: string }[];
-		};
-		assert.match(result.content[0]?.text ?? "", /pull\/1/u);
+	it("stages existing files, then commits only listed files", async () => {
+		const cwd = tempRepo(["src/a.ts", "src/b.ts"]);
+		try {
+			const calls: Call[] = [];
+			setupExec({
+				calls,
+				stdout: {
+					...defaultArgs("git", [
+						"symbolic-ref",
+						"--short",
+						"refs/remotes/origin/HEAD",
+					]),
+					"gh pr create --draft --title Add a and b --body ## Summary\n- adds a and b":
+						"https://github.com/owner/repo/pull/1\n",
+				},
+			});
+			const create = findTool("create_pull_request");
+			const result = (await invoke(create, validCreateInput, cwd)) as {
+				readonly content: readonly { readonly text: string }[];
+			};
+			assert.match(result.content[0]?.text ?? "", /pull\/1/u);
 
-		const commands = calls.map((call) => `${call.bin} ${call.args.join(" ")}`);
-		// git add must come before git commit --only, and commit must use --only.
-		const addIndex = commands.findIndex((cmd) =>
-			/^git add -- src\/a\.ts src\/b\.ts$/u.test(cmd),
-		);
-		const commitIndex = commands.findIndex((cmd) =>
-			/^git commit --only -m feat: add a and b -- src\/a\.ts src\/b\.ts$/u.test(
-				cmd,
-			),
-		);
-		assert.notEqual(
-			addIndex,
-			-1,
-			`git add should run; commands:\n${commands.join("\n")}`,
-		);
-		assert.notEqual(
-			commitIndex,
-			-1,
-			`git commit --only should run; commands:\n${commands.join("\n")}`,
-		);
-		assert.ok(
-			addIndex < commitIndex,
-			`git add must precede git commit --only; commands:\n${commands.join("\n")}`,
-		);
-		// No destructive reset of the whole index.
-		assert.ok(
-			!commands.some((cmd) => cmd.startsWith("git reset ")),
-			`should not run git reset; commands:\n${commands.join("\n")}`,
-		);
+			const commands = calls.map(
+				(call) => `${call.bin} ${call.args.join(" ")}`,
+			);
+			const addIndex = commands.indexOf("git add -- src/a.ts src/b.ts");
+			const commitIndex = commands.indexOf(
+				"git commit --only -m feat: add a and b -- src/a.ts src/b.ts",
+			);
+			assert.notEqual(
+				addIndex,
+				-1,
+				`git add should run; commands:\n${commands.join("\n")}`,
+			);
+			assert.notEqual(
+				commitIndex,
+				-1,
+				`git commit --only should run; commands:\n${commands.join("\n")}`,
+			);
+			assert.ok(addIndex < commitIndex);
+			assert.ok(!commands.some((cmd) => cmd.includes("diff --cached")));
+			assert.ok(!commands.some((cmd) => cmd.startsWith("git reset ")));
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
 	});
 });
 
@@ -269,48 +278,87 @@ describe("update_pull_request", () => {
 		);
 	});
 
-	it("stages files with git add then commits only those files via git commit --only", async () => {
-		const calls: Call[] = [];
-		setupExec({
-			calls,
-			stdout: {
-				"git symbolic-ref --short refs/remotes/origin/HEAD": "origin/main\n",
-				"git rev-parse --abbrev-ref HEAD": "feature/test\n",
-			},
-		});
-		const update = findTool("update_pull_request");
-		const result = (await invoke(
-			update,
-			{ commitFiles: ["src/a.ts"], commitMessage: "msg" },
-			"/repo",
-		)) as { readonly content: readonly { readonly text: string }[] };
-		assert.match(result.content[0]?.text ?? "", /Pushed new commit/u);
+	it("stages existing files, then commits only listed files", async () => {
+		const cwd = tempRepo(["src/a.ts"]);
+		try {
+			const calls: Call[] = [];
+			setupExec({
+				calls,
+				stdout: {
+					"git symbolic-ref --short refs/remotes/origin/HEAD": "origin/main\n",
+					"git rev-parse --abbrev-ref HEAD": "feature/test\n",
+				},
+			});
+			const update = findTool("update_pull_request");
+			const result = (await invoke(
+				update,
+				{ commitFiles: ["src/a.ts"], commitMessage: "msg" },
+				cwd,
+			)) as { readonly content: readonly { readonly text: string }[] };
+			assert.match(result.content[0]?.text ?? "", /Pushed new commit/u);
 
-		const commands = calls.map((call) => `${call.bin} ${call.args.join(" ")}`);
-		const addIndex = commands.findIndex((cmd) =>
-			/^git add -- src\/a\.ts$/u.test(cmd),
-		);
-		const commitIndex = commands.findIndex((cmd) =>
-			/^git commit --only -m msg -- src\/a\.ts$/u.test(cmd),
-		);
-		assert.notEqual(
-			addIndex,
-			-1,
-			`git add should run; commands:\n${commands.join("\n")}`,
-		);
-		assert.notEqual(
-			commitIndex,
-			-1,
-			`git commit --only should run; commands:\n${commands.join("\n")}`,
-		);
-		assert.ok(
-			addIndex < commitIndex,
-			`git add must precede git commit --only; commands:\n${commands.join("\n")}`,
-		);
-		assert.ok(
-			!commands.some((cmd) => cmd.startsWith("git reset ")),
-			`should not run git reset; commands:\n${commands.join("\n")}`,
-		);
+			const commands = calls.map(
+				(call) => `${call.bin} ${call.args.join(" ")}`,
+			);
+			const addIndex = commands.indexOf("git add -- src/a.ts");
+			const commitIndex = commands.indexOf(
+				"git commit --only -m msg -- src/a.ts",
+			);
+			assert.notEqual(
+				addIndex,
+				-1,
+				`git add should run; commands:\n${commands.join("\n")}`,
+			);
+			assert.notEqual(
+				commitIndex,
+				-1,
+				`git commit --only should run; commands:\n${commands.join("\n")}`,
+			);
+			assert.ok(addIndex < commitIndex);
+			assert.ok(!commands.some((cmd) => cmd.includes("diff --cached")));
+			assert.ok(!commands.some((cmd) => cmd.startsWith("git reset ")));
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("stages only existing rename/delete paths and commits all listed paths with --only", async () => {
+		const cwd = tempRepo(["new/name.ts"]);
+		try {
+			const calls: Call[] = [];
+			setupExec({
+				calls,
+				stdout: {
+					"git symbolic-ref --short refs/remotes/origin/HEAD": "origin/main\n",
+					"git rev-parse --abbrev-ref HEAD": "feature/test\n",
+				},
+			});
+			const update = findTool("update_pull_request");
+			await invoke(
+				update,
+				{
+					commitFiles: ["old/name.ts", "new/name.ts", "deleted.ts"],
+					commitMessage: "rename and delete",
+				},
+				cwd,
+			);
+
+			const commands = calls.map(
+				(call) => `${call.bin} ${call.args.join(" ")}`,
+			);
+			assert.ok(
+				commands.includes("git add -- new/name.ts"),
+				`git add should stage only existing paths; commands:\n${commands.join("\n")}`,
+			);
+			assert.ok(
+				commands.includes(
+					"git commit --only -m rename and delete -- old/name.ts new/name.ts deleted.ts",
+				),
+				`git commit should use --only with all paths; commands:\n${commands.join("\n")}`,
+			);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
 	});
 
 	it("converts to draft with gh pr ready --undo", async () => {


### PR DESCRIPTION
## Summary

- Stage only the existing `commitFiles` paths before creating/updating PR commits, so rename/delete source paths that no longer exist are not passed to `git add`.
- Keep `git commit --only` over the full original `commitFiles` list so unrelated pre-staged changes are not committed.

## Background

The bug was that `git add -- <commitFiles...>` would fail when `commitFiles` included rename/delete source paths that no longer existed in the working tree. The `add` step unconditionally tried to stage every path before the commit.

`git commit --only` is intentionally preserved because it limits the commit to exactly the requested paths and avoids committing unrelated user-staged changes that happen to be in the index. By separating staging (only existing files) from committing (the full desired path list), the tool neither breaks on missing paths nor leaks unrelated staged content.