### PR TITLE
feat(pi): add prompt stash quick action

### DIFF
--- a/files/pi/agent/extensions/user/features/prompt-stash.ts
+++ b/files/pi/agent/extensions/user/features/prompt-stash.ts
@@ -1,0 +1,275 @@
+import {
+	DynamicBorder,
+	type ExtensionContext,
+	type Theme,
+} from "@earendil-works/pi-coding-agent";
+import { type TUI, matchesKey, truncateToWidth } from "@earendil-works/pi-tui";
+import type { Feature } from "../feature";
+import {
+	type PromptStashEntry,
+	type PromptStashStore,
+	createPromptStashStore,
+	formatPromptStashLabel,
+	getOnlyPromptStashId,
+} from "../lib/prompt-stash";
+import { registerQuickActionHandler } from "../lib/quick-actions";
+import { decodePrintableInput, showFilterSelect } from "../lib/ui";
+import {
+	type KeyedPanelItem,
+	describePrintableInput,
+	renderKeyedPanelItem,
+} from "../lib/ui/keyed-panel";
+
+type PromptStashAction = "stash" | "stashClear" | "apply" | "pop" | "clear";
+type PromptStashMenuComponent = {
+	render(width: number): string[];
+	invalidate(): void;
+	handleInput(data: string): void;
+};
+
+type PromptStashMenuItem = KeyedPanelItem & {
+	readonly id: PromptStashAction;
+};
+
+const PROMPT_STASH_ACTIONS: readonly PromptStashMenuItem[] = [
+	{
+		id: "stashClear",
+		key: "s",
+		label: "Stash and clear",
+		description: "Save editor prompt and clear the editor",
+	},
+	{
+		id: "stash",
+		key: "S",
+		label: "Stash",
+		description: "Save editor prompt",
+	},
+	{
+		id: "apply",
+		key: "a",
+		label: "Apply",
+		description: "Select and restore a stash without consuming it",
+	},
+	{
+		id: "pop",
+		key: "p",
+		label: "Pop",
+		description: "Select, restore, and consume a stash",
+	},
+	{
+		id: "clear",
+		key: "c",
+		label: "Clear all",
+		description: "Delete all prompt stashes",
+	},
+];
+
+const NOTICE_CLEAR_MS = 1200;
+const STASH_LABEL_WIDTH = 80;
+
+function renderPromptStashMenu(
+	theme: Theme,
+	border: DynamicBorder,
+	notice: string | undefined,
+	width: number,
+): string[] {
+	return [
+		...border.render(width),
+		truncateToWidth(theme.fg("accent", theme.bold("Prompt Stash")), width, ""),
+		...PROMPT_STASH_ACTIONS.map((action) =>
+			renderKeyedPanelItem(theme, action, { width, labelWidth: 24 }),
+		),
+		truncateToWidth(
+			notice ? theme.fg("warning", notice) : theme.fg("dim", "q/esc back"),
+			width,
+			"",
+		),
+		...border.render(width),
+	];
+}
+
+function createPromptStashMenuComponent(
+	tui: TUI,
+	theme: Theme,
+	done: (result: PromptStashAction | undefined) => void,
+): PromptStashMenuComponent {
+	const border = new DynamicBorder((text: string) => theme.fg("accent", text));
+	let notice: string | undefined;
+	let clearNoticeTimer: ReturnType<typeof setTimeout> | undefined;
+
+	const close = (result: PromptStashAction | undefined): void => {
+		if (clearNoticeTimer) clearTimeout(clearNoticeTimer);
+		done(result);
+	};
+
+	const setNotice = (message: string): void => {
+		if (clearNoticeTimer) clearTimeout(clearNoticeTimer);
+		notice = message;
+		clearNoticeTimer = setTimeout(() => {
+			notice = undefined;
+			tui.requestRender();
+		}, NOTICE_CLEAR_MS);
+	};
+
+	return {
+		render: (width: number) =>
+			renderPromptStashMenu(theme, border, notice, width),
+		invalidate: () => border.invalidate(),
+		handleInput(data: string) {
+			if (matchesKey(data, "escape")) {
+				close(undefined);
+				return;
+			}
+
+			const input = decodePrintableInput(data);
+			if (!input) return;
+			if (input === "q") {
+				close(undefined);
+				return;
+			}
+
+			const action = PROMPT_STASH_ACTIONS.find((item) => item.key === input);
+			if (action) {
+				close(action.id);
+				return;
+			}
+
+			setNotice(`Unknown action: ${describePrintableInput(input)}`);
+			tui.requestRender();
+		},
+	};
+}
+
+async function showPromptStashMenu(
+	ctx: ExtensionContext,
+): Promise<PromptStashAction | undefined> {
+	return ctx.ui.custom<PromptStashAction | undefined>(
+		(tui, theme, _keybindings, done) =>
+			createPromptStashMenuComponent(tui, theme, done),
+	);
+}
+
+function toFilterItem(entry: PromptStashEntry): {
+	value: string;
+	label: string;
+	description: string;
+} {
+	return {
+		value: entry.id,
+		label: formatPromptStashLabel(entry, STASH_LABEL_WIDTH),
+		description: new Date(entry.createdAt).toLocaleTimeString(),
+	};
+}
+
+async function selectPromptStash(
+	ctx: ExtensionContext,
+	store: PromptStashStore,
+	title: string,
+): Promise<string | undefined> {
+	const entries = store.list();
+	if (entries.length === 0) {
+		ctx.ui.notify("No prompt stashes", "warning");
+		return undefined;
+	}
+
+	const onlyId = getOnlyPromptStashId(entries);
+	if (onlyId) return onlyId;
+
+	return showFilterSelect(ctx, {
+		title,
+		items: entries.map(toFilterItem),
+		filterPlaceholder: "type to search stashes",
+		maxVisible: 10,
+	});
+}
+
+function stashEditor(
+	ctx: ExtensionContext,
+	store: PromptStashStore,
+	clear: boolean,
+): void {
+	const entry = store.stash(ctx.ui.getEditorText());
+	if (!entry) {
+		ctx.ui.notify("Write a prompt before stashing it", "warning");
+		return;
+	}
+
+	if (clear) ctx.ui.setEditorText("");
+	ctx.ui.notify(`Prompt stashed as #${entry.index}`, "info");
+}
+
+async function applySelectedStash(
+	ctx: ExtensionContext,
+	store: PromptStashStore,
+): Promise<void> {
+	const id = await selectPromptStash(ctx, store, "Prompt Stash: Apply");
+	if (!id) return;
+
+	const text = store.apply(id);
+	if (!text) {
+		ctx.ui.notify("Prompt stash not found", "warning");
+		return;
+	}
+	ctx.ui.setEditorText(text);
+	ctx.ui.notify("Prompt stash applied", "info");
+}
+
+async function popSelectedStash(
+	ctx: ExtensionContext,
+	store: PromptStashStore,
+): Promise<void> {
+	const id = await selectPromptStash(ctx, store, "Prompt Stash: Pop");
+	if (!id) return;
+
+	const text = store.pop(id);
+	if (!text) {
+		ctx.ui.notify("Prompt stash not found", "warning");
+		return;
+	}
+	ctx.ui.setEditorText(text);
+	ctx.ui.notify("Prompt stash popped", "info");
+}
+
+async function openPromptStash(
+	ctx: ExtensionContext,
+	store: PromptStashStore,
+): Promise<void> {
+	const action = await showPromptStashMenu(ctx);
+	switch (action) {
+		case "stash":
+			stashEditor(ctx, store, false);
+			break;
+		case "stashClear":
+			stashEditor(ctx, store, true);
+			break;
+		case "apply":
+			await applySelectedStash(ctx, store);
+			break;
+		case "pop":
+			await popSelectedStash(ctx, store);
+			break;
+		case "clear": {
+			const count = store.clear();
+			ctx.ui.notify(
+				count === 0
+					? "No prompt stashes to clear"
+					: `Cleared ${count} prompt stashes`,
+				count === 0 ? "warning" : "info",
+			);
+			break;
+		}
+	}
+}
+
+function register(): void {
+	const store = createPromptStashStore();
+	registerQuickActionHandler("promptStash", (ctx) =>
+		openPromptStash(ctx, store),
+	);
+}
+
+export function createPromptStashFeature(): Feature {
+	return { name: "prompt-stash", dependsOn: ["quick-actions"], register };
+}
+
+export default createPromptStashFeature();

