### PR TITLE
Add NixOS switch support

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -33,7 +33,7 @@ jobs:
               - '**/*.nix'
 
   home-manager-activation-package:
-    name: home-manager activationPackage (${{ matrix.config }})
+    name: Home Manager activationPackage (${{ matrix.config }})
     runs-on: ${{ matrix.os }}
     needs:
       - changes
@@ -58,12 +58,35 @@ jobs:
             experimental-features = nix-command flakes
       - run: nix build ${{ matrix.attr }}
 
+  nixos-configuration:
+    name: NixOS configuration (${{ matrix.config }})
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+    if: ${{ needs.changes.outputs.nix == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - config: nixos
+            attr: .#nixosConfigurations.nixos.config.system.build.toplevel
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - run: nix build ${{ matrix.attr }}
+
   all-nix-build-passed:
     name: All Nix Build Passed
     runs-on: ubuntu-latest
     needs:
       - changes
       - home-manager-activation-package
+      - nixos-configuration
     if: ${{ always() }}
     steps:
       - name: Verify all Nix build jobs passed

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # dotfiles
 
-d-issy's Nix Flakes + Home Manager dotfiles for Linux and macOS.
+d-issy's Nix Flakes + Home Manager dotfiles for Linux, macOS, and NixOS.
 
 ## Requirements
 
-- macOS Apple Silicon (`aarch64-darwin`)
-- macOS Intel (`x86_64-darwin`)
-- WSL2 / Linux (`x86_64-linux`)
+- One of the following environments:
+  - macOS Apple Silicon (`aarch64-darwin`)
+  - macOS Intel (`x86_64-darwin`)
+  - WSL2 / Linux (`x86_64-linux`)
+  - NixOS (`x86_64-linux`)
 - Nix with `nix-command` and `flakes` enabled
 
 ## Init
@@ -19,11 +21,12 @@ export NIX_CONFIG="extra-experimental-features = nix-command flakes"
 
 ## Switch
 
-`.#switch` automatically selects the matching Home Manager configuration for the current system.
+`.#switch` automatically selects the matching configuration for the current system.
 
 ```sh
 nix run .#switch
 ```
+
 
 ## Generations
 

--- a/flake.nix
+++ b/flake.nix
@@ -88,6 +88,23 @@
           name = "dot-switch";
           runtimeInputs = [ home-manager.packages.${system}.default ];
           text = ''
+            if [ -f /etc/NIXOS ]; then
+              host="''${DOT_NIXOS_HOST:-$(hostname)}"
+              flake_ref=".#$host"
+
+              if ! nix eval ".#nixosConfigurations.$host.config.networking.hostName" >/dev/null 2>&1; then
+                if nix eval ".#nixosConfigurations.nixos.config.networking.hostName" >/dev/null 2>&1; then
+                  flake_ref=".#nixos"
+                else
+                  echo "error: nixosConfigurations.$host is not defined" >&2
+                  echo "hint: add it to flake.nix or set DOT_NIXOS_HOST=<name>" >&2
+                  exit 1
+                fi
+              fi
+
+              exec sudo /run/current-system/sw/bin/nixos-rebuild switch --flake "$flake_ref" "$@"
+            fi
+
             exec home-manager switch --flake ".#${homeConfigurationName}" "$@"
           '';
         };
@@ -111,6 +128,31 @@
           text = ''
             exec home-manager generations "$@"
           '';
+        };
+
+      mkExtendedLib =
+        pkgs:
+        pkgs.lib.extend (
+          _: _: {
+            hm = home-manager.lib.hm;
+          }
+        );
+
+      mkDotSpecialArgs =
+        pkgs:
+        let
+          extendedLib = mkExtendedLib pkgs;
+          files = ./files;
+        in
+        {
+          dot = {
+            root = ./.;
+            inherit files;
+          }
+          // (import ./modules/dot/builtins {
+            inherit pkgs files;
+            lib = extendedLib;
+          });
         };
 
       mkLintChecks = pkgs: {
@@ -158,30 +200,69 @@
         system: homeModule:
         let
           pkgs = mkPkgs system;
-          extendedLib = pkgs.lib.extend (
-            _: _: {
-              hm = home-manager.lib.hm;
-            }
-          );
-          files = ./files;
+          extendedLib = mkExtendedLib pkgs;
         in
         home-manager.lib.homeManagerConfiguration {
           inherit pkgs;
           lib = extendedLib;
-          extraSpecialArgs = {
-            dot = {
-              root = ./.;
-              inherit files;
-            }
-            // (import ./modules/dot/builtins {
-              inherit pkgs files;
-              lib = extendedLib;
-            });
-          };
+          extraSpecialArgs = mkDotSpecialArgs pkgs;
           modules = [
             homeModule
             nixvim.homeModules.nixvim
             ./modules/dot
+          ];
+        };
+
+      mkNixosConfiguration =
+        system:
+        let
+          pkgs = mkPkgs system;
+        in
+        nixpkgs.lib.nixosSystem {
+          inherit system;
+          specialArgs = mkDotSpecialArgs pkgs;
+          modules = [
+            { nixpkgs.pkgs = pkgs; }
+            {
+              networking.hostName = "nixos";
+
+              # Keep the generic NixOS configuration evaluable without
+              # machine-specific hardware settings. Real hosts can override
+              # these values in a hostname-specific configuration.
+              boot.loader.grub.enable = false;
+              fileSystems."/" = {
+                device = "none";
+                fsType = "tmpfs";
+              };
+
+              nix.settings.experimental-features = [
+                "nix-command"
+                "flakes"
+              ];
+
+              users.users.issy = {
+                isNormalUser = true;
+                extraGroups = [ "wheel" ];
+                shell = pkgs.zsh;
+              };
+
+              programs.zsh.enable = true;
+
+              system.stateVersion = "26.05";
+            }
+            home-manager.nixosModules.home-manager
+            {
+              home-manager = {
+                useGlobalPkgs = true;
+                useUserPackages = true;
+                extraSpecialArgs = mkDotSpecialArgs pkgs;
+                users.issy.imports = [
+                  ./modules/home/nixos.nix
+                  nixvim.homeModules.nixvim
+                  ./modules/dot
+                ];
+              };
+            }
           ];
         };
     in
@@ -245,6 +326,10 @@
         linux = mkHomeManagerConfiguration "x86_64-linux" ./modules/home/linux.nix;
         macos = mkHomeManagerConfiguration "aarch64-darwin" ./modules/home/macos.nix;
         macos_intel = mkHomeManagerConfiguration "x86_64-darwin" ./modules/home/macos.nix;
+      };
+
+      nixosConfigurations = {
+        nixos = mkNixosConfiguration "x86_64-linux";
       };
     };
 }

--- a/modules/home/nixos.nix
+++ b/modules/home/nixos.nix
@@ -1,0 +1,5 @@
+{ ... }:
+
+{
+  imports = [ ./linux.nix ];
+}


### PR DESCRIPTION

## Summary

- add a NixOS flake configuration that reuses the existing Home Manager modules
- make `nix run .#switch` choose `nixos-rebuild switch` on NixOS and keep Home Manager elsewhere
- document NixOS usage and add CI coverage for NixOS configuration evaluation

## Background

This keeps the existing repository structure centered on `modules/home` while allowing the same switch command to work across macOS, non-NixOS Linux, and NixOS.
