### PR TITLE
feat(pi): derive thinking levels from active model

### DIFF
--- a/files/pi/agent/extensions/user/features/thinking.ts
+++ b/files/pi/agent/extensions/user/features/thinking.ts
@@ -5,16 +5,19 @@ import type {
 import type { AutocompleteItem } from "@earendil-works/pi-tui";
 import type { Feature } from "../feature";
 import {
+	getThinkingLevels,
 	isThinkingLevel,
 	setThinkingLevel,
 	showEffortSelector,
-	thinkingLevels,
 } from "../lib/thinking";
 import { filterCompletionsByPrefix } from "../lib/ui";
 
-function completeLevel(prefix: string): AutocompleteItem[] | null {
+function completeLevel(
+	prefix: string,
+	levels: ReturnType<typeof getThinkingLevels>,
+): AutocompleteItem[] | null {
 	return filterCompletionsByPrefix(
-		thinkingLevels.map((level) => ({ value: level, label: level })),
+		levels.map((level) => ({ value: level, label: level })),
 		prefix,
 	);
 }
@@ -22,15 +25,16 @@ function completeLevel(prefix: string): AutocompleteItem[] | null {
 const selectEffort =
 	(pi: ExtensionAPI) =>
 	async (args: string, ctx: ExtensionCommandContext): Promise<void> => {
+		const levels = getThinkingLevels(ctx.model);
 		const level = args.trim();
 		if (!level) {
 			await showEffortSelector(pi, ctx);
 			return;
 		}
 
-		if (!isThinkingLevel(level)) {
+		if (!isThinkingLevel(level, levels)) {
 			ctx.ui.notify(
-				`Unknown thinking level "${level}". Available: ${thinkingLevels.join(", ")}`,
+				`Unknown thinking level "${level}". Available: ${levels.join(", ")}`,
 				"error",
 			);
 			return;
@@ -40,9 +44,17 @@ const selectEffort =
 	};
 
 function register(pi: ExtensionAPI): void {
+	let levels: ReturnType<typeof getThinkingLevels> = [];
+
+	pi.on("session_start", (_event, ctx) => {
+		levels = getThinkingLevels(ctx.model);
+	});
+	pi.on("model_select", (event) => {
+		levels = getThinkingLevels(event.model);
+	});
 	pi.registerCommand("effort", {
 		description: "Select thinking effort",
-		getArgumentCompletions: completeLevel,
+		getArgumentCompletions: (prefix) => completeLevel(prefix, levels),
 		handler: selectEffort(pi),
 	});
 }

--- a/files/pi/agent/extensions/user/lib/thinking.ts
+++ b/files/pi/agent/extensions/user/lib/thinking.ts
@@ -1,21 +1,24 @@
-import type { ModelThinkingLevel } from "@earendil-works/pi-ai";
+import {
+	type ModelThinkingLevel,
+	getSupportedThinkingLevels,
+} from "@earendil-works/pi-ai";
 import type {
 	ExtensionAPI,
 	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
 import { showFilterSelect } from "./ui";
 
-export const thinkingLevels: readonly ModelThinkingLevel[] = [
-	"off",
-	"minimal",
-	"low",
-	"medium",
-	"high",
-	"xhigh",
-];
+export function getThinkingLevels(
+	model: ExtensionContext["model"],
+): readonly ModelThinkingLevel[] {
+	return model ? getSupportedThinkingLevels(model) : [];
+}
 
-export function isThinkingLevel(value: string): value is ModelThinkingLevel {
-	return thinkingLevels.includes(value as ModelThinkingLevel);
+export function isThinkingLevel(
+	value: string,
+	levels: readonly ModelThinkingLevel[],
+): value is ModelThinkingLevel {
+	return levels.includes(value as ModelThinkingLevel);
 }
 
 export function setThinkingLevel(
@@ -32,14 +35,16 @@ export async function showEffortSelector(
 	ctx: ExtensionContext,
 ): Promise<void> {
 	const current = pi.getThinkingLevel();
+	const levels = getThinkingLevels(ctx.model);
 	const result = await showFilterSelect(ctx, {
 		title: "Select Thinking Effort",
-		items: thinkingLevels.map((level) => ({
+		items: levels.map((level) => ({
 			value: level,
 			label: level,
 		})),
 		currentValue: current,
 	});
 
-	if (result && isThinkingLevel(result)) setThinkingLevel(pi, ctx, result);
+	if (result && isThinkingLevel(result, levels))
+		setThinkingLevel(pi, ctx, result);
 }

--- a/modules/dot/programs/scripts/git-autocommit.nix
+++ b/modules/dot/programs/scripts/git-autocommit.nix
@@ -350,16 +350,7 @@ in
     };
 
     thinking = lib.mkOption {
-      type =
-        with lib.types;
-        nullOr (enum [
-          "off"
-          "minimal"
-          "low"
-          "medium"
-          "high"
-          "xhigh"
-        ]);
+      type = with lib.types; nullOr str;
       default = null;
       description = "Pi thinking level passed to git-auto-commit. When null, no --thinking option is passed.";
     };

--- a/modules/dot/programs/scripts/worktree/default.nix
+++ b/modules/dot/programs/scripts/worktree/default.nix
@@ -45,16 +45,7 @@ in
     };
 
     thinking = lib.mkOption {
-      type =
-        with lib.types;
-        nullOr (enum [
-          "off"
-          "minimal"
-          "low"
-          "medium"
-          "high"
-          "xhigh"
-        ]);
+      type = with lib.types; nullOr str;
       default = null;
       description = "Pi thinking level passed to worktree name generation. When null, no --thinking option is passed.";
     };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,13 +10,13 @@ importers:
     dependencies:
       '@earendil-works/pi-ai':
         specifier: '*'
-        version: 0.80.3(ws@8.21.0)(zod@4.4.3)
+        version: 0.80.6(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: '*'
-        version: 0.80.3(ws@8.21.0)(zod@4.4.3)
+        version: 0.80.6(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: '*'
-        version: 0.80.3
+        version: 0.80.6
       typebox:
         specifier: '*'
         version: 1.3.3
@@ -167,22 +167,22 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@earendil-works/pi-agent-core@0.80.3':
-    resolution: {integrity: sha512-3qw0/GeRQBU/nlGjDe5Yb7ePKTmoxefx2YxyKMFAviFUMXpFexBG/hS7mBtwFahFvzrrTPPoRT6sFIDjwoDWPQ==}
+  '@earendil-works/pi-agent-core@0.80.6':
+    resolution: {integrity: sha512-Lvn89ko42h5ETUb6Z0Ku6ldskEqXaTdQBYvSa0+7bdG9V6rUEpXptv5e0OVZ1HDcvi8s6/2lGCQWsxKX+DFHNw==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-ai@0.80.3':
-    resolution: {integrity: sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-coding-agent@0.80.3':
-    resolution: {integrity: sha512-TIggw9gCXpA+Ph7OjdTA7ka2NPwTVuPmy39KDSyUzaKq8VvHfMGR7vtRz4JB7Um/RMRblmzhu4p9tUCk6MTgGA==}
+  '@earendil-works/pi-ai@0.80.6':
+    resolution: {integrity: sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-tui@0.80.3':
-    resolution: {integrity: sha512-2BJI6qwRQfnM0Q7seL1+SbacU/jRRjBnN7Hu3n9BjAn7/s5FaBNnvdD1qBQYRsFTHfjqMaDsjYqanPyqwXj99w==}
+  '@earendil-works/pi-coding-agent@0.80.6':
+    resolution: {integrity: sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-tui@0.80.6':
+    resolution: {integrity: sha512-bSuzS4EVSqEPj/Qr/p9eqCESfKsGuDNbl77EGci8Iaqqt/C/XCBZL1MjXaxSWW1NsT5afjp/Cb0NTPzOLv/aPA==}
     engines: {node: '>=22.19.0'}
 
   '@emnapi/core@1.11.1':
@@ -1477,9 +1477,9 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@earendil-works/pi-agent-core@0.80.3(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.80.6(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.80.3(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.80.6(ws@8.21.0)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -1491,7 +1491,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.80.3(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.80.6(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
@@ -1512,11 +1512,11 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.80.3(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.80.6(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.80.3(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.80.3(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.80.3
+      '@earendil-works/pi-agent-core': 0.80.6(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.80.6(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.80.6
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cross-spawn: 7.0.6
@@ -1542,7 +1542,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-tui@0.80.3':
+  '@earendil-works/pi-tui@0.80.6':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5

--- a/tests/pi/agent/extensions/user/lib/thinking.test.ts
+++ b/tests/pi/agent/extensions/user/lib/thinking.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { describe, it } from "vitest";
+import { getThinkingLevels, isThinkingLevel } from "#pi-user/lib/thinking";
+
+const model = {
+	reasoning: true,
+	thinkingLevelMap: {
+		xhigh: null,
+		max: "max",
+	},
+} as NonNullable<ExtensionContext["model"]>;
+
+describe("thinking levels", () => {
+	it("uses the levels supported by the current Pi model", () => {
+		const levels = getThinkingLevels(model);
+
+		assert.equal(levels.includes("xhigh"), false);
+		assert.equal(levels.includes("max"), true);
+		assert.equal(isThinkingLevel("max", levels), true);
+		assert.equal(isThinkingLevel("xhigh", levels), false);
+		assert.equal(isThinkingLevel("invalid", levels), false);
+	});
+
+	it("has no choices before Pi selects a model", () => {
+		assert.deepEqual(getThinkingLevels(undefined), []);
+	});
+});


### PR DESCRIPTION
Updates Pi packages to 0.80.6 and sources thinking choices dynamically from `@earendil-works/pi-ai`’s `getSupportedThinkingLevels` for the active model. Completions refresh when the model changes, Nix wrappers no longer hard-code thinking enums, and tests cover model-specific levels.

Validation: `nix fmt` and `nix flake check` passed. `pnpm lint` and `pnpm test` could not run because dependency installation aborts in the local Node/libuv supply-chain policy subprocess.