### PR TITLE
Use default Claude Code output style

### DIFF
--- a/files/claude/settings.json
+++ b/files/claude/settings.json
@@ -39,7 +39,7 @@
       "Bash(rmdir:*)"
     ]
   },
-  "outputStyle": "Explanatory",
+  "outputStyle": "default",
   "includeGitInstructions": false,
   "autoMemoryEnabled": false,
   "env": {


### PR DESCRIPTION

## Summary

- Set `outputStyle` to `default` in `files/claude/settings.json`, replacing `Explanatory`

## Background

- The Explanatory style's `★ Insight` blocks are no longer wanted
- The Claude settings are deployed via `dot.mergeJson`, which only overwrites keys present in the repo file. Removing the key would leave the old `Explanatory` value in `~/.claude/settings.json`, so the value is set explicitly instead