--- a/files/pi/agent/extensions/user/features/quick-actions.ts
+++ b/files/pi/agent/extensions/user/features/quick-actions.ts
@@ -24,6 +24,9 @@ const openQuickActions =
 			case "refinePrompt":
 				await runQuickAction("refinePrompt", ctx);
 				break;
+			case "promptStash":
+				await runQuickAction("promptStash", ctx);
+				break;
 		}
 	};
 

--- a/files/pi/agent/extensions/user/lib/prompt-stash.ts
+++ b/files/pi/agent/extensions/user/lib/prompt-stash.ts
@@ -1,0 +1,72 @@
+export type PromptStashEntry = {
+	readonly id: string;
+	readonly index: number;
+	readonly text: string;
+	readonly createdAt: number;
+};
+
+export type PromptStashStore = {
+	stash(text: string): PromptStashEntry | undefined;
+	list(): readonly PromptStashEntry[];
+	apply(id: string): string | undefined;
+	pop(id: string): string | undefined;
+	clear(): number;
+};
+
+const DEFAULT_LABEL_WIDTH = 80;
+
+export function createPromptStashStore(): PromptStashStore {
+	let entries: PromptStashEntry[] = [];
+	let nextIndex = 1;
+
+	return {
+		stash(text) {
+			const normalized = text.trim();
+			if (!normalized) return undefined;
+
+			const entry: PromptStashEntry = {
+				id: `prompt-stash-${nextIndex}`,
+				index: nextIndex,
+				text,
+				createdAt: Date.now(),
+			};
+			nextIndex += 1;
+			entries = [entry, ...entries];
+			return entry;
+		},
+		list() {
+			return entries;
+		},
+		apply(id) {
+			return entries.find((entry) => entry.id === id)?.text;
+		},
+		pop(id) {
+			const entry = entries.find((item) => item.id === id);
+			if (!entry) return undefined;
+			entries = entries.filter((item) => item.id !== id);
+			return entry.text;
+		},
+		clear() {
+			const count = entries.length;
+			entries = [];
+			return count;
+		},
+	};
+}
+
+export function getOnlyPromptStashId(
+	entries: readonly PromptStashEntry[],
+): string | undefined {
+	return entries.length === 1 ? entries[0]?.id : undefined;
+}
+
+export function formatPromptStashLabel(
+	entry: PromptStashEntry,
+	width = DEFAULT_LABEL_WIDTH,
+): string {
+	const text = entry.text.replace(/\s+/gu, " ").trim();
+	const label = `#${entry.index} ${text}`;
+	return label.length > width
+		? `${label.slice(0, Math.max(0, width - 1))}…`
+		: label;
+}

