### PR TITLE
Add Codex status line profile

### DIFF
--- a/files/codex/statusline.config.toml
+++ b/files/codex/statusline.config.toml
@@ -1,0 +1,7 @@
+[tui]
+status_line = [
+  "model-with-reasoning",
+  "current-dir",
+  "context-remaining",
+  "weekly-limit",
+]

--- a/modules/recipes/codex.nix
+++ b/modules/recipes/codex.nix
@@ -1,4 +1,37 @@
+{ pkgs, ... }:
+
+let
+  codexStatusline = pkgs.writeShellApplication {
+    name = "codex-statusline";
+    text = ''
+      case "''${1-}" in
+        "" | exec | e | review | resume | archive | delete | unarchive | fork | mcp | sandbox)
+          exec codex --profile statusline "$@"
+          ;;
+        debug)
+          if [[ "''${2-}" == "prompt-input" ]]; then
+            exec codex --profile statusline "$@"
+          fi
+          exec codex "$@"
+          ;;
+        -h | --help | -V | --version | login | logout | plugin | mcp-server | app-server | remote-control | app | completion | update | doctor | apply | cloud | exec-server | features | help)
+          exec codex "$@"
+          ;;
+        *)
+          exec codex --profile statusline "$@"
+          ;;
+      esac
+    '';
+  };
+in
 {
+  home = {
+    packages = [ codexStatusline ];
+    shellAliases.codex = "codex-statusline";
+  };
+
+  dot.home.file.".codex/statusline.config.toml".source = "codex/statusline.config.toml";
+
   home.file.".codex/hooks.json".text =
     builtins.toJSON {
       hooks.Stop = [


### PR DESCRIPTION
Adds a dedicated Codex status-line configuration and a shell wrapper that selects it for interactive commands while preserving the default profile for utility commands.

Tests: Not run (no command-execution tool available in this session).