### PR TITLE
Improve Pi agent rendering UX

### DIFF
--- a/files/pi/agent/extensions/user/features/render-policy.ts
+++ b/files/pi/agent/extensions/user/features/render-policy.ts
@@ -1,0 +1,175 @@
+import type {
+	AgentToolResult,
+	ExtensionAPI,
+} from "@earendil-works/pi-coding-agent";
+import {
+	createFindTool,
+	createGrepTool,
+	createLsTool,
+	createReadTool,
+} from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import type { Feature } from "../feature";
+
+type TruncationDetails = {
+	truncation?: { truncated?: boolean };
+	matchLimitReached?: number;
+	resultLimitReached?: number;
+	entryLimitReached?: number;
+};
+
+/**
+ * Extract the full text content from a tool result.
+ */
+function extractContentText(result: AgentToolResult<unknown>): string {
+	return result.content
+		.filter((c): c is { type: "text"; text: string } => c.type === "text")
+		.map((c) => c.text)
+		.join("");
+}
+
+/**
+ * Count non-empty lines in a tool result.
+ */
+function countContentLines(result: AgentToolResult<unknown>): number {
+	const text = extractContentText(result);
+	return text.split("\n").filter((l) => l.trim().length > 0).length;
+}
+
+/**
+ * Check whether the result was truncated (details-based, not text-based).
+ */
+function isTruncated(result: AgentToolResult<unknown>): boolean {
+	const d = result.details as TruncationDetails | undefined;
+	if (!d) return false;
+	if (d.truncation?.truncated) return true;
+	if ((d.matchLimitReached ?? 0) > 0) return true;
+	if ((d.resultLimitReached ?? 0) > 0) return true;
+	if ((d.entryLimitReached ?? 0) > 0) return true;
+	return false;
+}
+
+/**
+ * Override renderResult of built-in read-only tools.
+ *
+ * - read:  shows nothing in both collapsed and expanded states (content is completely hidden)
+ * - grep:  collapsed shows dimmed count only, expanded shows full content
+ * - find:  collapsed shows dimmed count only, expanded shows full content
+ * - ls:    collapsed shows dimmed count only, expanded shows full content
+ *
+ * renderCall remains as built-in, so parameter display is unaffected.
+ * Truncation warnings are included in the content when expanded.
+ * When collapsed and also truncated, the count gets a ", truncated" suffix.
+ */
+export function createRenderPolicyFeature(): Feature {
+	return {
+		name: "render-policy",
+		register(pi: ExtensionAPI) {
+			const cwd = process.cwd();
+			const originalRead = createReadTool(cwd);
+			const originalGrep = createGrepTool(cwd);
+			const originalFind = createFindTool(cwd);
+			const originalLs = createLsTool(cwd);
+
+			// ---------------------------------------------------------------
+			// read: shows nothing regardless of collapsed/expanded state
+			// ---------------------------------------------------------------
+			pi.registerTool({
+				name: "read",
+				label: "read",
+				description: originalRead.description,
+				parameters: originalRead.parameters,
+
+				execute(id, params, signal, onUpdate) {
+					return originalRead.execute(id, params, signal, onUpdate);
+				},
+
+				renderResult(_result, { isPartial }, theme) {
+					if (isPartial)
+						return new Text(theme.fg("warning", "Reading..."), 0, 0);
+					return new Text("", 0, 0);
+				},
+			});
+
+			// ---------------------------------------------------------------
+			// grep: collapsed → count only, expanded → full content
+			// ---------------------------------------------------------------
+			pi.registerTool({
+				name: "grep",
+				label: "grep",
+				description: originalGrep.description,
+				parameters: originalGrep.parameters,
+
+				execute(id, params, signal, onUpdate) {
+					return originalGrep.execute(id, params, signal, onUpdate);
+				},
+
+				renderResult(result, { expanded, isPartial }, theme) {
+					if (isPartial)
+						return new Text(theme.fg("warning", "Searching..."), 0, 0);
+					if (!expanded) {
+						const count = countContentLines(result);
+						const truncated = isTruncated(result);
+						const suffix = truncated ? theme.fg("warning", ", truncated") : "";
+						return new Text(theme.fg("dim", `${count} matches`) + suffix, 0, 0);
+					}
+					return new Text(extractContentText(result), 0, 0);
+				},
+			});
+
+			// ---------------------------------------------------------------
+			// find: collapsed → count only, expanded → full content
+			// ---------------------------------------------------------------
+			pi.registerTool({
+				name: "find",
+				label: "find",
+				description: originalFind.description,
+				parameters: originalFind.parameters,
+
+				execute(id, params, signal, onUpdate) {
+					return originalFind.execute(id, params, signal, onUpdate);
+				},
+
+				renderResult(result, { expanded, isPartial }, theme) {
+					if (isPartial)
+						return new Text(theme.fg("warning", "Searching..."), 0, 0);
+					if (!expanded) {
+						const count = countContentLines(result);
+						const truncated = isTruncated(result);
+						const suffix = truncated ? theme.fg("warning", ", truncated") : "";
+						return new Text(theme.fg("dim", `${count} files`) + suffix, 0, 0);
+					}
+					return new Text(extractContentText(result), 0, 0);
+				},
+			});
+
+			// ---------------------------------------------------------------
+			// ls: collapsed → count only, expanded → full content
+			// ---------------------------------------------------------------
+			pi.registerTool({
+				name: "ls",
+				label: "ls",
+				description: originalLs.description,
+				parameters: originalLs.parameters,
+
+				execute(id, params, signal, onUpdate) {
+					return originalLs.execute(id, params, signal, onUpdate);
+				},
+
+				renderResult(result, { expanded, isPartial }, theme) {
+					if (isPartial)
+						return new Text(theme.fg("warning", "Listing..."), 0, 0);
+					if (!expanded) {
+						const count = countContentLines(result);
+						const truncated = isTruncated(result);
+						const suffix = truncated ? theme.fg("warning", ", truncated") : "";
+						return new Text(theme.fg("dim", `${count} entries`) + suffix, 0, 0);
+					}
+					return new Text(extractContentText(result), 0, 0);
+				},
+			});
+		},
+	};
+}
+
+export default createRenderPolicyFeature;

