### PR TITLE
Add CLI programs

### DIFF
--- a/modules/dot/programs/default.nix
+++ b/modules/dot/programs/default.nix
@@ -7,8 +7,11 @@
     ./ghq.nix
     ./herdr.nix
     ./mise.nix
+    ./mycli.nix
     ./navi.nix
+    ./pgcli.nix
     ./scripts
     ./tmux
+    ./visidata.nix
   ];
 }

--- a/modules/dot/programs/mycli.nix
+++ b/modules/dot/programs/mycli.nix
@@ -1,0 +1,21 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.dot.programs.mycli;
+in
+{
+  options.dot.programs.mycli = {
+    enable = lib.mkEnableOption "mycli";
+
+    package = lib.mkPackageOption pkgs "mycli" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+  };
+}

--- a/modules/dot/programs/pgcli.nix
+++ b/modules/dot/programs/pgcli.nix
@@ -1,0 +1,21 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.dot.programs.pgcli;
+in
+{
+  options.dot.programs.pgcli = {
+    enable = lib.mkEnableOption "pgcli";
+
+    package = lib.mkPackageOption pkgs "pgcli" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+  };
+}

--- a/modules/dot/programs/visidata.nix
+++ b/modules/dot/programs/visidata.nix
@@ -1,0 +1,21 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.dot.programs.visidata;
+in
+{
+  options.dot.programs.visidata = {
+    enable = lib.mkEnableOption "visidata";
+
+    package = lib.mkPackageOption pkgs "visidata" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+  };
+}

--- a/modules/recipes/default.nix
+++ b/modules/recipes/default.nix
@@ -69,17 +69,20 @@
     ./lazygit.nix
     ./make.nix
     ./mise.nix
+    ./mycli.nix
     ./navi.nix
     ./neovim
     ./nix.nix
     ./javascript.nix
     ./nushell.nix
+    ./pgcli.nix
     ./pi.nix
     ./python.nix
     ./scripts.nix
     ./starship.nix
     ./tm.nix
     ./tmux.nix
+    ./visidata.nix
     ./zed.nix
     ./zsh.nix
   ];

--- a/modules/recipes/mycli.nix
+++ b/modules/recipes/mycli.nix
@@ -1,0 +1,3 @@
+{
+  dot.programs.mycli.enable = false;
+}

--- a/modules/recipes/pgcli.nix
+++ b/modules/recipes/pgcli.nix
@@ -1,0 +1,3 @@
+{
+  dot.programs.pgcli.enable = true;
+}

--- a/modules/recipes/visidata.nix
+++ b/modules/recipes/visidata.nix
@@ -1,0 +1,3 @@
+{
+  dot.programs.visidata.enable = true;
+}


### PR DESCRIPTION

## Summary

- add configurable `dot.programs` modules for mycli, pgcli, and VisiData
- enable pgcli and VisiData in the default recipes
- keep mycli disabled by default

## Background

- provide database CLI tools through the same enable/package option pattern as other managed programs
