### PR TITLE
Switch cloud CLI from gcloud to aws

### DIFF
--- a/modules/recipes/aws.nix
+++ b/modules/recipes/aws.nix
@@ -12,7 +12,7 @@ in
 {
   config = {
     dot.programs.aws = {
-      enable = false;
+      enable = true;
       plugins = {
         awsVault.enable = true;
         saml2aws.enable = true;

--- a/modules/recipes/gcloud.nix
+++ b/modules/recipes/gcloud.nix
@@ -10,7 +10,7 @@ in
 
 {
   config = {
-    dot.programs.gcloud.enable = true;
+    dot.programs.gcloud.enable = false;
 
     dot.programs.navi.cheats.gcloud.sections = lib.mkIf config.dot.programs.gcloud.enable [
       {


### PR DESCRIPTION
## Summary

Enables the AWS recipe and disables the gcloud recipe.

## Background

Switches the configured cloud CLI from gcloud to aws.