### PR TITLE
Fix Codex trust persistence

### DIFF
--- a/files/codex/statusline.config.toml
+++ b/files/codex/statusline.config.toml
@@ -1,7 +1,0 @@
-[tui]
-status_line = [
-  "model-with-reasoning",
-  "current-dir",
-  "context-remaining",
-  "weekly-limit",
-]

--- a/modules/recipes/codex.nix
+++ b/modules/recipes/codex.nix
@@ -1,16 +1,18 @@
 { pkgs, ... }:
 
 let
+  statusLineConfig = ''tui.status_line=["model-with-reasoning","current-dir","context-remaining","weekly-limit"]'';
+
   codexStatusline = pkgs.writeShellApplication {
     name = "codex-statusline";
     text = ''
       case "''${1-}" in
         "" | exec | e | review | resume | archive | delete | unarchive | fork | mcp | sandbox)
-          exec codex --profile statusline "$@"
+          exec codex --config '${statusLineConfig}' "$@"
           ;;
         debug)
           if [[ "''${2-}" == "prompt-input" ]]; then
-            exec codex --profile statusline "$@"
+            exec codex --config '${statusLineConfig}' "$@"
           fi
           exec codex "$@"
           ;;
@@ -18,7 +20,7 @@ let
           exec codex "$@"
           ;;
         *)
-          exec codex --profile statusline "$@"
+          exec codex --config '${statusLineConfig}' "$@"
           ;;
       esac
     '';
@@ -29,8 +31,6 @@ in
     packages = [ codexStatusline ];
     shellAliases.codex = "codex-statusline";
   };
-
-  dot.home.file.".codex/statusline.config.toml".source = "codex/statusline.config.toml";
 
   home.file.".codex/hooks.json".text =
     builtins.toJSON {


### PR DESCRIPTION
## Summary

Replace the status-line profile with a command-line configuration override and remove the Home Manager-managed profile file. This preserves the customized TUI footer while allowing Codex to persist mutable user state in its base configuration.

## Background

Codex attempts to write project trust decisions to the selected profile file when launched with `--profile`. The status-line profile was linked into the read-only Nix store, so accepting a repository trust prompt failed with `config/batchWrite`. Passing only the status-line value through `--config` avoids selecting an immutable profile and leaves trust persistence in the writable user configuration.