### PR TITLE
Remove Darwin seaborn overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,23 +45,6 @@
             builtins.elem (nixpkgs.lib.getName pkg) [
               "copilot-language-server"
             ];
-          overlays = [
-            (final: prev: {
-              pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
-                (_: pythonPrev: {
-                  seaborn = pythonPrev.seaborn.overridePythonAttrs (old: {
-                    # Temporary workaround for an upstream seaborn test failure on
-                    # Darwin. Remove once the test no longer depends on font metrics.
-                    disabledTests =
-                      (old.disabledTests or [ ])
-                      ++ final.lib.optionals final.stdenv.hostPlatform.isDarwin [
-                        "test_ticklabels_overlap"
-                      ];
-                  });
-                })
-              ];
-            })
-          ];
         };
 
       mkToolPackages = pkgs: rec {


### PR DESCRIPTION
## Summary

- remove the Darwin-specific `seaborn` test override
- let the macOS Home Manager build use the upstream Nixpkgs derivation unchanged

## Background

The override produces a custom Darwin derivation that cannot use Nixpkgs' binary cache. This isolated change tests whether rebuilding that derivation is responsible for the slow macOS CI job.