### PR TITLE
Refine Herdr UI and input settings

### DIFF
--- a/modules/recipes/herdr.nix
+++ b/modules/recipes/herdr.nix
@@ -18,6 +18,7 @@
         };
 
         settings = {
+          experimental.switch_ascii_input_source_in_prefix = true;
           onboarding = false;
           terminal.default_shell = "${pkgs.nushell}/bin/nu";
 
@@ -29,17 +30,26 @@
           };
 
           ui = {
+            hide_tab_bar_when_single_tab = true;
             pane_borders = true;
             pane_gaps = true;
+            prompt_new_tab_name = false;
             show_agent_labels_on_pane_borders = true;
 
             sound.enabled = false;
-            toast.delivery = "herdr";
+            toast = {
+              clipboard.position = "bottom-left";
+              delivery = "herdr";
+              herdr.position = "bottom-left";
+            };
           };
 
           theme = {
             name = "catppuccin";
             custom = {
+              surface_dim = "#313244";
+              surface0 = "#45475a";
+
               # Inactive tab text uses overlay0/overlay1 on surface0.
               overlay0 = "#a6adc8";
               overlay1 = "#bac2de";


### PR DESCRIPTION

## Summary

- make active and selected Herdr spaces easier to distinguish
- streamline single-tab creation and position toasts in the bottom-left
- temporarily switch the macOS input source to ASCII during prefix mode

## Background

- Herdr 0.7.4 uses a compact sidebar, making clear selection styling more important
- Japanese IME input can interfere with prefix commands without temporary input-source switching
