### PR TITLE
Improve Herdr and tmux selector controls

### DIFF
--- a/modules/dot/programs/scripts/hr.nix
+++ b/modules/dot/programs/scripts/hr.nix
@@ -71,24 +71,15 @@ let
         server_running=true
       fi
 
-      if "$server_running" && [ -n "$(${workspaceSwitcherCommand})" ]; then
-        selected=$(
-          ${workspaceSwitcherCommand} \
-            | ${fuzzyFinderCommand} \
-              --delimiter='\t' \
-              --with-nth=3 \
-              --header='Ctrl-C: repos/orgs' \
-              --bind="ctrl-c:reload(${repoSwitcherCommand})+change-header(Repos/orgs)"
-        )
-      else
-        selected=$(
-          ${repoSwitcherCommand} \
-            | ${fuzzyFinderCommand} \
-              --delimiter='\t' \
-              --with-nth=3 \
-              --header='Repos/orgs'
-        )
-      fi
+      selected=$(
+        ${workspaceSwitcherCommand} \
+          | ${fuzzyFinderCommand} \
+            --delimiter='\t' \
+            --with-nth=3 \
+            --header='Ctrl-R: repos/orgs  Ctrl-D: delete' \
+            --bind="ctrl-r:reload(${repoSwitcherCommand})+change-header(Repos/orgs)" \
+            --bind="ctrl-d:execute($herdr workspace close {2} >/dev/null)+reload(${workspaceSwitcherCommand})"
+      )
 
       if [ -z "$selected" ]; then
         exit 0
@@ -104,7 +95,7 @@ let
           ;;
         repo)
           [ -n "$value" ] && [ -d "$value" ] || exit 0
-          label="$(printf '%s' "$selected" | cut -f 4-)"
+          label="$(printf '%s' "$selected" | cut -f 3-)"
           [ -n "$label" ] || label="$(basename "$value")"
 
           if ! "$server_running"; then
@@ -140,12 +131,12 @@ let
 in
 {
   options.dot.programs.scripts.hr = {
-    enable = lib.mkEnableOption "personal hr Herdr workspace selector command";
+    enable = lib.mkEnableOption "personal hr Herdr space selector command";
 
     commandName = lib.mkOption {
       type = lib.types.str;
       default = "hr";
-      description = "Command name for selecting Herdr workspaces/repositories and launching Herdr.";
+      description = "Command name for selecting Herdr spaces and repositories.";
     };
 
     herdrPackage = lib.mkOption {

--- a/modules/dot/programs/scripts/tm.nix
+++ b/modules/dot/programs/scripts/tm.nix
@@ -42,8 +42,8 @@ let
         target=$(
           tmux list-sessions -F '#S' 2>/dev/null \
             | ${fuzzyFinderCommand} \
-              --header='Ctrl-C: repos/orgs  Ctrl-D: delete' \
-              --bind="ctrl-c:reload(${repoSwitcherCommand})+change-header(Repos/orgs)" \
+              --header='Ctrl-R: repos/orgs  Ctrl-D: delete' \
+              --bind="ctrl-r:reload(${repoSwitcherCommand})+change-header(Repos/orgs)" \
               --bind="ctrl-d:execute(tmux kill-session -t {1})+reload(tmux list-sessions -F '#S' 2>/dev/null || true)"
         )
       else


### PR DESCRIPTION
## Summary

- Update the Herdr selector to switch between spaces and repositories with Ctrl-R.
- Add Ctrl-D deletion for Herdr spaces and refresh the selector afterward.
- Align the tmux selector repository switch shortcut with Ctrl-R.
- Update the Herdr option descriptions to use “space” terminology.

## Background

The interactive selectors used inconsistent terminology and shortcut behavior. This change makes the Herdr selector space-oriented while keeping repository switching and deletion discoverable, and keeps the tmux shortcut naming consistent.