### PR TITLE
Prevent vtsls TSServer OOM crashes

### DIFF
--- a/modules/recipes/neovim/lsp/vtsls.nix
+++ b/modules/recipes/neovim/lsp/vtsls.nix
@@ -35,6 +35,10 @@ in
           updateImportsOnFileMove.enabled = "always";
           suggest.completeFunctionCalls = true;
           preferences.importModuleSpecifier = "non-relative";
+          tsserver = {
+            maxTsServerMemory = 8192;
+            useSyntaxServer = "never";
+          };
           inherit inlayHints;
         };
 


### PR DESCRIPTION

## Summary

- increase the TSServer memory limit to 8 GB
- use a single TSServer process for TypeScript syntax and semantic operations

## Background

- TSServer repeatedly exhausted its default 3 GB heap and exited with SIGABRT
- vtsls restarted the failed process continuously, producing large numbers of crashes
