### PR TITLE
Ensure Atuin Nushell keybinding loads after integration

### DIFF
--- a/modules/recipes/atuin.nix
+++ b/modules/recipes/atuin.nix
@@ -19,7 +19,10 @@ with lib;
       };
     };
 
-    programs.nushell.extraConfig = mkAfter ''
+    # Home Manager's Atuin Nushell integration uses mkOrder 2000; this
+    # keybinding calls _atuin_search_cmd defined by that integration, so it
+    # must be emitted after it.
+    programs.nushell.extraConfig = mkOrder 2100 ''
       $env.config = (
       $env.config | upsert keybindings (
         $env.config.keybindings | append {


### PR DESCRIPTION
## Summary
- Ensure the Atuin Nushell keybinding config is emitted after Home Manager's Atuin Nushell integration.
- Add an inline comment documenting why the ordering is required.

## Background
Home Manager's Atuin Nushell integration defines `_atuin_search_cmd` with `mkOrder 2000`. The custom keybinding calls that function, so it must be emitted later; this change uses `mkOrder 2100` to guarantee the dependency is available first.