--- a/files/pi/agent/extensions/user/features/render-policy.ts
+++ b/files/pi/agent/extensions/user/features/render-policy.ts
@@ -1,14 +1,17 @@
 import type {
 	AgentToolResult,
 	ExtensionAPI,
+	Theme,
+	ToolRenderResultOptions,
 } from "@earendil-works/pi-coding-agent";
 import {
-	createFindTool,
-	createGrepTool,
-	createLsTool,
-	createReadTool,
+	createFindToolDefinition,
+	createGrepToolDefinition,
+	createLsToolDefinition,
+	createReadToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
+import type { Component } from "@earendil-works/pi-tui";
 import type { Feature } from "../feature";
 
 type TruncationDetails = {
@@ -49,9 +52,58 @@ function isTruncated(result: AgentToolResult<unknown>): boolean {
 	return false;
 }
 
+function isErrorResult(
+	result: AgentToolResult<unknown>,
+	context: unknown,
+): boolean {
+	if ((context as { isError?: boolean }).isError === true) return true;
+	return (
+		(result as AgentToolResult<unknown> & { isError?: boolean }).isError ===
+		true
+	);
+}
+
+type OriginalResultRenderer = {
+	renderResult?: (
+		result: AgentToolResult<unknown>,
+		options: ToolRenderResultOptions,
+		theme: Theme,
+		context: never,
+	) => Component;
+};
+
+class TrimLeadingBlankLines implements Component {
+	constructor(private readonly component: Component) {}
+
+	render(width: number): string[] {
+		const lines = [...this.component.render(width)];
+		while (lines[0]?.trim() === "") lines.shift();
+		return lines;
+	}
+
+	invalidate(): void {
+		this.component.invalidate();
+	}
+}
+
+function renderOriginalErrorResult(
+	originalTool: unknown,
+	result: AgentToolResult<unknown>,
+	options: ToolRenderResultOptions,
+	theme: Theme,
+	context: unknown,
+): Component {
+	const renderer = (originalTool as OriginalResultRenderer).renderResult;
+	const component =
+		renderer?.(result, options, theme, context as never) ??
+		new Text(extractContentText(result), 0, 0);
+	return new TrimLeadingBlankLines(component);
+}
+
 /**
  * Override renderResult of built-in read-only tools.
  *
+ * - error results are always shown
  * - read:  shows nothing in both collapsed and expanded states (content is completely hidden)
  * - grep:  collapsed shows dimmed count only, expanded shows full content
  * - find:  collapsed shows dimmed count only, expanded shows full content
@@ -66,10 +118,10 @@ export function createRenderPolicyFeature(): Feature {
 		name: "render-policy",
 		register(pi: ExtensionAPI) {
 			const cwd = process.cwd();
-			const originalRead = createReadTool(cwd);
-			const originalGrep = createGrepTool(cwd);
-			const originalFind = createFindTool(cwd);
-			const originalLs = createLsTool(cwd);
+			const originalRead = createReadToolDefinition(cwd);
+			const originalGrep = createGrepToolDefinition(cwd);
+			const originalFind = createFindToolDefinition(cwd);
+			const originalLs = createLsToolDefinition(cwd);
 
 			// ---------------------------------------------------------------
 			// read: shows nothing regardless of collapsed/expanded state
@@ -80,13 +132,21 @@ export function createRenderPolicyFeature(): Feature {
 				description: originalRead.description,
 				parameters: originalRead.parameters,
 
-				execute(id, params, signal, onUpdate) {
-					return originalRead.execute(id, params, signal, onUpdate);
+				execute(id, params, signal, onUpdate, ctx) {
+					return originalRead.execute(id, params, signal, onUpdate, ctx);
 				},
 
-				renderResult(_result, { isPartial }, theme) {
-					if (isPartial)
+				renderResult(result, options, theme, context) {
+					if (options.isPartial)
 						return new Text(theme.fg("warning", "Reading..."), 0, 0);
+					if (isErrorResult(result, context))
+						return renderOriginalErrorResult(
+							originalRead,
+							result,
+							options,
+							theme,
+							context,
+						);
 					return new Text("", 0, 0);
 				},
 			});
@@ -100,14 +160,22 @@ export function createRenderPolicyFeature(): Feature {
 				description: originalGrep.description,
 				parameters: originalGrep.parameters,
 
-				execute(id, params, signal, onUpdate) {
-					return originalGrep.execute(id, params, signal, onUpdate);
+				execute(id, params, signal, onUpdate, ctx) {
+					return originalGrep.execute(id, params, signal, onUpdate, ctx);
 				},
 
-				renderResult(result, { expanded, isPartial }, theme) {
-					if (isPartial)
+				renderResult(result, options, theme, context) {
+					if (options.isPartial)
 						return new Text(theme.fg("warning", "Searching..."), 0, 0);
-					if (!expanded) {
+					if (isErrorResult(result, context))
+						return renderOriginalErrorResult(
+							originalGrep,
+							result,
+							options,
+							theme,
+							context,
+						);
+					if (!options.expanded) {
 						const count = countContentLines(result);
 						const truncated = isTruncated(result);
 						const suffix = truncated ? theme.fg("warning", ", truncated") : "";
@@ -126,14 +194,22 @@ export function createRenderPolicyFeature(): Feature {
 				description: originalFind.description,
 				parameters: originalFind.parameters,
 
-				execute(id, params, signal, onUpdate) {
-					return originalFind.execute(id, params, signal, onUpdate);
+				execute(id, params, signal, onUpdate, ctx) {
+					return originalFind.execute(id, params, signal, onUpdate, ctx);
 				},
 
-				renderResult(result, { expanded, isPartial }, theme) {
-					if (isPartial)
+				renderResult(result, options, theme, context) {
+					if (options.isPartial)
 						return new Text(theme.fg("warning", "Searching..."), 0, 0);
-					if (!expanded) {
+					if (isErrorResult(result, context))
+						return renderOriginalErrorResult(
+							originalFind,
+							result,
+							options,
+							theme,
+							context,
+						);
+					if (!options.expanded) {
 						const count = countContentLines(result);
 						const truncated = isTruncated(result);
 						const suffix = truncated ? theme.fg("warning", ", truncated") : "";
@@ -152,14 +228,22 @@ export function createRenderPolicyFeature(): Feature {
 				description: originalLs.description,
 				parameters: originalLs.parameters,
 
-				execute(id, params, signal, onUpdate) {
-					return originalLs.execute(id, params, signal, onUpdate);
+				execute(id, params, signal, onUpdate, ctx) {
+					return originalLs.execute(id, params, signal, onUpdate, ctx);
 				},
 
-				renderResult(result, { expanded, isPartial }, theme) {
-					if (isPartial)
+				renderResult(result, options, theme, context) {
+					if (options.isPartial)
 						return new Text(theme.fg("warning", "Listing..."), 0, 0);
-					if (!expanded) {
+					if (isErrorResult(result, context))
+						return renderOriginalErrorResult(
+							originalLs,
+							result,
+							options,
+							theme,
+							context,
+						);
+					if (!options.expanded) {
 						const count = countContentLines(result);
 						const truncated = isTruncated(result);
 						const suffix = truncated ? theme.fg("warning", ", truncated") : "";

--- a/files/pi/agent/extensions/user/features/turn-metrics.ts
+++ b/files/pi/agent/extensions/user/features/turn-metrics.ts
@@ -25,6 +25,7 @@ const DEFAULT_INDICATOR_FRAMES = [
 	"⠏",
 ] as const;
 const DEFAULT_INDICATOR_INTERVAL_MS = 80;
+const THOUGHT_METRICS_DISPLAY_MS = 2000;
 
 type WorkPhase = "Thinking" | "Working";
 type PhaseColor = "accent" | "warning";
@@ -123,7 +124,7 @@ function register(pi: ExtensionAPI): void {
 			thinkingStartedAt = now;
 			thoughtDisplayUntil = undefined;
 		} else {
-			thoughtDisplayUntil = now + 1000;
+			thoughtDisplayUntil = now + THOUGHT_METRICS_DISPLAY_MS;
 		}
 	}
 

--- a/files/pi/agent/extensions/user/features/turn-metrics.ts
+++ b/files/pi/agent/extensions/user/features/turn-metrics.ts
@@ -115,12 +115,13 @@ function register(pi: ExtensionAPI): void {
 		if (phase === nextPhase) return;
 
 		if (phase === "Thinking" && thinkingStartedAt !== undefined) {
-			completedThinkingMs += now - thinkingStartedAt;
+			completedThinkingMs = now - thinkingStartedAt; // reset per period
 			thinkingStartedAt = undefined;
 		}
 
 		phase = nextPhase;
 		if (phase === "Thinking") {
+			completedThinkingMs = 0; // reset cumulative — show only current period
 			thinkingStartedAt = now;
 			thoughtDisplayUntil = undefined;
 		} else {
@@ -138,10 +139,17 @@ function register(pi: ExtensionAPI): void {
 
 	function buildLiveMetrics(now = Date.now()): string {
 		if (phase === "Thinking") {
-			return `${formatLiveElapsed(getThinkingElapsedMs(now))} thinking`;
+			const thinkingMs = getThinkingElapsedMs(now);
+			return thinkingMs < 1000
+				? "small thought"
+				: `${formatLiveElapsed(thinkingMs)} thinking`;
 		}
 		if (thoughtDisplayUntil !== undefined && now < thoughtDisplayUntil) {
-			return `${getLiveElapsed(now)} total · ${formatLiveElapsedDecimal(completedThinkingMs)} thought`;
+			const thoughtDuration =
+				completedThinkingMs < 1000
+					? "small thought"
+					: `${formatLiveElapsedDecimal(completedThinkingMs)} thought`;
+			return `${getLiveElapsed(now)} total · ${thoughtDuration}`;
 		}
 		return getLiveElapsed(now);
 	}

--- a/files/pi/agent/extensions/user/features/turn-metrics.ts
+++ b/files/pi/agent/extensions/user/features/turn-metrics.ts
@@ -4,7 +4,11 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import type { Feature } from "../feature";
 import { ENTER_FOCUS_TOOL, isTerminatingFocusResult } from "../lib/focus";
-import { formatHumanElapsed, formatLiveElapsed } from "../lib/time";
+import {
+	formatHumanElapsed,
+	formatLiveElapsed,
+	formatLiveElapsedDecimal,
+} from "../lib/time";
 
 const WIDGET_KEY = "turn-metrics";
 const TICK_MS = 1000;
@@ -133,12 +137,10 @@ function register(pi: ExtensionAPI): void {
 
 	function buildLiveMetrics(now = Date.now()): string {
 		if (phase === "Thinking") {
-			return `${getLiveElapsed(now)} total · ${formatLiveElapsed(
-				getThinkingElapsedMs(now),
-			)} thinking`;
+			return `${formatLiveElapsed(getThinkingElapsedMs(now))} thinking`;
 		}
 		if (thoughtDisplayUntil !== undefined && now < thoughtDisplayUntil) {
-			return `${getLiveElapsed(now)} total · ${formatLiveElapsed(completedThinkingMs)} thought`;
+			return `${getLiveElapsed(now)} total · ${formatLiveElapsedDecimal(completedThinkingMs)} thought`;
 		}
 		return getLiveElapsed(now);
 	}

--- a/files/pi/agent/extensions/user/lib/file/apply-patch.ts
+++ b/files/pi/agent/extensions/user/lib/file/apply-patch.ts
@@ -44,7 +44,7 @@ type ApplyPatchDetails = {
 
 const lineNoSchema = Type.Integer({ minimum: 1 });
 
-const targetLineNoRangeSchema = Type.Object({
+const allowedReplacementLineRangeSchema = Type.Object({
 	start: lineNoSchema,
 	end: lineNoSchema,
 });
@@ -54,10 +54,10 @@ const replaceSchema = Type.Object({
 	newText: Type.String(),
 	startLineNo: Type.Optional(lineNoSchema),
 	endLineNo: Type.Optional(lineNoSchema),
-	targetLineNoRanges: Type.Optional(
-		Type.Array(targetLineNoRangeSchema, {
+	allowedReplacementLineRanges: Type.Optional(
+		Type.Array(allowedReplacementLineRangeSchema, {
 			description:
-				"Optional safe 1-based line number ranges that contain only intended oldText replacements. When omitted, the whole file is searched.",
+				"Optional 1-based line ranges where exact oldText replacement is allowed. oldText must match exactly, including whitespace and newlines. Use the smallest ranges that include the intended replacements; avoid broad ranges such as the whole file. These ranges limit where replacement may occur; they are not replaced by themselves.",
 		}),
 	),
 });
@@ -72,7 +72,7 @@ export const applyPatchSchema = Type.Object({
 	replaces: Type.Optional(
 		Type.Array(replaceSchema, {
 			description:
-				"Replace oldText with newText. If oldText matches multiple locations, use startLineNo/endLineNo or targetLineNoRanges to specify a safe range that contains only intended replacements.",
+				"Replace oldText with newText. oldText must match exactly, including whitespace and newlines. If line numbers can make the edit unambiguous, use allowedReplacementLineRanges with concise oldText and the smallest suitable line ranges to save tokens; use wider oldText only when needed, such as multiple matches on the same line.",
 		}),
 	),
 	removeLineRanges: Type.Optional(
@@ -228,7 +228,7 @@ function collectLineRangeUsage(
 	}
 }
 
-function assertTargetLineNoRange(
+function assertAllowedReplacementLineRange(
 	index: LineIndex,
 	start: number,
 	end: number,
@@ -299,17 +299,17 @@ function createSequentialReplaceEdits(
 			`replaces[${replaceIndex}] must specify both startLineNo and endLineNo, or neither.`,
 		);
 	}
-	if ((replace.targetLineNoRanges?.length ?? 0) > 0) {
+	if ((replace.allowedReplacementLineRanges?.length ?? 0) > 0) {
 		if (hasStart || hasEnd) {
 			throw new Error(
-				`replaces[${replaceIndex}] must specify either startLineNo/endLineNo or targetLineNoRanges, not both.`,
+				`replaces[${replaceIndex}] must specify either startLineNo/endLineNo or allowedReplacementLineRanges, not both.`,
 			);
 		}
 		for (const [rangeIndex, range] of (
-			replace.targetLineNoRanges ?? []
+			replace.allowedReplacementLineRanges ?? []
 		).entries()) {
-			const label = `replaces[${replaceIndex}].targetLineNoRanges[${rangeIndex}]`;
-			assertTargetLineNoRange(index, range.start, range.end, label);
+			const label = `replaces[${replaceIndex}].allowedReplacementLineRanges[${rangeIndex}]`;
+			assertAllowedReplacementLineRange(index, range.start, range.end, label);
 			const chars = rangeContentChars(index, range.start, range.end);
 			const positions = findOccurrences(
 				text.slice(chars.start, chars.end),
@@ -318,7 +318,7 @@ function createSequentialReplaceEdits(
 			);
 			if (positions.length === 0) {
 				throw new Error(
-					`${label} oldText did not match within the target line range.`,
+					`${label} oldText did not match within the allowed replacement line range.`,
 				);
 			}
 			assertNoSameLineMatches(index, positions, label);
@@ -349,7 +349,7 @@ function createSequentialReplaceEdits(
 		throw new Error(`replaces[${replaceIndex}] oldText was not found.`);
 	if (positions.length > 1) {
 		throw new Error(
-			`replaces[${replaceIndex}] oldText matched multiple locations.\nSpecify targetLineNoRanges for a safe range that contains only intended replacements.\nMatched lines: ${matchedLinesSummary(index, positions)}.${multipleMatchesOnSameLineWarning(index, positions)}`,
+			`replaces[${replaceIndex}] oldText matched multiple locations.\nSpecify allowedReplacementLineRanges with the smallest line ranges that contain only intended replacements.\nMatched lines: ${matchedLinesSummary(index, positions)}.${multipleMatchesOnSameLineWarning(index, positions)}`,
 		);
 	}
 	const start = positions[0] ?? 0;
@@ -431,17 +431,17 @@ function createEdits(text: string, params: ApplyPatchToolInput): TextEdit[] {
 				`replaces[${i}] must specify both startLineNo and endLineNo, or neither.`,
 			);
 		}
-		if ((replace.targetLineNoRanges?.length ?? 0) > 0) {
+		if ((replace.allowedReplacementLineRanges?.length ?? 0) > 0) {
 			if (hasStart || hasEnd) {
 				throw new Error(
-					`replaces[${i}] must specify either startLineNo/endLineNo or targetLineNoRanges, not both.`,
+					`replaces[${i}] must specify either startLineNo/endLineNo or allowedReplacementLineRanges, not both.`,
 				);
 			}
 			for (const [rangeIndex, range] of (
-				replace.targetLineNoRanges ?? []
+				replace.allowedReplacementLineRanges ?? []
 			).entries()) {
-				const label = `replaces[${i}].targetLineNoRanges[${rangeIndex}]`;
-				assertTargetLineNoRange(index, range.start, range.end, label);
+				const label = `replaces[${i}].allowedReplacementLineRanges[${rangeIndex}]`;
+				assertAllowedReplacementLineRange(index, range.start, range.end, label);
 				const chars = rangeContentChars(index, range.start, range.end);
 				const positions = findOccurrences(
 					text.slice(chars.start, chars.end),
@@ -450,7 +450,7 @@ function createEdits(text: string, params: ApplyPatchToolInput): TextEdit[] {
 				);
 				if (positions.length === 0) {
 					throw new Error(
-						`${label} oldText did not match within the target line range.`,
+						`${label} oldText did not match within the allowed replacement line range.`,
 					);
 				}
 				assertNoSameLineMatches(index, positions, label);
@@ -483,7 +483,7 @@ function createEdits(text: string, params: ApplyPatchToolInput): TextEdit[] {
 			throw new Error(`replaces[${i}] oldText was not found.`);
 		if (positions.length > 1) {
 			throw new Error(
-				`replaces[${i}] oldText matched multiple locations.\nSpecify targetLineNoRanges for a safe range that contains only intended replacements.\nMatched lines: ${matchedLinesSummary(index, positions)}.${multipleMatchesOnSameLineWarning(index, positions)}`,
+				`replaces[${i}] oldText matched multiple locations.\nSpecify allowedReplacementLineRanges with the smallest line ranges that contain only intended replacements.\nMatched lines: ${matchedLinesSummary(index, positions)}.${multipleMatchesOnSameLineWarning(index, positions)}`,
 			);
 		}
 		const start = positions[0] ?? 0;

--- a/files/pi/agent/extensions/user/lib/time.ts
+++ b/files/pi/agent/extensions/user/lib/time.ts
@@ -28,6 +28,10 @@ export function formatHumanElapsed(ms: number): string {
 }
 
 export function formatLiveElapsed(ms: number): string {
+	return ms < 60_000 ? `${elapsedSeconds(ms)}s` : formatHumanElapsed(ms);
+}
+
+export function formatLiveElapsedDecimal(ms: number): string {
 	return ms < 60_000
 		? `${Math.max(0, ms / 1000).toFixed(1)}s`
 		: formatHumanElapsed(ms);

--- a/files/pi/agent/extensions/user/lib/tool/agent.ts
+++ b/files/pi/agent/extensions/user/lib/tool/agent.ts
@@ -266,12 +266,20 @@ function renderAgentResult(
 	return new Text(expandedText, 0, 0);
 }
 
+function firstLine(value: string): { text: string; omittedLines: boolean } {
+	const lineBreak = /\r\n|\n|\r/u.exec(value);
+	if (!lineBreak) return { text: value, omittedLines: false };
+	return { text: value.slice(0, lineBreak.index), omittedLines: true };
+}
+
 /** Format a single tool-call argument value for display. */
 function formatArg(v: unknown, options: { truncate: boolean }): string {
 	if (typeof v === "string") {
-		return options.truncate && v.length > 80
-			? `"${v.slice(0, 80)}…"`
-			: `"${v}"`;
+		const { text, omittedLines } = firstLine(v);
+		const truncated = options.truncate && text.length > 80;
+		const display = truncated ? text.slice(0, 80) : text;
+		const suffix = omittedLines || truncated ? "…" : "";
+		return `"${display}${suffix}"`;
 	}
 	if (typeof v === "number" || typeof v === "boolean" || v == null) {
 		return String(v);

--- a/files/pi/agent/extensions/user/lib/tool/agent.ts
+++ b/files/pi/agent/extensions/user/lib/tool/agent.ts
@@ -441,12 +441,6 @@ class AgentProgress {
 		return formatLiveElapsed(this.elapsedMs());
 	}
 
-	private toolUsageSuffix(): string {
-		return this.count > 0
-			? ` (${this.count} tool${this.count !== 1 ? "s" : ""} used)`
-			: "";
-	}
-
 	private get runningIcon(): string {
 		return Math.floor(this.elapsedMs() / 600) % 2 === 0 ? "◉" : "○";
 	}
@@ -484,7 +478,7 @@ class AgentProgress {
 	}
 
 	private runningLine(): string {
-		return `${fg(colors.positive, this.runningIcon)} ${this.glossyRunningLabel}  ${this.elapsedLabel()}${this.toolUsageSuffix()}`;
+		return `${fg(colors.positive, this.runningIcon)} ${this.glossyRunningLabel}  ${this.elapsedLabel()}`;
 	}
 
 	private emitStarting(): void {

--- a/files/pi/agent/extensions/user/lib/tool/agent.ts
+++ b/files/pi/agent/extensions/user/lib/tool/agent.ts
@@ -125,15 +125,6 @@ type AgentResult = AgentToolResult<AgentDetails>;
 /** A result flagged as an error (the `isError` flag is an extension of the base shape). */
 type AgentErrorResult = AgentResult & { isError: true };
 
-const MAX_TITLE_LEN = 30;
-
-/** Truncate a label to `MAX_TITLE_LEN`, appending an ellipsis when clipped. */
-function truncateTitle(label: string): string {
-	return label.length > MAX_TITLE_LEN
-		? `${label.slice(0, MAX_TITLE_LEN)}…`
-		: label;
-}
-
 function truncateMiddleToWidth(text: string, width: number): string {
 	if (visibleWidth(text) <= width) return text;
 	if (width <= 1) return truncateToWidth(text, width, "");
@@ -178,13 +169,12 @@ class OneLinePerRowText implements Component {
 /** Format the one-line call display: `agent <title> in <focus>`. */
 function renderAgentCall(rawArgs: unknown, theme: Theme): Component {
 	const args = rawArgs as AgentInput;
-	const titlePart = args.title ? truncateTitle(args.title) : null;
-	const titleDisplay = titlePart ?? theme.fg("dim", "...");
-	const inPart = theme.fg("dim", " in ");
-	const focusDisplay = args.focus
-		? theme.fg("warning", args.focus)
+	const titlePart = args.title || null;
+	const titleDisplay = titlePart
+		? theme.fg("accent", titlePart)
 		: theme.fg("dim", "...");
-	const text = `${theme.bold("agent")} ${titleDisplay}${inPart}${focusDisplay}`;
+	const focusPart = theme.fg("toolOutput", ` in ${args.focus || "..."}`);
+	const text = `${theme.bold("agent")} ${titleDisplay}${focusPart}`;
 	return new Text(text, 0, 0);
 }
 
@@ -718,7 +708,7 @@ const createAgentExecute =
 			}
 		}
 		const { focus, prompt, title } = input;
-		const header = `${truncateTitle(title ?? focus)} (focus=${focus})`;
+		const header = `${title ?? focus} (focus=${focus})`;
 		const startedAt = Date.now();
 		const progress = new AgentProgress(
 			startedAt,

--- a/files/pi/agent/extensions/user/lib/tool/builtin.ts
+++ b/files/pi/agent/extensions/user/lib/tool/builtin.ts
@@ -51,7 +51,7 @@ function registerFileTools(catalog: ToolCatalog): void {
 				name: "apply_patch",
 				label: "apply_patch",
 				description:
-					"Apply one or more edits to a single file using pre-edit 1-based line numbers and/or text replacement. Supports replaces, removeLineRanges, and insertLines in one call.",
+					"Apply one or more edits to a single file using pre-edit 1-based line numbers and/or exact text replacement. Supports replaces, removeLineRanges, and insertLines in one call.",
 				promptSnippet: "Apply multiple edits to one file",
 				promptGuidelines: [
 					"Use path plus the operation array that matches the edit: replaces for changing existing text, removeLineRanges for deleting whole lines, and insertLines for adding lines.",
@@ -60,7 +60,8 @@ function registerFileTools(catalog: ToolCatalog): void {
 					"Read the target file immediately before line-number based edits; after applying one patch, read again before another line-number based patch because line numbers may have shifted.",
 					"Keep non-replace operations on separate lines: removeLineRanges and insertLines reserve their target lines so overlapping edits fail instead of guessing order.",
 					"For insertLines, choose exactly one insertion point: insertAfterLineNo or insertBeforeLineNo.",
-					"When replaces.oldText matches multiple lines, set startLineNo/endLineNo or targetLineNoRanges to a safe range that contains all intended replacements and excludes unintended ones.",
+					"For replaces, oldText must match exactly, including whitespace and newlines.",
+					"When line numbers can make a replacement unambiguous, prefer allowedReplacementLineRanges with concise oldText and the smallest suitable line ranges; avoid broad ranges such as the whole file.",
 					"When the same line contains multiple oldText matches, make oldText wider (for example the full line or surrounding phrase) because line ranges cannot choose between matches on one line.",
 					"Multiple replaces run in order on temporary text before the file is written, so a later replace can match text produced by an earlier replace and any failure leaves the file unchanged.",
 				],

--- a/files/pi/agent/extensions/user/lib/tool/github.ts
+++ b/files/pi/agent/extensions/user/lib/tool/github.ts
@@ -176,13 +176,18 @@ const createPullRequestSchema = Type.Object({
 		description:
 			"Name of the working branch to use. If the current branch already matches, it is reused; otherwise a new branch is created. Must not be the repository default branch.",
 	}),
-	commitFiles: Type.Array(Type.String(), {
-		description:
-			"Explicit list of files to stage and commit. Existing listed files are staged; only listed files are committed.",
-	}),
-	commitMessage: Type.String({
-		description: "Commit message for the new commit.",
-	}),
+	commitFiles: Type.Optional(
+		Type.Array(Type.String(), {
+			description:
+				"Optional explicit list of files to stage and commit. Existing listed files are staged; only listed files are committed. Omit when the branch already has commits for the PR.",
+		}),
+	),
+	commitMessage: Type.Optional(
+		Type.String({
+			description:
+				"Commit message for the new commit. Required when commitFiles is provided.",
+		}),
+	),
 	title: Type.String({ description: "Pull request title." }),
 	body: Type.String({ description: "Pull request body." }),
 });
@@ -1045,11 +1050,13 @@ async function createPullRequest(
 	signal: AbortSignal | undefined,
 ): Promise<GithubToolOutput> {
 	const branchName = requireNonEmpty(params.branchName, "branchName");
-	const commitMessage = requireNonEmpty(params.commitMessage, "commitMessage");
 	const title = requireNonEmpty(params.title, "title");
 	const body = requireNonEmpty(params.body, "body");
-	if (params.commitFiles.length === 0) {
-		throw new Error("commitFiles must not be empty.");
+	if (params.commitFiles !== undefined) {
+		if (params.commitFiles.length === 0) {
+			throw new Error("commitFiles must not be empty.");
+		}
+		requireNonEmpty(params.commitMessage, "commitMessage");
 	}
 
 	const commands: string[] = [];
@@ -1070,13 +1077,19 @@ async function createPullRequest(
 			commands,
 		);
 	}
-	await stageAndCommitFiles(
-		cwd,
-		params.commitFiles,
-		commitMessage,
-		signal,
-		commands,
-	);
+	if (params.commitFiles !== undefined) {
+		const commitMessage = requireNonEmpty(
+			params.commitMessage,
+			"commitMessage",
+		);
+		await stageAndCommitFiles(
+			cwd,
+			params.commitFiles,
+			commitMessage,
+			signal,
+			commands,
+		);
+	}
 	await runCommand(
 		"git",
 		cwd,
@@ -1329,10 +1342,10 @@ export function registerGithubTools(catalog: ToolCatalog): void {
 		name: "create_pull_request",
 		label: "create pull request",
 		description:
-			"Create a new draft pull request from specified commit files. Reuses the current branch when it matches branchName; otherwise creates a new branch. Stages existing listed files, commits only listed files, pushes, and opens a draft PR with gh.",
+			"Create a new draft pull request. Reuses the current branch when it matches branchName; otherwise creates a new branch. When commitFiles is provided, stages existing listed files and commits only listed files. Then pushes and opens a draft PR with gh.",
 		parameters: createPullRequestSchema,
-		promptSnippet: "Create a draft pull request from explicit files",
-		extractSecretPaths: (input) => input.commitFiles,
+		promptSnippet: "Create a draft pull request",
+		extractSecretPaths: (input) => input.commitFiles ?? [],
 		write: true,
 		execute: createPullRequest,
 	});

--- a/files/pi/agent/extensions/user/main.ts
+++ b/files/pi/agent/extensions/user/main.ts
@@ -6,6 +6,7 @@ import { createExitConfirmFeature } from "./features/exit-confirm";
 import { createFocusFeature } from "./features/focus";
 import { createPromptRefineFeature } from "./features/prompt-refine";
 import { createQuickActionsFeature } from "./features/quick-actions";
+import { createRenderPolicyFeature } from "./features/render-policy";
 import { createStatusFeature } from "./features/status";
 import { createSystemRemindersFeature } from "./features/system-reminders";
 import { createThinkingFeature } from "./features/thinking";
@@ -24,6 +25,7 @@ function createFeatures(): readonly Feature[] {
 		createPromptRefineFeature(),
 		createThinkingFeature(),
 		createTmuxNoticeFeature(),
+		createRenderPolicyFeature(),
 		createToolFeature(),
 	];
 }

--- a/tests/pi/agent/extensions/user/features/render-policy.test.ts
+++ b/tests/pi/agent/extensions/user/features/render-policy.test.ts
@@ -1,0 +1,290 @@
+import assert from "node:assert/strict";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import type { Component } from "@earendil-works/pi-tui";
+import { describe, it } from "vitest";
+import { createRenderPolicyFeature } from "#pi-user/features/render-policy";
+
+type ToolDef = {
+	name: string;
+	label?: string;
+	description?: string;
+	parameters?: unknown;
+	execute?: (...args: unknown[]) => unknown;
+	renderResult?: (
+		result: { content: unknown[]; details?: unknown; isError?: boolean },
+		options: { expanded: boolean; isPartial: boolean },
+		theme: Theme,
+		_context: unknown,
+	) => Component;
+};
+
+type Harness = {
+	findTool(name: string): ToolDef;
+};
+
+function makeTheme(): Theme {
+	return {
+		fg(_name: string, text: string) {
+			return text;
+		},
+		bold(text: string) {
+			return text;
+		},
+	} as unknown as Theme;
+}
+
+function makeResult(overrides?: {
+	lines?: string[];
+	details?: unknown;
+	isError?: boolean;
+}): {
+	content: { type: "text"; text: string }[];
+	details?: unknown;
+	isError?: boolean;
+} {
+	return {
+		content: [{ type: "text", text: (overrides?.lines ?? []).join("\n") }],
+		details: overrides?.details,
+		isError: overrides?.isError ?? false,
+	};
+}
+
+function renderText(component: Component): string {
+	const lines = component.render(120);
+	return lines.map((l) => l.trimEnd()).join("\n");
+}
+
+function createHarness(): Harness {
+	const tools = new Map<string, ToolDef>();
+	const pi = {
+		registerTool(def: ToolDef) {
+			tools.set(def.name, def);
+		},
+	} as never;
+
+	createRenderPolicyFeature().register(pi, {} as never);
+
+	return {
+		findTool(name: string) {
+			const tool = tools.get(name);
+			assert.ok(tool, `Tool "${name}" was not registered`);
+			return tool!;
+		},
+	};
+}
+
+const theme = makeTheme();
+const noCtx = {};
+
+// ────────────────────────────────────────────────────────
+// read
+// ────────────────────────────────────────────────────────
+describe("read renderResult", () => {
+	const read = createHarness().findTool("read");
+
+	it("returns empty for completed result (collapsed)", () => {
+		const result = makeResult({ lines: ["a", "b", "c"] });
+		const component = read.renderResult!(
+			result,
+			{ expanded: false, isPartial: false },
+			theme,
+			noCtx,
+		);
+		assert.equal(renderText(component), "");
+	});
+
+	it("returns empty for completed result (expanded)", () => {
+		const result = makeResult({ lines: ["a", "b", "c"] });
+		const component = read.renderResult!(
+			result,
+			{ expanded: true, isPartial: false },
+			theme,
+			noCtx,
+		);
+		assert.equal(renderText(component), "");
+	});
+
+	it("shows Reading... during partial", () => {
+		const result = makeResult();
+		const component = read.renderResult!(
+			result,
+			{ expanded: false, isPartial: true },
+			theme,
+			noCtx,
+		);
+		assert.match(renderText(component), /Reading/u);
+	});
+});
+
+// ────────────────────────────────────────────────────────
+// grep
+// ────────────────────────────────────────────────────────
+describe("grep renderResult", () => {
+	const grep = createHarness().findTool("grep");
+
+	it("shows match count in collapsed (not truncated)", () => {
+		const result = makeResult({
+			lines: ["a.txt:1:foo", "b.txt:2:bar", "c.txt:3:baz"],
+		});
+		const component = grep.renderResult!(
+			result,
+			{ expanded: false, isPartial: false },
+			theme,
+			noCtx,
+		);
+		const text = renderText(component);
+		assert.match(text, /3 matches/u);
+		assert.doesNotMatch(text, /truncated/u);
+	});
+
+	it("shows match count with truncation warning when truncated", () => {
+		const result = makeResult({
+			lines: Array.from({ length: 150 }, (_, i) => `f${i}.ts:${i}:line`),
+			details: { matchLimitReached: 100 },
+		});
+		const component = grep.renderResult!(
+			result,
+			{ expanded: false, isPartial: false },
+			theme,
+			noCtx,
+		);
+		const text = renderText(component);
+		assert.match(text, /150 matches/u);
+		assert.match(text, /truncated/u);
+	});
+
+	it("shows full content in expanded", () => {
+		const result = makeResult({ lines: ["a.txt:1:foo", "b.txt:2:bar"] });
+		const component = grep.renderResult!(
+			result,
+			{ expanded: true, isPartial: false },
+			theme,
+			noCtx,
+		);
+		assert.equal(renderText(component), "a.txt:1:foo\nb.txt:2:bar");
+	});
+
+	it("shows Searching... during partial", () => {
+		const component = grep.renderResult!(
+			makeResult(),
+			{ expanded: false, isPartial: true },
+			theme,
+			noCtx,
+		);
+		assert.match(renderText(component), /Searching/u);
+	});
+});
+
+// ────────────────────────────────────────────────────────
+// find
+// ────────────────────────────────────────────────────────
+describe("find renderResult", () => {
+	const find = createHarness().findTool("find");
+
+	it("shows file count in collapsed (not truncated)", () => {
+		const result = makeResult({ lines: ["src/a.ts", "src/b.ts", "lib/c.ts"] });
+		const component = find.renderResult!(
+			result,
+			{ expanded: false, isPartial: false },
+			theme,
+			noCtx,
+		);
+		const text = renderText(component);
+		assert.match(text, /3 files/u);
+		assert.doesNotMatch(text, /truncated/u);
+	});
+
+	it("shows file count with truncation warning when truncated", () => {
+		const result = makeResult({
+			lines: Array.from({ length: 1500 }, (_, i) => `f${i}.ts`),
+			details: { truncation: { truncated: true } },
+		});
+		const component = find.renderResult!(
+			result,
+			{ expanded: false, isPartial: false },
+			theme,
+			noCtx,
+		);
+		const text = renderText(component);
+		assert.match(text, /1500 files/u);
+		assert.match(text, /truncated/u);
+	});
+
+	it("shows full content in expanded", () => {
+		const result = makeResult({ lines: ["a.ts", "b.ts"] });
+		const component = find.renderResult!(
+			result,
+			{ expanded: true, isPartial: false },
+			theme,
+			noCtx,
+		);
+		assert.equal(renderText(component), "a.ts\nb.ts");
+	});
+
+	it("shows Searching... during partial", () => {
+		const component = find.renderResult!(
+			makeResult(),
+			{ expanded: false, isPartial: true },
+			theme,
+			noCtx,
+		);
+		assert.match(renderText(component), /Searching/u);
+	});
+});
+
+// ────────────────────────────────────────────────────────
+// ls
+// ────────────────────────────────────────────────────────
+describe("ls renderResult", () => {
+	const ls = createHarness().findTool("ls");
+
+	it("shows entry count in collapsed (not truncated)", () => {
+		const result = makeResult({ lines: ["dir/", "file.ts", "other.js"] });
+		const component = ls.renderResult!(
+			result,
+			{ expanded: false, isPartial: false },
+			theme,
+			noCtx,
+		);
+		const text = renderText(component);
+		assert.match(text, /3 entries/u);
+		assert.doesNotMatch(text, /truncated/u);
+	});
+
+	it("shows entry count with truncation warning when truncated", () => {
+		const result = makeResult({
+			lines: Array.from({ length: 600 }, (_, i) => `f${i}`),
+			details: { entryLimitReached: 500 },
+		});
+		const component = ls.renderResult!(
+			result,
+			{ expanded: false, isPartial: false },
+			theme,
+			noCtx,
+		);
+		const text = renderText(component);
+		assert.match(text, /600 entries/u);
+		assert.match(text, /truncated/u);
+	});
+
+	it("shows full content in expanded", () => {
+		const result = makeResult({ lines: ["dir/", "file.ts"] });
+		const component = ls.renderResult!(
+			result,
+			{ expanded: true, isPartial: false },
+			theme,
+			noCtx,
+		);
+		assert.equal(renderText(component), "dir/\nfile.ts");
+	});
+
+	it("shows Listing... during partial", () => {
+		const component = ls.renderResult!(
+			makeResult(),
+			{ expanded: false, isPartial: true },
+			theme,
+			noCtx,
+		);
+		assert.match(renderText(component), /Listing/u);
+	});
+});

--- a/tests/pi/agent/extensions/user/features/render-policy.test.ts
+++ b/tests/pi/agent/extensions/user/features/render-policy.test.ts
@@ -75,6 +75,13 @@ function createHarness(): Harness {
 
 const theme = makeTheme();
 const noCtx = {};
+const errorCtx = {
+	args: { path: "missing.txt" },
+	cwd: process.cwd(),
+	isError: true,
+	lastComponent: undefined,
+	showImages: false,
+};
 
 // ────────────────────────────────────────────────────────
 // read
@@ -102,6 +109,19 @@ describe("read renderResult", () => {
 			noCtx,
 		);
 		assert.equal(renderText(component), "");
+	});
+
+	it("does not hide error results", () => {
+		const result = makeResult({ lines: ["read failed"], isError: true });
+		const component = read.renderResult!(
+			result,
+			{ expanded: false, isPartial: false },
+			theme,
+			errorCtx,
+		);
+		const text = renderText(component);
+		assert.notEqual(text, "");
+		assert.match(text, /read failed/u);
 	});
 
 	it("shows Reading... during partial", () => {
@@ -164,6 +184,19 @@ describe("grep renderResult", () => {
 		assert.equal(renderText(component), "a.txt:1:foo\nb.txt:2:bar");
 	});
 
+	it("does not collapse error results into a match count", () => {
+		const result = makeResult({ lines: ["grep failed"], isError: true });
+		const component = grep.renderResult!(
+			result,
+			{ expanded: false, isPartial: false },
+			theme,
+			errorCtx,
+		);
+		const text = renderText(component);
+		assert.match(text, /grep failed/u);
+		assert.doesNotMatch(text, /matches/u);
+	});
+
 	it("shows Searching... during partial", () => {
 		const component = grep.renderResult!(
 			makeResult(),
@@ -221,6 +254,19 @@ describe("find renderResult", () => {
 		assert.equal(renderText(component), "a.ts\nb.ts");
 	});
 
+	it("does not collapse error results into a file count", () => {
+		const result = makeResult({ lines: ["find failed"], isError: true });
+		const component = find.renderResult!(
+			result,
+			{ expanded: false, isPartial: false },
+			theme,
+			errorCtx,
+		);
+		const text = renderText(component);
+		assert.match(text, /find failed/u);
+		assert.doesNotMatch(text, /files/u);
+	});
+
 	it("shows Searching... during partial", () => {
 		const component = find.renderResult!(
 			makeResult(),
@@ -276,6 +322,19 @@ describe("ls renderResult", () => {
 			noCtx,
 		);
 		assert.equal(renderText(component), "dir/\nfile.ts");
+	});
+
+	it("does not collapse error results into an entry count", () => {
+		const result = makeResult({ lines: ["ls failed"], isError: true });
+		const component = ls.renderResult!(
+			result,
+			{ expanded: false, isPartial: false },
+			theme,
+			errorCtx,
+		);
+		const text = renderText(component);
+		assert.match(text, /ls failed/u);
+		assert.doesNotMatch(text, /entries/u);
 	});
 
 	it("shows Listing... during partial", () => {

--- a/tests/pi/agent/extensions/user/features/turn-metrics.test.ts
+++ b/tests/pi/agent/extensions/user/features/turn-metrics.test.ts
@@ -130,7 +130,7 @@ describe("turn metrics feature", () => {
 		const line = h.workingMessages.at(-1) ?? "";
 		assert.match(line, /9s thinking/u);
 	});
-	it("displays thought metrics for 1 second after thinking phase ends", async () => {
+	it("displays thought metrics for 2 seconds after thinking phase ends", async () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(0);
 		const h = createHarness();
@@ -148,22 +148,33 @@ describe("turn metrics feature", () => {
 			"message_update",
 			assistantMessage([{ type: "text", text: "now working" }]),
 		);
-		// Just transitioned to Working, thought display active until T=16s
+		// Just transitioned to Working, thought display active until T=17s
 
 		const thoughtLine = h.workingMessages.at(-1) ?? "";
 		assert.match(thoughtLine, /15s total/u);
 		assert.match(thoughtLine, /5\.0s thought/u);
 		assert.doesNotMatch(thoughtLine, /Thought for/u);
 
-		// Advance past the 1-second thought display window
+		// Still within the 2-second thought display window
 		vi.setSystemTime(16_001);
 		await h.emit(
 			"message_update",
 			assistantMessage([{ type: "text", text: "still working" }]),
 		);
 
+		const stillThoughtLine = h.workingMessages.at(-1) ?? "";
+		assert.match(stillThoughtLine, /16s total/u);
+		assert.match(stillThoughtLine, /5\.0s thought/u);
+
+		// Advance past the 2-second thought display window
+		vi.setSystemTime(17_001);
+		await h.emit(
+			"message_update",
+			assistantMessage([{ type: "text", text: "still working" }]),
+		);
+
 		const normalLine = h.workingMessages.at(-1) ?? "";
-		assert.match(normalLine, /16s/u);
+		assert.match(normalLine, /17s/u);
 		assert.doesNotMatch(normalLine, /thought/u);
 		assert.doesNotMatch(normalLine, /total/u);
 		assert.doesNotMatch(normalLine, /Thought/u);

--- a/tests/pi/agent/extensions/user/features/turn-metrics.test.ts
+++ b/tests/pi/agent/extensions/user/features/turn-metrics.test.ts
@@ -86,7 +86,6 @@ describe("turn metrics feature", () => {
 
 		const line = h.widgets.at(-1)?.[0] ?? "";
 		assert.match(line, /Worked for 9s/u);
-		assert.doesNotMatch(line, /9\.2s/u);
 	});
 
 	it("renders live elapsed time with fractional seconds only under one minute", async () => {
@@ -100,7 +99,7 @@ describe("turn metrics feature", () => {
 			"message_update",
 			assistantMessage([{ type: "text", text: "working" }]),
 		);
-		assert.match(h.workingMessages.at(-1) ?? "", /9\.2s/u);
+		assert.match(h.workingMessages.at(-1) ?? "", /9s/u);
 
 		vi.setSystemTime(72_300);
 		await h.emit(
@@ -109,7 +108,6 @@ describe("turn metrics feature", () => {
 		);
 		const line = h.workingMessages.at(-1) ?? "";
 		assert.match(line, /1m 12s/u);
-		assert.doesNotMatch(line, /72\.3s/u);
 	});
 
 	it("renders thinking metrics with both total and thinking elapsed time", async () => {
@@ -130,8 +128,7 @@ describe("turn metrics feature", () => {
 		);
 
 		const line = h.workingMessages.at(-1) ?? "";
-		assert.match(line, /18\.4s total/u);
-		assert.match(line, /9\.2s thinking/u);
+		assert.match(line, /9s thinking/u);
 	});
 	it("displays thought metrics for 1 second after thinking phase ends", async () => {
 		vi.useFakeTimers();
@@ -154,7 +151,7 @@ describe("turn metrics feature", () => {
 		// Just transitioned to Working, thought display active until T=16s
 
 		const thoughtLine = h.workingMessages.at(-1) ?? "";
-		assert.match(thoughtLine, /15\.0s total/u);
+		assert.match(thoughtLine, /15s total/u);
 		assert.match(thoughtLine, /5\.0s thought/u);
 		assert.doesNotMatch(thoughtLine, /Thought for/u);
 
@@ -166,7 +163,7 @@ describe("turn metrics feature", () => {
 		);
 
 		const normalLine = h.workingMessages.at(-1) ?? "";
-		assert.match(normalLine, /16\.0s/u);
+		assert.match(normalLine, /16s/u);
 		assert.doesNotMatch(normalLine, /thought/u);
 		assert.doesNotMatch(normalLine, /total/u);
 		assert.doesNotMatch(normalLine, /Thought/u);
@@ -190,7 +187,7 @@ describe("turn metrics feature", () => {
 		);
 		// In thought display window
 		const thoughtLine = h.workingMessages.at(-1) ?? "";
-		assert.match(thoughtLine, /15\.0s total/u);
+		assert.match(thoughtLine, /15s total/u);
 		assert.match(thoughtLine, /5\.0s thought/u);
 		assert.doesNotMatch(thoughtLine, /Thought for/u);
 		// Go back to thinking while still in thought window
@@ -201,7 +198,6 @@ describe("turn metrics feature", () => {
 		);
 
 		const thinkingLine = h.workingMessages.at(-1) ?? "";
-		assert.match(thinkingLine, /total/u);
 		assert.match(thinkingLine, /thinking/u);
 		assert.doesNotMatch(thinkingLine, /Thought/u);
 	});

--- a/tests/pi/agent/extensions/user/features/turn-metrics.test.ts
+++ b/tests/pi/agent/extensions/user/features/turn-metrics.test.ts
@@ -130,6 +130,31 @@ describe("turn metrics feature", () => {
 		const line = h.workingMessages.at(-1) ?? "";
 		assert.match(line, /9s thinking/u);
 	});
+
+	it("shows 'small thought' when thinking for under 1 second", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(0);
+		const h = createHarness();
+
+		await h.emit("before_agent_start");
+		// thinking starts immediately after a text message
+		vi.setSystemTime(100);
+		await h.emit(
+			"message_update",
+			assistantMessage([{ type: "thinking", thinking: "quick reasoning" }]),
+		);
+		// advance to 800ms (still < 1s)
+		vi.setSystemTime(800);
+		await h.emit(
+			"message_update",
+			assistantMessage([{ type: "thinking", thinking: "still quick" }]),
+		);
+
+		const line = h.workingMessages.at(-1) ?? "";
+		assert.match(line, /small thought/u);
+		assert.doesNotMatch(line, /s thinking/u);
+	});
+
 	it("displays thought metrics for 2 seconds after thinking phase ends", async () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(0);
@@ -179,6 +204,32 @@ describe("turn metrics feature", () => {
 		assert.doesNotMatch(normalLine, /total/u);
 		assert.doesNotMatch(normalLine, /Thought/u);
 	});
+
+	it("shows 'small thought' when thought duration is under 1 second", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(0);
+		const h = createHarness();
+
+		await h.emit("before_agent_start");
+		vi.setSystemTime(1_000);
+		await h.emit(
+			"message_update",
+			assistantMessage([{ type: "thinking", thinking: "quick reasoning" }]),
+		);
+		// 500ms of thinking
+		vi.setSystemTime(1_500);
+		await h.emit(
+			"message_update",
+			assistantMessage([{ type: "text", text: "done thinking" }]),
+		);
+		// Thought display active until T=3.5s
+
+		const thoughtLine = h.workingMessages.at(-1) ?? "";
+		assert.match(thoughtLine, /1s total/u);
+		assert.match(thoughtLine, /small thought/u);
+		assert.doesNotMatch(thoughtLine, /0\.5s thought/u);
+	});
+
 	it("clears thought display when going back to thinking", async () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(0);
@@ -209,7 +260,8 @@ describe("turn metrics feature", () => {
 		);
 
 		const thinkingLine = h.workingMessages.at(-1) ?? "";
-		assert.match(thinkingLine, /thinking/u);
+		// Re-entered thinking for only 500ms (< 1s), so shows "small thought"
+		assert.match(thinkingLine, /small thought/u);
 		assert.doesNotMatch(thinkingLine, /Thought/u);
 	});
 });

--- a/tests/pi/agent/extensions/user/lib/file/apply-patch.test.ts
+++ b/tests/pi/agent/extensions/user/lib/file/apply-patch.test.ts
@@ -91,7 +91,7 @@ describe("apply_patch", () => {
 			[
 				[
 					"replaces[0] oldText matched multiple locations.",
-					"Specify targetLineNoRanges for a safe range that contains only intended replacements.",
+					"Specify allowedReplacementLineRanges with the smallest line ranges that contain only intended replacements.",
 					"Matched lines: [1, 3].",
 					"Warning: oldText matched multiple times on the same line.",
 					"Use a wider oldText, such as the full line or surrounding phrase, so the intended replacement is unambiguous.",
@@ -102,7 +102,7 @@ describe("apply_patch", () => {
 		);
 	});
 
-	it("replaces all matching text within the target line number ranges", async () => {
+	it("replaces all matching text within the allowed replacement line ranges", async () => {
 		const root = tempRepo();
 		const path = join(root, "src", "example.txt");
 		writeFileSync(
@@ -118,7 +118,7 @@ describe("apply_patch", () => {
 					{
 						oldText: "same",
 						newText: "changed",
-						targetLineNoRanges: [{ start: 1, end: 3 }],
+						allowedReplacementLineRanges: [{ start: 1, end: 3 }],
 					},
 				],
 			},
@@ -132,7 +132,7 @@ describe("apply_patch", () => {
 		assert.equal(result.details.edits, 2);
 	});
 
-	it("uses target line number ranges to disambiguate globally ambiguous text", async () => {
+	it("uses allowed replacement line ranges to disambiguate globally ambiguous text", async () => {
 		const root = tempRepo();
 		const path = join(root, "src", "example.txt");
 		writeFileSync(
@@ -148,7 +148,7 @@ describe("apply_patch", () => {
 					{
 						oldText: "same",
 						newText: "changed",
-						targetLineNoRanges: [{ start: 3, end: 3 }],
+						allowedReplacementLineRanges: [{ start: 3, end: 3 }],
 					},
 				],
 			},
@@ -174,12 +174,12 @@ describe("apply_patch", () => {
 					{
 						oldText: "one",
 						newText: "two",
-						targetLineNoRanges: [{ start: 1, end: 1 }],
+						allowedReplacementLineRanges: [{ start: 1, end: 1 }],
 					},
 					{
 						oldText: "two two",
 						newText: "done",
-						targetLineNoRanges: [{ start: 1, end: 1 }],
+						allowedReplacementLineRanges: [{ start: 1, end: 1 }],
 					},
 				],
 			},
@@ -209,7 +209,7 @@ describe("apply_patch", () => {
 		assert.equal(readFileSync(path, "utf8"), "one\n");
 	});
 
-	it("rejects multiple matches on the same line within a target line number range", async () => {
+	it("rejects multiple matches on the same line within an allowed replacement line range", async () => {
 		const root = tempRepo();
 		const path = join(root, "src", "example.txt");
 		writeFileSync(path, "same same\n");
@@ -222,13 +222,13 @@ describe("apply_patch", () => {
 					{
 						oldText: "same",
 						newText: "changed",
-						targetLineNoRanges: [{ start: 1, end: 1 }],
+						allowedReplacementLineRanges: [{ start: 1, end: 1 }],
 					},
 				],
 			},
 			[
 				[
-					"replaces[0].targetLineNoRanges[0] oldText matched multiple locations on line 1.",
+					"replaces[0].allowedReplacementLineRanges[0] oldText matched multiple locations on line 1.",
 					"Line ranges cannot disambiguate multiple matches on the same line.",
 					"Use a wider oldText, such as the full line or surrounding phrase, so the intended replacement is unambiguous.",
 				].join("\n"),
@@ -237,7 +237,7 @@ describe("apply_patch", () => {
 		assert.equal(readFileSync(path, "utf8"), "same same\n");
 	});
 
-	it("rejects a target line number range that contains no match", async () => {
+	it("rejects an allowed replacement line range that contains no match", async () => {
 		const root = tempRepo();
 		const path = join(root, "src", "example.txt");
 		writeFileSync(path, "same\nother\nsame\n");
@@ -250,18 +250,18 @@ describe("apply_patch", () => {
 					{
 						oldText: "same",
 						newText: "changed",
-						targetLineNoRanges: [{ start: 2, end: 2 }],
+						allowedReplacementLineRanges: [{ start: 2, end: 2 }],
 					},
 				],
 			},
 			[
-				"replaces[0].targetLineNoRanges[0] oldText did not match within the target line range",
+				"replaces[0].allowedReplacementLineRanges[0] oldText did not match within the allowed replacement line range",
 			],
 		);
 		assert.equal(readFileSync(path, "utf8"), "same\nother\nsame\n");
 	});
 
-	it("rejects target line number ranges with start after end", async () => {
+	it("rejects allowed replacement line ranges with start after end", async () => {
 		const root = tempRepo();
 		const path = join(root, "src", "example.txt");
 		writeFileSync(path, "same\nother\n");
@@ -274,11 +274,11 @@ describe("apply_patch", () => {
 					{
 						oldText: "same",
 						newText: "changed",
-						targetLineNoRanges: [{ start: 2, end: 1 }],
+						allowedReplacementLineRanges: [{ start: 2, end: 1 }],
 					},
 				],
 			},
-			["replaces[0].targetLineNoRanges[0] start must be <= end"],
+			["replaces[0].allowedReplacementLineRanges[0] start must be <= end"],
 		);
 		assert.equal(readFileSync(path, "utf8"), "same\nother\n");
 	});

--- a/tests/pi/agent/extensions/user/lib/time.test.ts
+++ b/tests/pi/agent/extensions/user/lib/time.test.ts
@@ -13,8 +13,8 @@ describe("time formatting", () => {
 		assert.equal(formatHumanElapsed(72_300), "1m 12s");
 	});
 
-	it("formats live elapsed time with fractional seconds only under one minute", () => {
-		assert.equal(formatLiveElapsed(9_200), "9.2s");
+	it("formats live elapsed time without fractional seconds", () => {
+		assert.equal(formatLiveElapsed(9_200), "9s");
 		assert.equal(formatLiveElapsed(72_300), "1m 12s");
 	});
 });

--- a/tests/pi/agent/extensions/user/lib/tool/agent.test.ts
+++ b/tests/pi/agent/extensions/user/lib/tool/agent.test.ts
@@ -18,6 +18,13 @@ const plainTheme = {
 	bold: (text: string) => text,
 } as Theme;
 
+function markerTheme(): Theme {
+	return {
+		fg: (name: string, text: string) => `<${name}>${text}</${name}>`,
+		bold: (text: string) => `<bold>${text}</bold>`,
+	} as Theme;
+}
+
 function renderText(
 	component: { render(width: number): string[] },
 	width = 200,
@@ -464,5 +471,111 @@ describe("agent PI_AGENT environment guard", () => {
 		const tools = catalog.list();
 		const agent = tools.find((t) => t.definition.name === AGENT_TOOL);
 		assert.ok(agent);
+	});
+});
+
+describe("agent renderCall", () => {
+	it("displays title in accent color matching read's path style", () => {
+		const catalog = createToolCatalog();
+		registerAgentTool(catalog);
+
+		const tools = catalog.list();
+		const agent = tools.find((t) => t.definition.name === AGENT_TOOL);
+		assert.ok(agent);
+
+		// renderCall is optional in ToolDefinition
+		if (!agent.definition.renderCall) return;
+
+		const component = agent.definition.renderCall(
+			{ focus: "explore", prompt: "do stuff", title: "my task" },
+			plainTheme,
+			{ state: {}, invalidate: () => undefined } as never,
+		);
+
+		const text = renderText(component as { render(width: number): string[] });
+
+		// agent label stays bold (plainTheme strips ansi, so just check presence)
+		assert.match(text, /agent/u);
+		// "in" separator and focus name are preserved
+		assert.match(text, /explore/u);
+		// title is rendered (accent in real theme, but plainTheme passes through)
+		assert.match(text, /my task/u);
+		// no title fallback to dim ...
+		assert.doesNotMatch(text, /\.\.\./u);
+	});
+
+	it("renders focus suffix with grep/find toolOutput color", () => {
+		const catalog = createToolCatalog();
+		registerAgentTool(catalog);
+
+		const tools = catalog.list();
+		const agent = tools.find((t) => t.definition.name === AGENT_TOOL);
+		assert.ok(agent);
+
+		if (!agent.definition.renderCall) return;
+
+		const component = agent.definition.renderCall(
+			{ focus: "explore", prompt: "do stuff", title: "my task" },
+			markerTheme(),
+			{ state: {}, invalidate: () => undefined } as never,
+		);
+
+		const text = renderText(component as { render(width: number): string[] });
+
+		assert.match(text, /<bold>agent<\/bold>/u);
+		assert.match(text, /<accent>my task<\/accent>/u);
+		assert.match(text, /<toolOutput> in explore<\/toolOutput>/u);
+		assert.doesNotMatch(text, /<warning>explore<\/warning>/u);
+	});
+
+	it("does not pre-truncate title before terminal-width rendering", () => {
+		const catalog = createToolCatalog();
+		registerAgentTool(catalog);
+
+		const tools = catalog.list();
+		const agent = tools.find((t) => t.definition.name === AGENT_TOOL);
+		assert.ok(agent);
+
+		if (!agent.definition.renderCall) return;
+
+		const title = "very/long/path/like/read/tool/title/example.ts";
+		const component = agent.definition.renderCall(
+			{ focus: "explore", prompt: "do stuff", title },
+			plainTheme,
+			{ state: {}, invalidate: () => undefined } as never,
+		);
+
+		const text = renderText(component as { render(width: number): string[] });
+
+		assert.match(text, /agent/u);
+		assert.match(text, / in explore/u);
+		assert.match(
+			text,
+			new RegExp(title.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"),
+		);
+		assert.doesNotMatch(text, /…/u);
+	});
+
+	it("with no title shows dim placeholder", () => {
+		const catalog = createToolCatalog();
+		registerAgentTool(catalog);
+
+		const tools = catalog.list();
+		const agent = tools.find((t) => t.definition.name === AGENT_TOOL);
+		assert.ok(agent);
+
+		if (!agent.definition.renderCall) return;
+
+		const component = agent.definition.renderCall(
+			{ focus: "explore", prompt: "do stuff" },
+			plainTheme,
+			{ state: {}, invalidate: () => undefined } as never,
+		);
+
+		const text = renderText(component as { render(width: number): string[] });
+
+		assert.match(text, /agent/u);
+		assert.match(text, /explore/u);
+		assert.match(text, /\.\.\./u);
 	});
 });

--- a/tests/pi/agent/extensions/user/lib/tool/agent.test.ts
+++ b/tests/pi/agent/extensions/user/lib/tool/agent.test.ts
@@ -197,13 +197,13 @@ describe("agent tool registration", () => {
 						' 3. grep (pattern={"raw":"TODO"})',
 						' 4. read (path="src/b.ts")',
 						' 5. lint (options={"fix":false})  ← running',
-						"◉ Running  1.2s (5 tools used)",
+						"◉ Running  1.2s",
 					].join("\n"),
 				},
 			],
 			details: {
 				_status: "running",
-				_runningLine: "◉ Running  1.2s (5 tools used)",
+				_runningLine: "◉ Running  1.2s",
 				toolCallCount: 5,
 				durationMs: 1200,
 				prompt: "Investigate the failing tests",
@@ -238,6 +238,7 @@ describe("agent tool registration", () => {
 		assert.match(output, /3\. grep/u);
 		assert.match(output, /5\. lint/u);
 		assert.match(output, /options=\{"fix":false\}/u);
+		assert.doesNotMatch(output, /5 tools used/u);
 		assert.doesNotMatch(output, /\[object Object\]/u);
 	});
 
@@ -251,13 +252,13 @@ describe("agent tool registration", () => {
 					type: "text" as const,
 					text: [
 						' 1. grep (pattern="this is a very long pattern that used to wrap in narrow terminals")  2.3s  ← running',
-						"◉ Running  1.2s (1 tool used)",
+						"◉ Running  1.2s",
 					].join("\n"),
 				},
 			],
 			details: {
 				_status: "running",
-				_runningLine: "◉ Running  1.2s (1 tool used)",
+				_runningLine: "◉ Running  1.2s",
 				toolCallCount: 1,
 				durationMs: 1200,
 			},
@@ -289,7 +290,7 @@ describe("agent tool registration", () => {
 			content: [{ type: "text" as const, text: "latest tail only" }],
 			details: {
 				_status: "running",
-				_runningLine: "◉ Running  1.2s (5 tools used)",
+				_runningLine: "◉ Running  1.2s",
 				toolCallCount: 5,
 				durationMs: 1200,
 				prompt: "Investigate the failing tests",
@@ -322,6 +323,7 @@ describe("agent tool registration", () => {
 		assert.match(output, /5\. lint/u);
 		assert.match(output, new RegExp(longPattern, "u"));
 		assert.match(output, /◉ Running\s+1\.2s/u);
+		assert.doesNotMatch(output, /5 tools used/u);
 		assert.doesNotMatch(output, /\[object Object\]/u);
 	});
 
@@ -358,17 +360,17 @@ describe("agent tool registration", () => {
 		assert.doesNotMatch(output, /tools:/u);
 		assert.doesNotMatch(output, /read(?!_chunk)\b/u);
 	});
-	it("renders agent running time with fractions and completed time without fractions", () => {
+	it("renders agent running time without live count and completed stats with count", () => {
 		const definition = getAgentDefinition();
 		assert.ok(definition.renderResult);
 
 		const running = renderText(
 			definition.renderResult(
 				{
-					content: [{ type: "text", text: "◉ Running  9.2s (1 tool used)" }],
+					content: [{ type: "text", text: "◉ Running  9.2s" }],
 					details: {
 						_status: "running",
-						_runningLine: "◉ Running  9.2s (1 tool used)",
+						_runningLine: "◉ Running  9.2s",
 						toolCallCount: 1,
 						durationMs: 9200,
 					},
@@ -379,6 +381,7 @@ describe("agent tool registration", () => {
 			) as { render(width: number): string[] },
 		);
 		assert.match(running, /9\.2s/u);
+		assert.doesNotMatch(running, /1 tool used/u);
 
 		const completed = renderText(
 			definition.renderResult(

--- a/tests/pi/agent/extensions/user/lib/tool/agent.test.ts
+++ b/tests/pi/agent/extensions/user/lib/tool/agent.test.ts
@@ -334,6 +334,45 @@ describe("agent tool registration", () => {
 		assert.doesNotMatch(output, /\[object Object\]/u);
 	});
 
+	it("omits multiline string argument lines in running tool history", () => {
+		const definition = getAgentDefinition();
+		assert.ok(definition.renderResult);
+
+		const result = {
+			content: [{ type: "text" as const, text: "latest tail only" }],
+			details: {
+				_status: "running",
+				_runningLine: "◉ Running  1.2s",
+				toolCallCount: 1,
+				durationMs: 1200,
+				toolCalls: [
+					{
+						name: "write",
+						args: {
+							path: "notes.txt",
+							content: "first line\nsecond line\nthird line",
+						},
+						startTime: 0,
+					},
+				],
+			},
+		} satisfies AgentToolResult<Record<string, unknown>>;
+
+		const output = renderText(
+			definition.renderResult(
+				result,
+				{ expanded: true, isPartial: true },
+				plainTheme,
+				renderResultContext(),
+			) as { render(width: number): string[] },
+		);
+
+		assert.match(output, /1\. write/u);
+		assert.match(output, /content="first line…"/u);
+		assert.doesNotMatch(output, /second line/u);
+		assert.doesNotMatch(output, /third line/u);
+	});
+
 	it("omits tool history from completed expanded output", () => {
 		const definition = getAgentDefinition();
 		assert.ok(definition.renderResult);

--- a/tests/pi/agent/extensions/user/lib/tool/github.test.ts
+++ b/tests/pi/agent/extensions/user/lib/tool/github.test.ts
@@ -169,9 +169,49 @@ describe("create_pull_request", () => {
 		const error = await reject(
 			invoke(create, { ...validCreateInput, branchName: "main" }, "/repo"),
 		);
+
 		assert.match(error.message, /repository default branch/u);
 		// Detection may run, but no branch creation should happen.
 		assert.ok(!calls.some((c) => c.bin === "git" && c.args[0] === "switch"));
+	});
+
+	it("creates a draft PR from existing branch commits without committing files", async () => {
+		const calls: Call[] = [];
+		setupExec({
+			calls,
+			stdout: {
+				...defaultArgs("git", [
+					"symbolic-ref",
+					"--short",
+					"refs/remotes/origin/HEAD",
+				]),
+				"git branch --show-current": "feature/test\n",
+				"gh pr create --draft --title Add a and b --body ## Summary\n- adds a and b":
+					"https://github.com/owner/repo/pull/1\n",
+			},
+		});
+		const create = findTool("create_pull_request");
+		const result = (await invoke(
+			create,
+			{
+				branchName: "feature/test",
+				title: "Add a and b",
+				body: "## Summary\n- adds a and b",
+			},
+			"/repo",
+		)) as { readonly content: readonly { readonly text: string }[] };
+		assert.match(result.content[0]?.text ?? "", /pull\/1/u);
+
+		const commands = calls.map((call) => `${call.bin} ${call.args.join(" ")}`);
+		assert.ok(commands.includes("git branch --show-current"));
+		assert.ok(commands.includes("git push -u origin feature/test"));
+		assert.ok(
+			commands.includes(
+				"gh pr create --draft --title Add a and b --body ## Summary\n- adds a and b",
+			),
+		);
+		assert.ok(!commands.some((cmd) => cmd.startsWith("git add ")));
+		assert.ok(!commands.some((cmd) => cmd.startsWith("git commit ")));
 	});
 
 	it("reuses the current branch when it matches branchName", async () => {


### PR DESCRIPTION
## Summary

- Make render policy explicit for read-only tools.
- Improve thinking and turn metrics display.
- Surface render errors in policy tests for easier diagnosis.
- Simplify agent tool display with truncation and aligned colors.
- Allow PR creation from branches that already have commits without requiring new commit files.
- Rename targetLineNoRanges to allowedReplacementLineRanges and clarify exact matching/minimal range guidance.

## Background

This improves readability and UX for Pi agent extension tool and turn displays, makes read-only tool rendering behavior explicit, makes render-policy failures easier to diagnose, and fixes the PR creation workflow for clean branches with existing commits.