### PR TITLE
Skip Nixvim in macOS CI

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -45,9 +45,9 @@ jobs:
           - config: linux
             os: ubuntu-latest
             attr: .#homeConfigurations.linux.activationPackage
-          - config: macos
+          - config: macos (without Nixvim)
             os: macos-latest
-            attr: .#homeConfigurations.macos.activationPackage
+            attr: .#homeConfigurations.macos_ci.activationPackage
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/flake.nix
+++ b/flake.nix
@@ -213,7 +213,11 @@
       };
 
       mkHomeManagerConfiguration =
-        system: homeModule:
+        {
+          system,
+          homeModule,
+          includeNeovim ? true,
+        }:
         let
           pkgs = mkPkgs system;
           extendedLib = mkExtendedLib pkgs;
@@ -221,12 +225,14 @@
         home-manager.lib.homeManagerConfiguration {
           inherit pkgs;
           lib = extendedLib;
-          extraSpecialArgs = mkDotSpecialArgs pkgs;
+          extraSpecialArgs = (mkDotSpecialArgs pkgs) // {
+            inherit includeNeovim;
+          };
           modules = [
             homeModule
-            nixvim.homeModules.nixvim
             ./modules/dot
-          ];
+          ]
+          ++ extendedLib.optional includeNeovim nixvim.homeModules.nixvim;
         };
 
       mkNixosConfiguration =
@@ -271,7 +277,9 @@
               home-manager = {
                 useGlobalPkgs = true;
                 useUserPackages = true;
-                extraSpecialArgs = mkDotSpecialArgs pkgs;
+                extraSpecialArgs = (mkDotSpecialArgs pkgs) // {
+                  includeNeovim = true;
+                };
                 users.issy.imports = [
                   ./modules/home/nixos.nix
                   nixvim.homeModules.nixvim
@@ -339,9 +347,23 @@
       };
 
       homeConfigurations = {
-        linux = mkHomeManagerConfiguration "x86_64-linux" ./modules/home/linux.nix;
-        macos = mkHomeManagerConfiguration "aarch64-darwin" ./modules/home/macos.nix;
-        macos_intel = mkHomeManagerConfiguration "x86_64-darwin" ./modules/home/macos.nix;
+        linux = mkHomeManagerConfiguration {
+          system = "x86_64-linux";
+          homeModule = ./modules/home/linux.nix;
+        };
+        macos = mkHomeManagerConfiguration {
+          system = "aarch64-darwin";
+          homeModule = ./modules/home/macos.nix;
+        };
+        macos_ci = mkHomeManagerConfiguration {
+          system = "aarch64-darwin";
+          homeModule = ./modules/home/macos.nix;
+          includeNeovim = false;
+        };
+        macos_intel = mkHomeManagerConfiguration {
+          system = "x86_64-darwin";
+          homeModule = ./modules/home/macos.nix;
+        };
       };
 
       nixosConfigurations = {

--- a/modules/recipes/default.nix
+++ b/modules/recipes/default.nix
@@ -1,4 +1,10 @@
-{ config, pkgs, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  includeNeovim ? true,
+  ...
+}:
 
 {
   xdg.enable = true;
@@ -71,7 +77,9 @@
     ./mise.nix
     ./mycli.nix
     ./navi.nix
-    ./neovim
+  ]
+  ++ lib.optional includeNeovim ./neovim
+  ++ [
     ./nix.nix
     ./javascript.nix
     ./nushell.nix


### PR DESCRIPTION
## Summary

- add a `macos_ci` Home Manager configuration that skips the Nixvim module and Neovim recipe
- use that target for the macOS activation-package CI job while retaining the full macOS and Linux configurations

## Background

The macOS activation-package build spends most of its time rebuilding the Nixvim closure after flake input updates. The CI-specific configuration preserves macOS Home Manager coverage for the remaining modules without rebuilding Nixvim on every Nix change.