### PR TITLE
Fix Neovim Copilot completion setup

### DIFF
--- a/modules/recipes/neovim/plugins/ai.nix
+++ b/modules/recipes/neovim/plugins/ai.nix
@@ -15,4 +15,21 @@ _:
       };
     };
   };
+
+  programs.nixvim.extraConfigLua = ''
+    vim.defer_fn(function()
+      local auth = require("copilot.auth")
+      auth.is_authenticated(function(error)
+        if not error and not auth.is_authenticated() then
+          vim.schedule(function()
+            vim.notify(
+              "GitHub Copilot is not authenticated.\nRun `:Copilot auth` to enable completions.",
+              vim.log.levels.WARN,
+              { title = "Copilot login required" }
+            )
+          end)
+        end
+      end)
+    end, 500)
+  '';
 }

--- a/modules/recipes/neovim/plugins/ai.nix
+++ b/modules/recipes/neovim/plugins/ai.nix
@@ -1,33 +1,17 @@
 _:
 
 {
-  programs.nixvim.plugins = {
-    copilot-lua = {
-      enable = true;
-      lazyLoad.settings.cmd = "Copilot";
-      settings = {
-        suggestion.enabled = false;
-        panel.enabled = false;
-        filetypes = {
-          markdown = true;
-          help = true;
-        };
+  programs.nixvim.plugins.copilot-lua = {
+    enable = true;
+    settings = {
+      panel.enabled = false;
+      suggestion = {
+        enabled = true;
+        autoTrigger = true;
       };
-    };
-
-    avante = {
-      enable = true;
-      settings = {
-        provider = "copilot";
-        file_selector.provider = "snacks";
-        windows = {
-          sidebar_header = {
-            enabled = true;
-            align = "right";
-            rounded = false;
-          };
-          input.prefix = "";
-        };
+      filetypes = {
+        markdown = true;
+        help = true;
       };
     };
   };

--- a/modules/recipes/neovim/plugins/ai.nix
+++ b/modules/recipes/neovim/plugins/ai.nix
@@ -17,19 +17,27 @@ _:
   };
 
   programs.nixvim.extraConfigLua = ''
-    vim.defer_fn(function()
+    local function check_copilot_auth(attempt)
+      local client = require("copilot.client")
+      if not client.initialized then
+        if attempt < 20 then
+          vim.defer_fn(function() check_copilot_auth(attempt + 1) end, 250)
+        end
+        return
+      end
+
       local auth = require("copilot.auth")
-      auth.is_authenticated(function(error)
-        if not error and not auth.is_authenticated() then
-          vim.schedule(function()
-            vim.notify(
-              "GitHub Copilot is not authenticated.\nRun `:Copilot auth` to enable completions.",
-              vim.log.levels.WARN,
-              { title = "Copilot login required" }
-            )
-          end)
+      auth.is_authenticated(function()
+        if not auth.is_authenticated() then
+          vim.notify(
+            "GitHub Copilot is not authenticated.\nRun `:Copilot auth` to enable completions.",
+            vim.log.levels.WARN,
+            { title = "Copilot login required" }
+          )
         end
       end)
-    end, 500)
+    end
+
+    vim.defer_fn(function() check_copilot_auth(1) end, 250)
   '';
 }


### PR DESCRIPTION
## Summary

Enable native Copilot inline completions in Neovim and remove the unused Avante integration.

## Background

Avante expects legacy Copilot authentication files, while the installed copilot.lua stores credentials in the newer auth database. This caused Neovim startup errors even after successful authentication. Copilot now provides inline suggestions directly and warns when authentication is required.
