### PR TITLE
Add dot fzf module

### DIFF
--- a/modules/dot/programs/default.nix
+++ b/modules/dot/programs/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ./agent-skills.nix
     ./aws.nix
+    ./fzf.nix
     ./gcloud.nix
     ./ghq.nix
     ./mise.nix

--- a/modules/dot/programs/fzf.nix
+++ b/modules/dot/programs/fzf.nix
@@ -1,0 +1,38 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.dot.programs.fzf;
+in
+{
+  options.dot.programs.fzf = {
+    enable = lib.mkEnableOption "fzf";
+
+    package = lib.mkPackageOption pkgs "fzf" { };
+
+    defaultOptions = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Options to set in FZF_DEFAULT_OPTS.";
+      example = [
+        "--reverse"
+        "--border"
+      ];
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home = {
+      packages = [ cfg.package ];
+      sessionVariables = lib.mkIf (cfg.defaultOptions != [ ]) {
+        FZF_DEFAULT_OPTS = lib.concatStringsSep " " cfg.defaultOptions;
+      };
+    };
+
+    dot.options.fuzzyFinder.package = lib.mkDefault cfg.package;
+  };
+}

--- a/modules/recipes/fzf.nix
+++ b/modules/recipes/fzf.nix
@@ -1,15 +1,10 @@
-{ pkgs, ... }:
-
 {
-  config = {
-    dot.options.fuzzyFinder.package = pkgs.fzf;
+  config.dot.programs.fzf = {
+    enable = true;
 
-    programs.fzf = {
-      enable = true;
-      defaultOptions = [
-        "--reverse"
-        "--border"
-      ];
-    };
+    defaultOptions = [
+      "--reverse"
+      "--border"
+    ];
   };
 }


### PR DESCRIPTION
## Summary

Add a minimal `dot.programs.fzf` module that installs `fzf` and manages `FZF_DEFAULT_OPTS`, then switch the fzf recipe to use it instead of Home Manager's broader shell integration.