--- a/files/pi/agent/extensions/user/lib/quick-actions.ts
+++ b/files/pi/agent/extensions/user/lib/quick-actions.ts
@@ -11,7 +11,12 @@ import {
 	renderKeyedPanelItem,
 } from "./ui/keyed-panel";
 
-export type QuickActionId = "focus" | "effort" | "model" | "refinePrompt";
+export type QuickActionId =
+	| "focus"
+	| "effort"
+	| "model"
+	| "refinePrompt"
+	| "promptStash";
 
 type QuickAction = KeyedPanelItem & {
 	id: QuickActionId;
@@ -43,6 +48,12 @@ const QUICK_ACTIONS: readonly QuickAction[] = [
 		key: "r",
 		label: "Refine Prompt",
 		description: "Improve the editor prompt with AI",
+	},
+	{
+		id: "promptStash",
+		key: "s",
+		label: "Prompt Stash",
+		description: "Save or restore editor prompts",
 	},
 ];
 

--- a/files/pi/agent/extensions/user/main.ts
+++ b/files/pi/agent/extensions/user/main.ts
@@ -5,6 +5,7 @@ import { createUserExtensionServices } from "./lib/services";
 import { createExitConfirmFeature } from "./features/exit-confirm";
 import { createFocusFeature } from "./features/focus";
 import { createPromptRefineFeature } from "./features/prompt-refine";
