### PR TITLE
fix(pi): reuse current branch in create pull request tool

### DIFF
--- a/files/pi/agent/extensions/user/lib/tool/github.ts
+++ b/files/pi/agent/extensions/user/lib/tool/github.ts
@@ -174,7 +174,7 @@ type GithubPrChecksInput = Static<typeof githubPrChecksSchema>;
 const createPullRequestSchema = Type.Object({
 	branchName: Type.String({
 		description:
-			"Name of the new working branch to create. Must not be the repository default branch.",
+			"Name of the working branch to use. If the current branch already matches, it is reused; otherwise a new branch is created. Must not be the repository default branch.",
 	}),
 	commitFiles: Type.Array(Type.String(), {
 		description:
@@ -988,6 +988,24 @@ async function currentBranch(
 	return branch;
 }
 
+async function currentBranchIfAvailable(
+	cwd: string,
+	signal: AbortSignal | undefined,
+	commands: string[],
+): Promise<string | undefined> {
+	const result = await execCommand(
+		"git",
+		cwd,
+		["branch", "--show-current"],
+		signal,
+	);
+	commands.push(result.command);
+	if (result.exitCode !== 0) return undefined;
+
+	const branch = result.stdout.trim();
+	return branch === "" ? undefined : branch;
+}
+
 function existingWorkingTreeFiles(
 	cwd: string,
 	files: readonly string[],
@@ -1042,7 +1060,16 @@ async function createPullRequest(
 		);
 	}
 
-	await runCommand("git", cwd, ["switch", "-c", branchName], signal, commands);
+	const branch = await currentBranchIfAvailable(cwd, signal, commands);
+	if (branch !== branchName) {
+		await runCommand(
+			"git",
+			cwd,
+			["switch", "-c", branchName],
+			signal,
+			commands,
+		);
+	}
 	await stageAndCommitFiles(
 		cwd,
 		params.commitFiles,
@@ -1302,7 +1329,7 @@ export function registerGithubTools(catalog: ToolCatalog): void {
 		name: "create_pull_request",
 		label: "create pull request",
 		description:
-			"Create a new draft pull request from specified commit files. Creates a new branch, stages existing listed files, commits only listed files, pushes, and opens a draft PR with gh.",
+			"Create a new draft pull request from specified commit files. Reuses the current branch when it matches branchName; otherwise creates a new branch. Stages existing listed files, commits only listed files, pushes, and opens a draft PR with gh.",
 		parameters: createPullRequestSchema,
 		promptSnippet: "Create a draft pull request from explicit files",
 		extractSecretPaths: (input) => input.commitFiles,

--- a/tests/pi/agent/extensions/user/lib/tool/github.test.ts
+++ b/tests/pi/agent/extensions/user/lib/tool/github.test.ts
@@ -197,9 +197,9 @@ describe("create_pull_request", () => {
 			};
 			assert.match(result.content[0]?.text ?? "", /pull\/1/u);
 
-			const commands = new Set(calls.map(
-				(call) => `${call.bin} ${call.args.join(" ")}`,
-			));
+			const commands = new Set(
+				calls.map((call) => `${call.bin} ${call.args.join(" ")}`),
+			);
 			assert.ok(commands.has("git branch --show-current"));
 			assert.ok(!commands.has("git switch -c feature/test"));
 			assert.ok(

--- a/tests/pi/agent/extensions/user/lib/tool/github.test.ts
+++ b/tests/pi/agent/extensions/user/lib/tool/github.test.ts
@@ -174,6 +174,45 @@ describe("create_pull_request", () => {
 		assert.ok(!calls.some((c) => c.bin === "git" && c.args[0] === "switch"));
 	});
 
+	it("reuses the current branch when it matches branchName", async () => {
+		const cwd = tempRepo(["src/a.ts", "src/b.ts"]);
+		try {
+			const calls: Call[] = [];
+			setupExec({
+				calls,
+				stdout: {
+					...defaultArgs("git", [
+						"symbolic-ref",
+						"--short",
+						"refs/remotes/origin/HEAD",
+					]),
+					"git branch --show-current": "feature/test\n",
+					"gh pr create --draft --title Add a and b --body ## Summary\n- adds a and b":
+						"https://github.com/owner/repo/pull/1\n",
+				},
+			});
+			const create = findTool("create_pull_request");
+			const result = (await invoke(create, validCreateInput, cwd)) as {
+				readonly content: readonly { readonly text: string }[];
+			};
+			assert.match(result.content[0]?.text ?? "", /pull\/1/u);
+
+			const commands = new Set(calls.map(
+				(call) => `${call.bin} ${call.args.join(" ")}`,
+			));
+			assert.ok(commands.has("git branch --show-current"));
+			assert.ok(!commands.has("git switch -c feature/test"));
+			assert.ok(
+				commands.has(
+					"git commit --only -m feat: add a and b -- src/a.ts src/b.ts",
+				),
+			);
+			assert.ok(commands.has("git push -u origin feature/test"));
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
 	it("stages existing files, then commits only listed files", async () => {
 		const cwd = tempRepo(["src/a.ts", "src/b.ts"]);
 		try {


### PR DESCRIPTION
## Summary
- Reuse the current branch in `create_pull_request` when it already matches `branchName`
- Keep creating `branchName` when running from a different branch
- Add test coverage for the current-branch reuse path

## Background
When working in a git worktree, the target branch may already exist and be checked out before `create_pull_request` runs. The tool previously always ran `git switch -c <branchName>`, which fails if that branch already exists. Reusing the current branch in that case lets the PR creation flow work from an existing worktree branch while preserving the existing behavior for other branches.