### PR TITLE
Remove seaborn overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,23 +45,6 @@
             builtins.elem (nixpkgs.lib.getName pkg) [
               "copilot-language-server"
             ];
-          overlays = [
-            (final: prev: {
-              pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
-                (_: pythonPrev: {
-                  seaborn = pythonPrev.seaborn.overridePythonAttrs (old: {
-                    # Temporary workaround for an upstream seaborn test failure on
-                    # Darwin. Remove once the test no longer depends on font metrics.
-                    disabledTests =
-                      (old.disabledTests or [ ])
-                      ++ final.lib.optionals final.stdenv.hostPlatform.isDarwin [
-                        "test_ticklabels_overlap"
-                      ];
-                  });
-                })
-              ];
-            })
-          ];
         };
 
       mkToolPackages = pkgs: rec {


### PR DESCRIPTION
## Summary

- Remove the temporary Darwin-specific seaborn test overlay.

## Background

The upstream workaround is no longer needed, so importing nixpkgs no longer modifies `pythonPackagesExtensions`.