### PR TITLE
Fix Pi live agent usage cost/status metrics with in-flight updates and branch-scoped cache hit rate

### DIFF
--- a/files/pi/agent/extensions/user/features/status.ts
+++ b/files/pi/agent/extensions/user/features/status.ts
@@ -8,8 +8,10 @@ import type { Feature } from "../feature";
 import {
 	FOOTER_NOTICE_EVENT,
 	type FooterNoticeState,
+	type LiveAgentUsageTracker,
 	type RenderTrigger,
 	createFooterNoticeState,
+	createLiveAgentUsageTracker,
 	createRenderTrigger,
 	createStatusBarFooter,
 	handleFooterNotice,
@@ -20,25 +22,31 @@ const initFooter =
 		pi: ExtensionAPI,
 		render: RenderTrigger,
 		notice: FooterNoticeState,
+		liveAgentUsage: LiveAgentUsageTracker,
 	): ExtensionHandler<SessionStartEvent> =>
 	(_event, ctx) => {
 		if (!ctx.hasUI) return;
-		ctx.ui.setFooter(createStatusBarFooter(pi, ctx, render.set, notice));
+		ctx.ui.setFooter(
+			createStatusBarFooter(pi, ctx, render.set, notice, liveAgentUsage),
+		);
 	};
 
