### PR TITLE
Disable Herdr notification sounds

### DIFF
--- a/modules/recipes/herdr.nix
+++ b/modules/recipes/herdr.nix
@@ -33,6 +33,7 @@
             pane_gaps = true;
             show_agent_labels_on_pane_borders = true;
 
+            sound.enabled = false;
             toast.delivery = "herdr";
           };
 


### PR DESCRIPTION

## Summary

- Disable sounds when agents change state in background Herdr workspaces
- Keep in-app toast notifications enabled

## Background

- Herdr notification sounds are disruptive during normal use
