### PR TITLE
Clarify change-scoped verification guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,4 +8,8 @@ Per-tool recipe in `modules/recipes/[tool].nix`, config files in `files/[tool]/`
 - Do not write to files under `~/` directly unless the user explicitly asks; otherwise, make changes through `files/` in this repository
 - To deploy files from `files/`, prefer the `dot.*` options (`dot.xdg.configFile` / `dot.home.file`) over raw `home.file` / `xdg.configFile`
 - Do not switch unless explicitly asked. To apply: `nix run .#switch` (auto-selects the host config)
-- Format with `nix fmt`; verify with `pnpm lint` and `nix flake check` (`nix flake check` runs treefmt, deadnix, statix, oxlint, actionlint, zizmor)
+- Format changed files with `nix fmt`
+- Choose verification based on the change scope:
+  - Run `nix flake check` for Nix/Home Manager, flake, repository tooling, or GitHub Actions changes; it runs treefmt, deadnix, statix, oxlint, actionlint, and zizmor
+  - Run `pnpm lint` for TypeScript/JavaScript, `tsconfig`, or package/dependency changes that can affect TypeScript checking
+  - Run both when a change spans both scopes; neither is required for documentation-only changes unless they affect tooling or generated output


### PR DESCRIPTION

## Summary

- separate formatting guidance from verification requirements
- define when to run `nix flake check` and `pnpm lint`
- clarify when both checks or neither check are appropriate

## Background

- the previous rule required both checks for every change
- scope-specific guidance avoids unrelated validation while preserving the relevant repository checks
