### PR TITLE
Fix vulnerable undici transitive dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  undici@<8.9.0: 8.9.0
+
 importers:
 
   .:
@@ -1108,8 +1111,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@8.5.0:
-    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+  undici@8.9.0:
+    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
     engines: {node: '>=22.19.0'}
 
   vite@8.2.0:
@@ -1528,7 +1531,7 @@ snapshots:
       proper-lockfile: 4.1.2
       semver: 7.8.0
       typebox: 1.3.7
-      undici: 8.5.0
+      undici: 8.9.0
       yaml: 2.9.0
     optionalDependencies:
       '@mariozechner/clipboard': 0.3.9
@@ -2330,7 +2333,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@8.5.0: {}
+  undici@8.9.0: {}
 
   vite@8.2.0(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,7 @@ allowBuilds:
   '@google/genai': false
   koffi: false
   protobufjs: false
+overrides:
+  "undici@<8.9.0": 8.9.0
+minimumReleaseAgeExclude:
+  - undici@8.9.0


### PR DESCRIPTION
## Summary

- Pin vulnerable transitive `undici` releases to 8.9.0.
- Regenerate the pnpm lockfile with the patched resolution.

## Background

Dependabot alert #9 identified `undici` 8.5.0 as vulnerable to cross-user information disclosure and a cache-control parsing crash. The upstream dependency resolves it transitively, so a targeted pnpm override ensures every vulnerable `undici` edge uses the first patched 8.x release.
