### PR TITLE
Clarify home directory write rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Per-tool recipe in `modules/recipes/[tool].nix`, config files in `files/[tool]/`
 
 ## Rules
 
-- Do not write to files under `~/` directly; make changes through `files/` in this repository, except when the user explicitly asks to test sandbox behavior
+- Do not write to files under `~/` directly unless the user explicitly asks; otherwise, make changes through `files/` in this repository
 - To deploy files from `files/`, prefer the `dot.*` options (`dot.xdg.configFile` / `dot.home.file`) over raw `home.file` / `xdg.configFile`
 - Do not switch unless explicitly asked. To apply: `nix run .#switch` (auto-selects the host config)
 - Format with `nix fmt`; verify with `pnpm lint` and `nix flake check` (`nix flake check` runs treefmt, deadnix, statix, oxlint, actionlint, zizmor)


### PR DESCRIPTION
## Summary

- Allow direct writes under `~/` when the user explicitly requests them.
- Keep repository-managed dotfile changes as the default.

## Background

- The previous wording limited the exception to sandbox behavior tests.
- This made explicit user requests appear prohibited, contrary to the intended safeguard against unsolicited home-directory changes.