### PR TITLE
Move pnpm store ignore to global gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules/
 coverage/
 .direnv/
-.pnpm-store/

--- a/modules/recipes/git.nix
+++ b/modules/recipes/git.nix
@@ -198,6 +198,9 @@ _:
       ".direnv"
       ".envrc"
       ""
+      "### pnpm ###"
+      ".pnpm-store"
+      ""
       "### Git Worktree ###"
       ".worktree"
     ];


### PR DESCRIPTION
Moves the pnpm store ignore pattern into the managed global gitignore configuration and removes the repository-local entry.