### PR TITLE
Add configurable Codex program module

### DIFF
--- a/modules/dot/programs/codex.nix
+++ b/modules/dot/programs/codex.nix
@@ -1,0 +1,88 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.dot.programs.codex;
+
+  flattenSettings =
+    path: settings:
+    lib.concatMap (
+      name:
+      let
+        value = settings.${name};
+        key = lib.concatStringsSep "." (path ++ [ name ]);
+      in
+      if builtins.isAttrs value then
+        flattenSettings (path ++ [ name ]) value
+      else
+        [ "${key}=${builtins.toJSON value}" ]
+    ) (lib.attrNames settings);
+
+  configArgs = lib.concatMapStringsSep " " (setting: "--config ${lib.escapeShellArg setting}") (
+    flattenSettings [ ] cfg.settings
+  );
+
+  codexWrapper = pkgs.writeShellApplication {
+    name = "codex-statusline";
+    text = ''
+      case "''${1-}" in
+        "" | exec | e | review | resume | archive | delete | unarchive | fork | mcp | sandbox)
+          exec ${cfg.command} ${configArgs} "$@"
+          ;;
+        debug)
+          if [[ "''${2-}" == "prompt-input" ]]; then
+            exec ${cfg.command} ${configArgs} "$@"
+          fi
+          exec ${cfg.command} "$@"
+          ;;
+        -h | --help | -V | --version | login | logout | plugin | mcp-server | app-server | remote-control | app | completion | update | doctor | apply | cloud | exec-server | features | help)
+          exec ${cfg.command} "$@"
+          ;;
+        *)
+          exec ${cfg.command} ${configArgs} "$@"
+          ;;
+      esac
+    '';
+  };
+in
+{
+  options.dot.programs.codex = {
+    enable = lib.mkEnableOption "Codex";
+
+    command = lib.mkOption {
+      type = lib.types.str;
+      default = "codex";
+      description = "Codex command invoked by the wrapper.";
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+      description = "Codex settings passed as command-line configuration overrides.";
+      example = {
+        agents.max_concurrent_threads_per_session = 8;
+      };
+    };
+
+    hooks = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+      description = "Codex hooks written to .codex/hooks.json.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home = {
+      packages = [ codexWrapper ];
+      shellAliases.codex = "codex-statusline";
+    };
+
+    home.file.".codex/hooks.json" = lib.mkIf (cfg.hooks != { }) {
+      text = builtins.toJSON { inherit (cfg) hooks; } + "\n";
+    };
+  };
+}

--- a/modules/dot/programs/default.nix
+++ b/modules/dot/programs/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ./agent-skills.nix
     ./aws.nix
+    ./codex.nix
     ./fzf.nix
     ./gcloud.nix
     ./ghq.nix

--- a/modules/recipes/codex.nix
+++ b/modules/recipes/codex.nix
@@ -1,50 +1,32 @@
-{ pkgs, ... }:
+_:
 
-let
-  statusLineConfig = ''tui.status_line=["model-with-reasoning","current-dir","context-remaining","weekly-limit"]'';
-
-  codexStatusline = pkgs.writeShellApplication {
-    name = "codex-statusline";
-    text = ''
-      case "''${1-}" in
-        "" | exec | e | review | resume | archive | delete | unarchive | fork | mcp | sandbox)
-          exec codex --config '${statusLineConfig}' "$@"
-          ;;
-        debug)
-          if [[ "''${2-}" == "prompt-input" ]]; then
-            exec codex --config '${statusLineConfig}' "$@"
-          fi
-          exec codex "$@"
-          ;;
-        -h | --help | -V | --version | login | logout | plugin | mcp-server | app-server | remote-control | app | completion | update | doctor | apply | cloud | exec-server | features | help)
-          exec codex "$@"
-          ;;
-        *)
-          exec codex --config '${statusLineConfig}' "$@"
-          ;;
-      esac
-    '';
-  };
-in
 {
-  home = {
-    packages = [ codexStatusline ];
-    shellAliases.codex = "codex-statusline";
-  };
+  dot.programs.codex = {
+    enable = true;
 
-  home.file.".codex/hooks.json".text =
-    builtins.toJSON {
-      hooks.Stop = [
-        {
-          hooks = [
-            {
-              type = "command";
-              command = "tmux-notice on codex-wait >/dev/null 2>&1 || true";
-              timeout = 5;
-            }
-          ];
-        }
+    settings = {
+      # 272,000 tokens × 97.5% (default: 95% = 258,400 tokens).
+      model_auto_compact_token_limit = 265200;
+      tui.status_line = [
+        "model-with-reasoning"
+        "current-dir"
+        "context-remaining"
+        "weekly-limit"
       ];
-    }
-    + "\n";
+      # Increase concurrent threads from the default of 4 to 16.
+      agents.max_concurrent_threads_per_session = 16;
+    };
+
+    hooks.Stop = [
+      {
+        hooks = [
+          {
+            type = "command";
+            command = "tmux-notice on codex-wait >/dev/null 2>&1 || true";
+            timeout = 5;
+          }
+        ];
+      }
+    ];
+  };
 }


### PR DESCRIPTION
## Summary

- Add a reusable `dot.programs.codex` Home Manager module for Codex command configuration and hooks.
- Move the Codex recipe’s wrapper, status-line settings, concurrency limit, compaction limit, and stop hook into the module interface.

## Background

The Codex recipe previously embedded its wrapper implementation directly. Extracting it into a reusable module keeps the recipe focused on configuration while making the command and settings available through standard `dot.programs.codex` options.