-const cleanupFooterNotice =
+const cleanupStatus =
 	(
 		notice: FooterNoticeState,
 		unsubscribe: () => void,
+		liveAgentUsage: LiveAgentUsageTracker,
 	): ExtensionHandler<SessionShutdownEvent> =>
 	() => {
 		unsubscribe();
+		liveAgentUsage.clear();
 		notice.dispose();
 	};
 
 function register(pi: ExtensionAPI): void {
 	const render = createRenderTrigger();
 	const notice = createFooterNoticeState(render);
+	const liveAgentUsage = createLiveAgentUsageTracker();
 	const unsubscribeFooterNotice = pi.events.on(
 		FOOTER_NOTICE_EVENT,
 		handleFooterNotice(notice),
@@ -46,11 +54,17 @@ function register(pi: ExtensionAPI): void {
 
 	pi.on("thinking_level_select", render.trigger);
 	pi.on("model_select", render.trigger);
-	pi.on("message_end", render.trigger);
-	pi.on("session_start", initFooter(pi, render, notice));
+	pi.on("tool_execution_update", (event) => {
+		if (liveAgentUsage.handleToolExecutionUpdate(event)) render.trigger();
+	});
+	pi.on("message_end", (event) => {
+		liveAgentUsage.handleMessageEnd(event);
+		render.trigger();
+	});
+	pi.on("session_start", initFooter(pi, render, notice, liveAgentUsage));
 	pi.on(
 		"session_shutdown",
-		cleanupFooterNotice(notice, unsubscribeFooterNotice),
+		cleanupStatus(notice, unsubscribeFooterNotice, liveAgentUsage),
 	);
 }
 

--- a/files/pi/agent/extensions/user/lib/status.ts
+++ b/files/pi/agent/extensions/user/lib/status.ts
@@ -13,4 +13,9 @@ export {
 	type RequestRender,
 } from "./status/render-trigger";
 export { formatCount } from "./status/format";
-export { getAssistantTotals, type Totals } from "./status/usage";
+export {
+	createLiveAgentUsageTracker,
+	getAssistantTotals,
+	type LiveAgentUsageTracker,
+	type Totals,
+} from "./status/usage";

--- a/files/pi/agent/extensions/user/lib/status/footer.ts
+++ b/files/pi/agent/extensions/user/lib/status/footer.ts
@@ -16,7 +16,7 @@ import {
 } from "./format";
 import type { FooterNoticeState } from "./notice";
 import type { RequestRender } from "./render-trigger";
-import { getAssistantTotals } from "./usage";
+import { type LiveAgentUsageTracker, getAssistantTotals } from "./usage";
 
 type FooterFactory = NonNullable<
 	Parameters<ExtensionUIContext["setFooter"]>[0]
@@ -30,6 +30,7 @@ export function createStatusBarFooter(
 	ctx: ExtensionContext,
 	setRequestRender: (requestRender: RequestRender | undefined) => void,
 	notice?: FooterNoticeState,
+	liveAgentUsage?: LiveAgentUsageTracker,
 ): FooterFactory {
 	return (
 		tui: TUI,
@@ -74,7 +75,10 @@ export function createStatusBarFooter(
 		}
 
 		function renderCost(): string {
-			const totals = getAssistantTotals(ctx.sessionManager.getBranch());
+			const totals = getAssistantTotals(
+				ctx.sessionManager.getBranch(),
+				liveAgentUsage?.snapshot(),
+			);
 			if (totals.cost <= 0) return "";
 			return fg(colors.muted, `$${totals.cost.toFixed(3)}`);
 		}

--- a/files/pi/agent/extensions/user/lib/status/footer.ts
+++ b/files/pi/agent/extensions/user/lib/status/footer.ts
@@ -67,6 +67,12 @@ export function createStatusBarFooter(
 			return fg(pickRemainingColor(remaining), text);
 		}
 
+		function renderCacheHitRate(): string {
+			const totals = getAssistantTotals(ctx.sessionManager.getBranch());
+			if (totals.latestCacheHitRate === undefined) return "";
+			return fg(colors.muted, `CH${formatPercent(totals.latestCacheHitRate)}`);
+		}
+
 		function renderCost(): string {
 			const totals = getAssistantTotals(ctx.sessionManager.getBranch());
 			if (totals.cost <= 0) return "";
@@ -110,7 +116,7 @@ export function createStatusBarFooter(
 				const left = [renderSessionStatus(separator), renderLocation()]
 					.filter(Boolean)
 					.join(` ${separator} `);
-				const right = [renderCost(), renderContextUsage()]
+				const right = [renderCacheHitRate(), renderCost(), renderContextUsage()]
 					.filter(Boolean)
 					.join("  ");
 				const gap = " ".repeat(

--- a/files/pi/agent/extensions/user/lib/status/usage.ts
+++ b/files/pi/agent/extensions/user/lib/status/usage.ts
@@ -13,6 +13,15 @@ export type Totals = {
 	latestCacheHitRate: number | undefined;
 };
 
+export type LiveAgentCostSnapshot = ReadonlyMap<string, number>;
+
+export type LiveAgentUsageTracker = {
+	snapshot(): LiveAgentCostSnapshot;
+	handleToolExecutionUpdate(event: unknown): boolean;
+	handleMessageEnd(event: unknown): boolean;
+	clear(): void;
+};
+
 type UsageCost = {
 	usage?: {
 		cost?: unknown;
@@ -23,12 +32,36 @@ type SubagentDetails = {
 	results?: unknown;
 };
 
+type ToolExecutionUpdateLike = {
+	type?: unknown;
+	toolCallId?: unknown;
+	toolName?: unknown;
+	partialResult?: {
+		details?: unknown;
+	};
+};
+
+type MessageEndLike = {
+	type?: unknown;
+	message?: {
+		role?: unknown;
+		toolCallId?: unknown;
+		toolName?: unknown;
+	};
+};
+
 function isUsageCost(value: unknown): value is UsageCost {
 	return typeof value === "object" && value !== null;
 }
 
 function getFiniteCost(value: unknown): number {
 	return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function getLiveAgentCost(details: unknown): number | undefined {
+	if (!isUsageCost(details)) return undefined;
+	const cost = details.usage?.cost;
+	return typeof cost === "number" && Number.isFinite(cost) ? cost : undefined;
 }
 
 function getChildAgentCost(message: ToolResultMessage): number {
@@ -50,7 +83,58 @@ function getChildAgentCost(message: ToolResultMessage): number {
 	return cost;
 }
 
-export function getAssistantTotals(entries: readonly SessionEntry[]): Totals {
+function getToolCallId(message: ToolResultMessage): string | undefined {
+	return typeof message.toolCallId === "string"
+		? message.toolCallId
+		: undefined;
+}
+
+export function createLiveAgentUsageTracker(): LiveAgentUsageTracker {
+	const costs = new Map<string, number>();
+
+	return {
+		snapshot() {
+			return new Map(costs);
+		},
+		handleToolExecutionUpdate(event: unknown) {
+			const ev = event as ToolExecutionUpdateLike;
+			if (ev.type !== "tool_execution_update") return false;
+			if (ev.toolName !== "agent" || typeof ev.toolCallId !== "string") {
+				return false;
+			}
+
+			const cost = getLiveAgentCost(ev.partialResult?.details);
+			if (cost === undefined) return false;
+
+			const previous = costs.get(ev.toolCallId);
+			costs.set(ev.toolCallId, cost);
+			return previous !== cost;
+		},
+		handleMessageEnd(event: unknown) {
+			const ev = event as MessageEndLike;
+			if (ev.type !== "message_end") return false;
+			const message = ev.message;
+			if (
+				message?.role !== "toolResult" ||
+				message.toolName !== "agent" ||
+				typeof message.toolCallId !== "string"
+			) {
+				return false;
+			}
+
+			const existed = costs.delete(message.toolCallId);
+			return existed;
+		},
+		clear() {
+			costs.clear();
+		},
+	};
+}
+
+export function getAssistantTotals(
+	entries: readonly SessionEntry[],
+	liveAgentCosts?: LiveAgentCostSnapshot,
+): Totals {
 	const totals: Totals = {
 		input: 0,
 		output: 0,
@@ -59,12 +143,20 @@ export function getAssistantTotals(entries: readonly SessionEntry[]): Totals {
 		cost: 0,
 		latestCacheHitRate: undefined,
 	};
+	const finalizedAgentToolCallIds = liveAgentCosts
+		? new Set<string>()
+		: undefined;
 
 	for (const entry of entries) {
 		if (entry.type !== "message") continue;
 
 		if (entry.message.role === "toolResult") {
-			totals.cost += getChildAgentCost(entry.message as ToolResultMessage);
+			const message = entry.message as ToolResultMessage;
+			totals.cost += getChildAgentCost(message);
+			if (message.toolName === "agent") {
+				const toolCallId = getToolCallId(message);
+				if (toolCallId) finalizedAgentToolCallIds?.add(toolCallId);
+			}
 			continue;
 		}
 
@@ -87,6 +179,13 @@ export function getAssistantTotals(entries: readonly SessionEntry[]): Totals {
 			latestPromptTokens > 0 ? (cacheRead / latestPromptTokens) * 100 : 0;
 		totals.latestCacheHitRate =
 			latestCacheHitRate > 0 ? latestCacheHitRate : undefined;
+	}
+
+	if (liveAgentCosts) {
+		for (const [toolCallId, cost] of liveAgentCosts) {
+			if (finalizedAgentToolCallIds?.has(toolCallId)) continue;
+			totals.cost += getFiniteCost(cost);
+		}
 	}
 
 	return totals;

--- a/files/pi/agent/extensions/user/lib/status/usage.ts
+++ b/files/pi/agent/extensions/user/lib/status/usage.ts
@@ -1,25 +1,92 @@
-import type { AssistantMessage } from "@earendil-works/pi-ai";
+import type {
+	AssistantMessage,
+	ToolResultMessage,
+} from "@earendil-works/pi-ai";
 import type { SessionEntry } from "@earendil-works/pi-coding-agent";
 
 export type Totals = {
 	input: number;
 	output: number;
+	cacheRead: number;
+	cacheWrite: number;
 	cost: number;
+	latestCacheHitRate: number | undefined;
 };
 
+type UsageCost = {
+	usage?: {
+		cost?: unknown;
+	};
+};
+
+type SubagentDetails = {
+	results?: unknown;
+};
+
+function isUsageCost(value: unknown): value is UsageCost {
+	return typeof value === "object" && value !== null;
+}
+
+function getFiniteCost(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function getChildAgentCost(message: ToolResultMessage): number {
+	if (message.toolName === "agent") {
+		const details = message.details;
+		return isUsageCost(details) ? getFiniteCost(details.usage?.cost) : 0;
+	}
+
+	if (message.toolName !== "subagent") return 0;
+
+	const details = message.details as SubagentDetails | undefined;
+	if (!Array.isArray(details?.results)) return 0;
+
+	let cost = 0;
+	for (const result of details.results) {
+		if (!isUsageCost(result)) continue;
+		cost += getFiniteCost(result.usage?.cost);
+	}
+	return cost;
+}
+
 export function getAssistantTotals(entries: readonly SessionEntry[]): Totals {
-	const totals: Totals = { input: 0, output: 0, cost: 0 };
+	const totals: Totals = {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		cost: 0,
+		latestCacheHitRate: undefined,
+	};
 
 	for (const entry of entries) {
-		if (entry.type !== "message" || entry.message.role !== "assistant")
+		if (entry.type !== "message") continue;
+
+		if (entry.message.role === "toolResult") {
+			totals.cost += getChildAgentCost(entry.message as ToolResultMessage);
 			continue;
+		}
+
+		if (entry.message.role !== "assistant") continue;
 
 		const usage = (entry.message as AssistantMessage).usage;
 		if (!usage) continue;
 
-		totals.input += usage.input ?? 0;
+		const input = usage.input ?? 0;
+		const cacheRead = usage.cacheRead ?? 0;
+		const cacheWrite = usage.cacheWrite ?? 0;
+		const latestPromptTokens = input + cacheRead + cacheWrite;
+
+		totals.input += input;
 		totals.output += usage.output ?? 0;
+		totals.cacheRead += cacheRead;
+		totals.cacheWrite += cacheWrite;
 		totals.cost += usage.cost?.total ?? 0;
+		const latestCacheHitRate =
+			latestPromptTokens > 0 ? (cacheRead / latestPromptTokens) * 100 : 0;
+		totals.latestCacheHitRate =
+			latestCacheHitRate > 0 ? latestCacheHitRate : undefined;
 	}
 
 	return totals;

--- a/files/pi/agent/extensions/user/lib/tool/agent.ts
+++ b/files/pi/agent/extensions/user/lib/tool/agent.ts
@@ -1,4 +1,5 @@
 import { fileURLToPath } from "node:url";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
 import {
 	type AgentToolResult,
 	type AgentToolUpdateCallback,
@@ -352,6 +353,28 @@ type ToolCallRecord = {
 	readonly startTime: number;
 };
 
+function addAssistantUsage(
+	current: AgentDetails["usage"] | undefined,
+	message: AssistantMessage,
+): AgentDetails["usage"] {
+	const usage = message.usage;
+	return {
+		inputTokens: (current?.inputTokens ?? 0) + (usage.input ?? 0),
+		outputTokens: (current?.outputTokens ?? 0) + (usage.output ?? 0),
+		cacheReadTokens: (current?.cacheReadTokens ?? 0) + (usage.cacheRead ?? 0),
+		cacheWriteTokens:
+			(current?.cacheWriteTokens ?? 0) + (usage.cacheWrite ?? 0),
+		totalTokens:
+			(current?.totalTokens ?? 0) +
+			(usage.totalTokens ??
+				(usage.input ?? 0) +
+					(usage.output ?? 0) +
+					(usage.cacheRead ?? 0) +
+					(usage.cacheWrite ?? 0)),
+		cost: (current?.cost ?? 0) + (usage.cost?.total ?? 0),
+	};
+}
+
 /**
  * Owns the live progress UI for a running agent: the initial "starting"
  * frame, the rolling tool tail (latest 3 tools, older ones summarized), and the
@@ -362,6 +385,7 @@ class AgentProgress {
 	private readonly toolCalls: ToolCallRecord[] = [];
 	private lastTail = "";
 	private timer: ReturnType<typeof setInterval> | undefined;
+	private usage: AgentDetails["usage"] | undefined;
 
 	constructor(
 		private readonly startedAt: number,
@@ -389,29 +413,14 @@ class AgentProgress {
 	recordToolStart(toolName: string, args: Record<string, unknown>): void {
 		this.toolCalls.push({ name: toolName, args, startTime: Date.now() });
 		this.lastTail = this.buildTail(false);
-		if (this.onUpdate) {
-			const runningLine = this.runningLine();
-			this.onUpdate({
-				content: [
-					{
-						type: "text",
-						text: `${this.lastTail}\n${runningLine}`,
-					},
-				],
-				details: {
-					_status: "running",
-					_runningLine: runningLine,
-					currentTool: toolName,
-					toolCallCount: this.count,
-					toolCalls: this.toolCalls,
-					durationMs: this.elapsedMs(),
-					title: this.title,
-					focus: this.focus,
-					prompt: this.prompt,
-				},
-			});
-		}
+		this.emitProgress();
 		this.restartRunningTimer();
+	}
+
+	/** Accumulate finalized child assistant usage and refresh parent live details. */
+	recordAssistantUsage(message: AssistantMessage): void {
+		this.usage = addAssistantUsage(this.usage, message);
+		this.emitProgress();
 	}
 
 	/** Snapshot the observed tool calls for terminal rendering. */
@@ -487,43 +496,56 @@ class AgentProgress {
 					text: `${fg(colors.muted, "(starting...)")}\n${runningLine}`,
 				},
 			],
-			details: {
-				_status: "starting",
-				_runningLine: runningLine,
-				toolCallCount: 0,
-				toolCalls: this.toolCalls,
-				durationMs: this.elapsedMs(),
-				title: this.title,
-				focus: this.focus,
-				prompt: this.prompt,
-			},
+			details: this.details("starting", runningLine),
+		});
+	}
+
+	private emitProgress(): void {
+		if (!this.onUpdate) return;
+		if (this.count === 0) {
+			this.emitStarting();
+			return;
+		}
+
+		const runningLine = this.runningLine();
+		this.onUpdate({
+			content: [
+				{
+					type: "text",
+					text: `${this.lastTail}\n${runningLine}`,
+				},
+			],
+			details: this.details(
+				"running",
+				runningLine,
+				this.toolCalls.at(-1)?.name,
+			),
 		});
 	}
 
 	private restartRunningTimer(): void {
 		clearInterval(this.timer);
 		if (!this.onUpdate) return;
-		this.timer = setInterval(() => {
-			const runningLine = this.runningLine();
-			this.onUpdate?.({
-				content: [
-					{
-						type: "text",
-						text: `${this.lastTail}\n${runningLine}`,
-					},
-				],
-				details: {
-					_status: "running",
-					_runningLine: runningLine,
-					toolCallCount: this.count,
-					toolCalls: this.toolCalls,
-					durationMs: this.elapsedMs(),
-					title: this.title,
-					focus: this.focus,
-					prompt: this.prompt,
-				},
-			});
-		}, 120);
+		this.timer = setInterval(() => this.emitProgress(), 120);
+	}
+
+	private details(
+		status: "starting" | "running",
+		runningLine: string,
+		currentTool?: string,
+	): AgentDetails {
+		return {
+			_status: status,
+			_runningLine: runningLine,
+			currentTool,
+			toolCallCount: this.count,
+			toolCalls: this.toolCalls,
+			durationMs: this.elapsedMs(),
+			title: this.title,
+			focus: this.focus,
+			prompt: this.prompt,
+			usage: this.usage,
+		};
 	}
 
 	private promptBlock(): string {
@@ -810,12 +832,22 @@ const createAgentExecute =
 			await client.start();
 
 			unsubscribe = client.onEvent((event) => {
-				if (event.type !== "tool_execution_start") return;
-				const ev = event as {
-					toolName: string;
-					args: Record<string, unknown>;
-				};
-				progress.recordToolStart(ev.toolName, ev.args ?? {});
+				if (event.type === "tool_execution_start") {
+					const ev = event as {
+						toolName: string;
+						args: Record<string, unknown>;
+					};
+					progress.recordToolStart(ev.toolName, ev.args ?? {});
+					return;
+				}
+
+				if (
+					event.type === "message_end" &&
+					event.message.role === "assistant" &&
+					event.message.usage
+				) {
+					progress.recordAssistantUsage(event.message as AssistantMessage);
+				}
 			});
 
 			await client.prompt(prompt);

--- a/tests/pi/agent/extensions/user/lib/status/footer.test.ts
+++ b/tests/pi/agent/extensions/user/lib/status/footer.test.ts
@@ -5,6 +5,7 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import { describe, it } from "vitest";
 import { createStatusBarFooter } from "#pi-user/lib/status/footer";
+import { createLiveAgentUsageTracker } from "#pi-user/lib/status/usage";
 
 function assistant(input: number, cacheRead: number): unknown {
 	return {
@@ -23,6 +24,48 @@ function assistant(input: number, cacheRead: number): unknown {
 }
 
 describe("createStatusBarFooter", () => {
+	it("includes live in-flight agent cost in the footer", () => {
+		const pi = {
+			getThinkingLevel: () => "",
+		} as unknown as ExtensionAPI;
+		const ctx = {
+			cwd: "/repo",
+			model: { id: "model" },
+			getContextUsage: () => undefined,
+			sessionManager: {
+				getBranch: () => [assistant(10, 0)],
+			},
+		} as unknown as ExtensionContext;
+		const footerData = {
+			onBranchChange: () => () => undefined,
+			getGitBranch: () => "main",
+			getExtensionStatuses: () => new Map(),
+		};
+		const liveAgentUsage = createLiveAgentUsageTracker();
+		liveAgentUsage.handleToolExecutionUpdate({
+			type: "tool_execution_update",
+			toolCallId: "call-1",
+			toolName: "agent",
+			partialResult: { details: { usage: { cost: 0.2 } } },
+		});
+
+		const footer = createStatusBarFooter(
+			pi,
+			ctx,
+			() => undefined,
+			undefined,
+			liveAgentUsage,
+		)(
+			{ requestRender: () => undefined } as never,
+			{} as never,
+			footerData as never,
+		);
+
+		const output = footer.render(200).join("\n");
+
+		assert.match(output, /\$0\.323/u);
+	});
+
 	it("scopes cache hit rate to the active branch like cost", () => {
 		const pi = {
 			getThinkingLevel: () => "",

--- a/tests/pi/agent/extensions/user/lib/status/footer.test.ts
+++ b/tests/pi/agent/extensions/user/lib/status/footer.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { describe, it } from "vitest";
+import { createStatusBarFooter } from "#pi-user/lib/status/footer";
+
+function assistant(input: number, cacheRead: number): unknown {
+	return {
+		type: "message",
+		message: {
+			role: "assistant",
+			usage: {
+				input,
+				output: 1,
+				cacheRead,
+				cacheWrite: 0,
+				cost: { total: 0.123 },
+			},
+		},
+	};
+}
+
+describe("createStatusBarFooter", () => {
+	it("scopes cache hit rate to the active branch like cost", () => {
+		const pi = {
+			getThinkingLevel: () => "",
+		} as unknown as ExtensionAPI;
+		const ctx = {
+			cwd: "/repo",
+			model: { id: "model" },
+			getContextUsage: () => undefined,
+			sessionManager: {
+				getEntries: () => [assistant(0, 100)],
+				getBranch: () => [assistant(10, 0)],
+			},
+		} as unknown as ExtensionContext;
+		const footerData = {
+			onBranchChange: () => () => undefined,
+			getGitBranch: () => "main",
+			getExtensionStatuses: () => new Map(),
+		};
+		const footer = createStatusBarFooter(pi, ctx, () => undefined)(
+			{ requestRender: () => undefined } as never,
+			{} as never,
+			footerData as never,
+		);
+
+		const output = footer.render(200).join("\n");
+
+		assert.match(output, /\$0\.123/u);
+		assert.doesNotMatch(output, /CH/u);
+	});
+});

--- a/tests/pi/agent/extensions/user/lib/status/usage.test.ts
+++ b/tests/pi/agent/extensions/user/lib/status/usage.test.ts
@@ -28,7 +28,157 @@ describe("getAssistantTotals", () => {
 		assert.deepEqual(getAssistantTotals(entries), {
 			input: 12,
 			output: 20,
+			cacheRead: 0,
+			cacheWrite: 0,
 			cost: 0.125,
+			latestCacheHitRate: undefined,
+		});
+	});
+
+	it("tracks cache tokens and latest cache hit rate", () => {
+		const entries = [
+			{
+				type: "message",
+				message: {
+					role: "assistant",
+					usage: {
+						input: 50,
+						output: 10,
+						cacheRead: 25,
+						cacheWrite: 25,
+						cost: { total: 0.01 },
+					},
+				},
+			},
+			{
+				type: "message",
+				message: {
+					role: "assistant",
+					usage: {
+						input: 20,
+						output: 5,
+						cacheRead: 80,
+						cacheWrite: 0,
+						cost: { total: 0.02 },
+					},
+				},
+			},
+		] as unknown as SessionEntry[];
+
+		assert.deepEqual(getAssistantTotals(entries), {
+			input: 70,
+			output: 15,
+			cacheRead: 105,
+			cacheWrite: 25,
+			cost: 0.03,
+			latestCacheHitRate: 80,
+		});
+	});
+
+	it("includes agent tool result cost in the displayed total", () => {
+		const entries = [
+			{
+				type: "message",
+				message: {
+					role: "assistant",
+					usage: { input: 10, output: 20, cost: { total: 0.1 } },
+				},
+			},
+			{
+				type: "message",
+				message: {
+					role: "toolResult",
+					toolName: "agent",
+					details: {
+						usage: {
+							inputTokens: 100,
+							outputTokens: 20,
+							cacheReadTokens: 10,
+							cacheWriteTokens: 0,
+							totalTokens: 130,
+							cost: 0.23,
+						},
+					},
+				},
+			},
+		] as unknown as SessionEntry[];
+
+		assert.deepEqual(getAssistantTotals(entries), {
+			input: 10,
+			output: 20,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: 0.33,
+			latestCacheHitRate: undefined,
+		});
+	});
+
+	it("includes subagent result cost in the displayed total", () => {
+		const entries = [
+			{
+				type: "message",
+				message: {
+					role: "assistant",
+					usage: { input: 10, output: 20, cost: { total: 0.1 } },
+				},
+			},
+			{
+				type: "message",
+				message: {
+					role: "toolResult",
+					toolName: "subagent",
+					details: {
+						results: [{ usage: { cost: 0.2 } }, { usage: { cost: 0.03 } }],
+					},
+				},
+			},
+		] as unknown as SessionEntry[];
+
+		assert.deepEqual(getAssistantTotals(entries), {
+			input: 10,
+			output: 20,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: 0.33,
+			latestCacheHitRate: undefined,
+		});
+	});
+
+	it("ignores malformed and non-child-agent tool result costs", () => {
+		const entries = [
+			{
+				type: "message",
+				message: {
+					role: "toolResult",
+					toolName: "bash",
+					details: { results: [{ usage: { cost: 1 } }] },
+				},
+			},
+			{
+				type: "message",
+				message: {
+					role: "toolResult",
+					toolName: "subagent",
+					details: { results: [{ usage: { cost: "0.2" } }, {}] },
+				},
+			},
+			{
+				type: "message",
+				message: {
+					role: "toolResult",
+					toolName: "agent",
+					details: { usage: { cost: Number.NaN } },
+				},
+			},
+		] as unknown as SessionEntry[];
+
+		assert.deepEqual(getAssistantTotals(entries), {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: 0,
+			latestCacheHitRate: undefined,
 		});
 	});
 });

--- a/tests/pi/agent/extensions/user/lib/status/usage.test.ts
+++ b/tests/pi/agent/extensions/user/lib/status/usage.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import type { SessionEntry } from "@earendil-works/pi-coding-agent";
 import { describe, it } from "vitest";
-import { getAssistantTotals } from "#pi-user/lib/status/usage";
+import {
+	createLiveAgentUsageTracker,
+	getAssistantTotals,
+} from "#pi-user/lib/status/usage";
 
 describe("getAssistantTotals", () => {
 	it("sums assistant usage and ignores other entries", () => {
@@ -73,6 +76,102 @@ describe("getAssistantTotals", () => {
 			cost: 0.03,
 			latestCacheHitRate: 80,
 		});
+	});
+
+	it("includes live in-flight agent cost in the displayed total", () => {
+		const entries = [
+			{
+				type: "message",
+				message: {
+					role: "assistant",
+					usage: { input: 10, output: 20, cost: { total: 0.1 } },
+				},
+			},
+		] as unknown as SessionEntry[];
+
+		assert.deepEqual(getAssistantTotals(entries, new Map([["call-1", 0.23]])), {
+			input: 10,
+			output: 20,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: 0.33,
+			latestCacheHitRate: undefined,
+		});
+	});
+
+	it("does not double count live agent cost once the final tool result exists", () => {
+		const entries = [
+			{
+				type: "message",
+				message: {
+					role: "assistant",
+					usage: { input: 10, output: 20, cost: { total: 0.1 } },
+				},
+			},
+			{
+				type: "message",
+				message: {
+					role: "toolResult",
+					toolCallId: "call-1",
+					toolName: "agent",
+					details: { usage: { cost: 0.23 } },
+				},
+			},
+		] as unknown as SessionEntry[];
+
+		assert.deepEqual(
+			getAssistantTotals(
+				entries,
+				new Map([
+					["call-1", 0.23],
+					["call-2", 0.04],
+				]),
+			),
+			{
+				input: 10,
+				output: 20,
+				cacheRead: 0,
+				cacheWrite: 0,
+				cost: 0.37,
+				latestCacheHitRate: undefined,
+			},
+		);
+	});
+
+	it("tracks live agent cost from tool execution updates and clears after tool result", () => {
+		const tracker = createLiveAgentUsageTracker();
+
+		assert.equal(
+			tracker.handleToolExecutionUpdate({
+				type: "tool_execution_update",
+				toolCallId: "call-1",
+				toolName: "agent",
+				partialResult: { details: { usage: { cost: 0.12 } } },
+			}),
+			true,
+		);
+		assert.deepEqual([...tracker.snapshot()], [["call-1", 0.12]]);
+		assert.equal(
+			tracker.handleToolExecutionUpdate({
+				type: "tool_execution_update",
+				toolCallId: "call-1",
+				toolName: "agent",
+				partialResult: { details: { usage: { cost: 0.12 } } },
+			}),
+			false,
+		);
+		assert.equal(
+			tracker.handleMessageEnd({
+				type: "message_end",
+				message: {
+					role: "toolResult",
+					toolCallId: "call-1",
+					toolName: "agent",
+				},
+			}),
+			true,
+		);
+		assert.deepEqual([...tracker.snapshot()], []);
 	});
 
 	it("includes agent tool result cost in the displayed total", () => {


### PR DESCRIPTION
## Summary

- Count child agent costs by iterating `toolResult` messages for **agent** and **subagent** results, preserving the existing subagent/result compatibility.
- Track branch-scoped cache hit rate from `cacheRead` tokens, shown as `CH{n}%` in the footer (hidden when 0%) — consistent with how cost is scoped to the active branch.
- Add live in-flight agent cost updates: a `LiveAgentUsageTracker` listens for `tool_execution_update` events on agent tools and merges the partial cost into the footer via `snapshot()`, making running agent costs visible immediately.
- Avoid double-counting after final `toolResult`: once the matching `message_end` arrives with a `toolResult`, the tracker removes the entry and the finalized cost is counted from the persisted tool result instead.
- Update `AgentProgress` to accumulate child assistant usage (`recordAssistantUsage`) and surface `usage` in the live agent tool `details` payload for consistent parent cost display.

## Background

Previously, footer usage metrics only counted `assistant` message costs. An agent tool runs a child Pi session, whose usage was only finalized in the `toolResult` message. This meant the footer cost jumped only after the agent completed, making the running cost unclear. Additionally, cache hit rate used all session entries (different scope than cost, which used only the branch entries), and child agent/subagent costs were omitted entirely. Live updates via `tool_execution_update` plus branch-scoped `cacheRead` tracking make the footer a more consistent, real-time view of the active branch's spend.