### PR TITLE
Separate Nix flake checks from builds

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -33,8 +33,34 @@ jobs:
               - '**/*.nix'
               - '.github/workflows/nix-build.yml'
 
-  home-manager-activation-package:
-    name: Home Manager activationPackage (${{ matrix.config }})
+  nix-flake-check:
+    name: Nix flake check (${{ matrix.config }})
+    runs-on: ${{ matrix.os }}
+    needs:
+      - changes
+    if: ${{ needs.changes.outputs.nix == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - config: linux
+            os: ubuntu-latest
+          - config: macos
+            os: macos-latest
+          - config: nixos
+            os: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - run: nix flake check
+
+  nix-build:
+    name: Nix build (${{ matrix.config }})
     runs-on: ${{ matrix.os }}
     needs:
       - changes
@@ -46,43 +72,8 @@ jobs:
           - config: linux
             os: ubuntu-latest
             attr: .#homeConfigurations.linux.activationPackage
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-      - run: nix build ${{ matrix.attr }}
-
-  macos-flake-check:
-    name: Nix flake check (macos)
-    runs-on: macos-latest
-    needs:
-      - changes
-    if: ${{ needs.changes.outputs.nix == 'true' }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-      - run: nix flake check
-
-  nixos-configuration:
-    name: NixOS configuration (${{ matrix.config }})
-    runs-on: ubuntu-latest
-    needs:
-      - changes
-    if: ${{ needs.changes.outputs.nix == 'true' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
           - config: nixos
+            os: ubuntu-latest
             attr: .#nixosConfigurations.nixos.config.system.build.toplevel
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -99,9 +90,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - changes
-      - home-manager-activation-package
-      - macos-flake-check
-      - nixos-configuration
+      - nix-flake-check
+      - nix-build
     if: ${{ always() }}
     steps:
       - name: Verify all Nix jobs passed

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -31,6 +31,7 @@ jobs:
             nix:
               - 'flake.lock'
               - '**/*.nix'
+              - '.github/workflows/nix-build.yml'
 
   home-manager-activation-package:
     name: Home Manager activationPackage (${{ matrix.config }})

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -45,9 +45,6 @@ jobs:
           - config: linux
             os: ubuntu-latest
             attr: .#homeConfigurations.linux.activationPackage
-          - config: macos
-            os: macos-latest
-            attr: .#homeConfigurations.macos.activationPackage
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -57,6 +54,22 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - run: nix build ${{ matrix.attr }}
+
+  macos-flake-check:
+    name: Nix flake check (macos)
+    runs-on: macos-latest
+    needs:
+      - changes
+    if: ${{ needs.changes.outputs.nix == 'true' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - run: nix flake check
 
   nixos-configuration:
     name: NixOS configuration (${{ matrix.config }})
@@ -86,10 +99,11 @@ jobs:
     needs:
       - changes
       - home-manager-activation-package
+      - macos-flake-check
       - nixos-configuration
     if: ${{ always() }}
     steps:
-      - name: Verify all Nix build jobs passed
+      - name: Verify all Nix jobs passed
         env:
           RESULTS: ${{ join(needs.*.result, ',') }}
         run: |


### PR DESCRIPTION
## Summary

- run `nix flake check` for Linux, macOS, and NixOS in a matrix job
- keep the Linux Home Manager activation-package and NixOS configuration builds in a separate matrix job
- run Nix CI when `.github/workflows/nix-build.yml` changes

## Motivation

Keep full build coverage while making flake-check results explicit for all supported configurations, including macOS.