### PR TITLE
Disable Herdr experimental input source switching

### DIFF
--- a/modules/recipes/herdr.nix
+++ b/modules/recipes/herdr.nix
@@ -18,7 +18,6 @@
         };
 
         settings = {
-          experimental.switch_ascii_input_source_in_prefix = true;
           onboarding = false;
           terminal.default_shell = "${pkgs.nushell}/bin/nu";
 


### PR DESCRIPTION

## Summary

- Disable Herdr experimental input-source switching.
- Keep the rest of the Herdr integration unchanged.

## Background

- The experiment was less stable than expected.
- Fall back to Herdr's default input-source behavior.
