### PR TITLE
fix(pi): truncate agent tool lines to one per row in collapsed view

### DIFF
--- a/files/pi/agent/extensions/user/lib/tool/agent.ts
+++ b/files/pi/agent/extensions/user/lib/tool/agent.ts
@@ -6,7 +6,13 @@ import {
 	RpcClient,
 	type Theme,
 } from "@earendil-works/pi-coding-agent";
-import { type Component, Text } from "@earendil-works/pi-tui";
+import {
+	type Component,
+	Text,
+	sliceByColumn,
+	truncateToWidth,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
 import { type TSchema, Type } from "typebox";
 import { type ToolCatalog, defineToolContribution } from "./catalog";
 import {
@@ -127,6 +133,47 @@ function truncateTitle(label: string): string {
 		: label;
 }
 
+function truncateMiddleToWidth(text: string, width: number): string {
+	if (visibleWidth(text) <= width) return text;
+	if (width <= 1) return truncateToWidth(text, width, "");
+
+	const ellipsis = "…";
+	const remainingWidth = width - visibleWidth(ellipsis);
+	const headWidth = Math.ceil(remainingWidth / 2);
+	const tailWidth = Math.floor(remainingWidth / 2);
+	const textWidth = visibleWidth(text);
+	return `${sliceByColumn(text, 0, headWidth, true)}${ellipsis}${sliceByColumn(text, textWidth - tailWidth, tailWidth, true)}`;
+}
+
+function truncateAgentLine(line: string, width: number): string {
+	if (visibleWidth(line) <= width) return line;
+
+	const argsStart = line.indexOf(" (");
+	const argsEnd = line.lastIndexOf(")");
+	if (argsStart === -1 || argsEnd <= argsStart + 2) {
+		return truncateToWidth(line, width, "");
+	}
+
+	const prefix = line.slice(0, argsStart + 2);
+	const args = line.slice(argsStart + 2, argsEnd);
+	const suffix = line.slice(argsEnd);
+	const argsWidth = width - visibleWidth(prefix) - visibleWidth(suffix);
+	if (argsWidth <= 0) return truncateToWidth(line, width, "");
+
+	return `${prefix}${truncateMiddleToWidth(args, argsWidth)}${suffix}`;
+}
+
+/** Render each input line as one terminal row by truncating instead of wrapping. */
+class OneLinePerRowText implements Component {
+	constructor(private readonly text: string) {}
+
+	render(width: number): string[] {
+		return this.text.split("\n").map((line) => truncateAgentLine(line, width));
+	}
+
+	invalidate(): void {}
+}
+
 /** Format the one-line call display: `agent <title> in <focus>`. */
 function renderAgentCall(rawArgs: unknown, theme: Theme): Component {
 	const args = rawArgs as AgentInput;
@@ -168,11 +215,11 @@ function renderAgentResult(
 			.filter((c) => c.type === "text")
 			.map((c) => c.text)
 			.join("\n");
-		if (!options.expanded) return new Text(text, 0, 0);
+		if (!options.expanded) return new OneLinePerRowText(text);
 
 		const promptText = result.details?.prompt?.trim();
 		const toolCalls = result.details?.toolCalls ?? [];
-		const toolText = formatToolCallRecords(toolCalls);
+		const toolText = formatToolCallRecords(toolCalls, { truncateArgs: false });
 		const runningLine = result.details?.["_runningLine"];
 		const statusText = runningLine ?? text.trim();
 		const runningParts = [
@@ -201,13 +248,11 @@ function renderAgentResult(
 				.filter((c) => c.type === "text")
 				.map((c) => c.text)
 				.join("\n");
-			return new Text(
+			return new OneLinePerRowText(
 				`${stateDisplay} ${theme.fg("error", errorText)} ${theme.fg("dim", stats)}`,
-				0,
-				0,
 			);
 		}
-		return new Text(`${stateDisplay} ${theme.fg("dim", stats)}`, 0, 0);
+		return new OneLinePerRowText(`${stateDisplay} ${theme.fg("dim", stats)}`);
 	}
 
 	// Expanded – prompt + response + state + stats
@@ -231,9 +276,11 @@ function renderAgentResult(
 }
 
 /** Format a single tool-call argument value for display. */
-function formatArg(v: unknown): string {
+function formatArg(v: unknown, options: { truncate: boolean }): string {
 	if (typeof v === "string") {
-		return v.length > 80 ? `"${v.slice(0, 80)}…"` : `"${v}"`;
+		return options.truncate && v.length > 80
+			? `"${v.slice(0, 80)}…"`
+			: `"${v}"`;
 	}
 	if (typeof v === "number" || typeof v === "boolean" || v == null) {
 		return String(v);
@@ -241,20 +288,26 @@ function formatArg(v: unknown): string {
 	try {
 		const json = JSON.stringify(v);
 		if (!json) return String(v);
-		return json.length > 120 ? `${json.slice(0, 120)}…` : json;
+		return options.truncate && json.length > 120
+			? `${json.slice(0, 120)}…`
+			: json;
 	} catch {
 		return Object.prototype.toString.call(v);
 	}
 }
-function formatToolCallRecords(toolCalls: readonly ToolCallRecord[]): string {
+function formatToolCallRecords(
+	toolCalls: readonly ToolCallRecord[],
+	options: { truncateArgs?: boolean } = {},
+): string {
 	return toolCalls
-		.map((_, index) => formatToolCallRecord(toolCalls, index))
+		.map((_, index) => formatToolCallRecord(toolCalls, index, options))
 		.join("\n");
 }
 
 function formatToolCallRecord(
 	toolCalls: readonly ToolCallRecord[],
 	index: number,
+	options: { truncateArgs?: boolean } = {},
 ): string {
 	const minDurationMs = 1000;
 	const tc = toolCalls[index];
@@ -262,7 +315,10 @@ function formatToolCallRecord(
 	const duration = next ? next.startTime - tc.startTime : undefined;
 	const p = Object.entries(tc.args)
 		.filter(([, v]) => v !== undefined)
-		.map(([k, v]) => `${k}=${formatArg(v)}`)
+		.map(
+			([k, v]) =>
+				`${k}=${formatArg(v, { truncate: options.truncateArgs ?? true })}`,
+		)
 		.join(", ");
 	const argsStr = p ? ` (${p})` : "";
 	const durationStr =

--- a/tests/pi/agent/extensions/user/lib/tool/agent.test.ts
+++ b/tests/pi/agent/extensions/user/lib/tool/agent.test.ts
@@ -4,6 +4,7 @@ import type {
 	Theme,
 	ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { describe, it } from "vitest";
 import {
 	type FocusDefinition,
@@ -17,9 +18,12 @@ const plainTheme = {
 	bold: (text: string) => text,
 } as Theme;
 
-function renderText(component: { render(width: number): string[] }): string {
+function renderText(
+	component: { render(width: number): string[] },
+	width = 200,
+): string {
 	return component
-		.render(200)
+		.render(width)
 		.map((line) => line.replace(/[ \t]+$/u, ""))
 		.join("\n");
 }
@@ -237,10 +241,50 @@ describe("agent tool registration", () => {
 		assert.doesNotMatch(output, /\[object Object\]/u);
 	});
 
+	it("keeps collapsed running tool rows to one rendered line each", () => {
+		const definition = getAgentDefinition();
+		assert.ok(definition.renderResult);
+
+		const result = {
+			content: [
+				{
+					type: "text" as const,
+					text: [
+						' 1. grep (pattern="this is a very long pattern that used to wrap in narrow terminals")  2.3s  ← running',
+						"◉ Running  1.2s (1 tool used)",
+					].join("\n"),
+				},
+			],
+			details: {
+				_status: "running",
+				_runningLine: "◉ Running  1.2s (1 tool used)",
+				toolCallCount: 1,
+				durationMs: 1200,
+			},
+		} satisfies AgentToolResult<Record<string, unknown>>;
+
+		const lines = (
+			definition.renderResult(
+				result,
+				{ expanded: false, isPartial: true },
+				plainTheme,
+				renderResultContext(),
+			) as { render(width: number): string[] }
+		).render(30);
+
+		assert.equal(lines.length, 2);
+		assert.match(lines[0] ?? "", /1\. grep/u);
+		assert.match(lines[0] ?? "", /…\).*2\.3s.*← running/u);
+		assert.match(lines[1] ?? "", /Running/u);
+		assert.ok(lines.every((line) => visibleWidth(line) <= 30));
+	});
+
 	it("renders expanded running updates with prompt and all tools", () => {
 		const definition = getAgentDefinition();
 		assert.ok(definition.renderResult);
 
+		const longPattern =
+			"this is a very long grep pattern that should remain fully visible in expanded running updates";
 		const result = {
 			content: [{ type: "text" as const, text: "latest tail only" }],
 			details: {
@@ -254,7 +298,7 @@ describe("agent tool registration", () => {
 					{ name: "find", args: { pattern: "*.ts" }, startTime: 500 },
 					{
 						name: "grep",
-						args: { pattern: { raw: "TODO" } },
+						args: { pattern: { raw: longPattern } },
 						startTime: 1000,
 					},
 					{ name: "read", args: { path: "src/b.ts" }, startTime: 1500 },
@@ -276,7 +320,7 @@ describe("agent tool registration", () => {
 		assert.match(output, /tools:\s*\n[\s\S]*1\. read(?!_chunk)/u);
 		assert.match(output, /2\. find/u);
 		assert.match(output, /5\. lint/u);
-		assert.match(output, /pattern=\{"raw":"TODO"\}/u);
+		assert.match(output, new RegExp(longPattern, "u"));
 		assert.match(output, /◉ Running\s+1\.2s/u);
 		assert.doesNotMatch(output, /\[object Object\]/u);
 	});


### PR DESCRIPTION
## Summary

- Replace wrapped collapsed agent output with one-line-per-row rendering that truncates to the terminal width.
- Truncate long tool-call arguments in the middle while preserving the tool name, timing, and running marker.
- Keep expanded running updates untruncated so full tool arguments remain available when expanded.
- Add coverage for narrow collapsed rendering and full expanded argument display.

## Background

The collapsed agent running display could wrap long tool-call lines in narrow terminals, making the status output harder to scan. This change keeps each rendered input line to one terminal row while preserving the details in expanded mode.