+import { createPromptStashFeature } from "./features/prompt-stash";
 import { createQuickActionsFeature } from "./features/quick-actions";
 import { createRenderPolicyFeature } from "./features/render-policy";
 import { createStatusFeature } from "./features/status";
@@ -23,6 +24,7 @@ function createFeatures(): readonly Feature[] {
 		createFocusFeature(),
 		createQuickActionsFeature(),
 		createPromptRefineFeature(),
+		createPromptStashFeature(),
 		createThinkingFeature(),
 		createTmuxNoticeFeature(),
 		createRenderPolicyFeature(),

--- a/tests/pi/agent/extensions/user/lib/prompt-stash.test.ts
+++ b/tests/pi/agent/extensions/user/lib/prompt-stash.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import {
+	createPromptStashStore,
+	formatPromptStashLabel,
+	getOnlyPromptStashId,
+} from "#pi-user/lib/prompt-stash";
+
+describe("prompt stash store", () => {
+	it("stores prompts in newest-first order", () => {
+		const store = createPromptStashStore();
+
+		const first = store.stash("first prompt");
+		const second = store.stash("second prompt");
+
+		assert.equal(first?.index, 1);
+		assert.equal(second?.index, 2);
+		assert.deepEqual(
+			store.list().map((entry) => entry.text),
+			["second prompt", "first prompt"],
+		);
+	});
+
+	it("does not store blank prompts", () => {
+		const store = createPromptStashStore();
+
+		assert.equal(store.stash("  \n\t  "), undefined);
+		assert.deepEqual(store.list(), []);
+	});
+
+	it("applies a stash without consuming it", () => {
+		const store = createPromptStashStore();
+		const entry = store.stash("keep me");
+		assert.ok(entry);
+
+		assert.equal(store.apply(entry.id), "keep me");
+		assert.deepEqual(
+			store.list().map((item) => item.text),
+			["keep me"],
+		);
+	});
+
+	it("pops a selected stash and consumes it", () => {
+		const store = createPromptStashStore();
+		const first = store.stash("first");
+		const second = store.stash("second");
+		assert.ok(first);
+		assert.ok(second);
+
+		assert.equal(store.pop(first.id), "first");
+		assert.deepEqual(
+			store.list().map((entry) => entry.text),
+			["second"],
+		);
+	});
+
+	it("clears all stashes", () => {
+		const store = createPromptStashStore();
+		store.stash("one");
+		store.stash("two");
+
+		assert.equal(store.clear(), 2);
+		assert.deepEqual(store.list(), []);
+	});
+});
+
+describe("getOnlyPromptStashId", () => {
+	it("returns the only stash id when exactly one stash exists", () => {
+		const store = createPromptStashStore();
+		const entry = store.stash("only prompt");
+		assert.ok(entry);
+
+		assert.equal(getOnlyPromptStashId(store.list()), entry.id);
+	});
+
+	it("returns undefined when zero or multiple stashes exist", () => {
+		const store = createPromptStashStore();
+
+		assert.equal(getOnlyPromptStashId(store.list()), undefined);
+		store.stash("one");
+		store.stash("two");
+		assert.equal(getOnlyPromptStashId(store.list()), undefined);
+	});
+});
+
+describe("formatPromptStashLabel", () => {
+	it("normalizes whitespace and trims long prompts to one line", () => {
+		const label = formatPromptStashLabel(
+			{
+				id: "prompt-stash-1",
+				index: 1,
+				text: "first line\nsecond line with extra words",
+				createdAt: 0,
+			},
+			24,
+		);
+
+		assert.equal(label, "#1 first line second li…");
+	});
+});


### PR DESCRIPTION
## Summary
- Add a Prompt Stash quick action under key `s`
- Register the prompt stash feature in the user extension
- Add prompt stash implementation and tests

## Testing
- Not run (not requested)
