### PR TITLE
Remove current directory from status displays

### DIFF
--- a/files/claude/statusline.sh
+++ b/files/claude/statusline.sh
@@ -70,8 +70,6 @@ MODEL=$(echo "$input" | jq -r '.model.display_name // "Unknown"')
 # "Opus 5 (1M context)" -> "Opus 5 (1M)"; the window size alone is unambiguous
 MODEL="${MODEL/ context)/)}"
 EFFORT=$(echo "$input" | jq -r '.effort.level // empty')
-CWD=$(echo "$input" | jq -r '.workspace.current_dir // "."')
-CWD_SHORT="${CWD##*/}"
 
 TOTAL_INPUT_TOKENS=$(echo "$input" | jq -r '.context_window.total_input_tokens // 0')
 TOTAL_OUTPUT_TOKENS=$(echo "$input" | jq -r '.context_window.total_output_tokens // 0')
@@ -99,7 +97,7 @@ GIT_BRANCH=""
 if git rev-parse --git-dir >/dev/null 2>&1; then
 	BRANCH=$(git branch --show-current 2>/dev/null)
 	if [[ -n "$BRANCH" ]]; then
-		GIT_BRANCH="${DIM}:${RESET}${CYAN}${BRANCH}${RESET}"
+		GIT_BRANCH=" ${DIM}|${RESET} ${CYAN}${BRANCH}${RESET}"
 	fi
 fi
 
@@ -108,7 +106,7 @@ MODEL_DISPLAY="${MODEL}"
 if [[ -n "$EFFORT" ]]; then
 	MODEL_DISPLAY+="${DIM}:${RESET}${EFFORT}"
 fi
-OUTPUT="${MODEL_DISPLAY} ${DIM}|${RESET} $CWD_SHORT${GIT_BRANCH}"
+OUTPUT="${MODEL_DISPLAY}${GIT_BRANCH}"
 
 if [[ "$TOTAL_INPUT_TOKENS" != "0" || "$TOTAL_OUTPUT_TOKENS" != "0" ]]; then
 	OUTPUT+=" ${DIM}|${RESET} ${DIM}↑${RESET}${GREEN}${INPUT_K}${RESET} ${DIM}↓${RESET}${YELLOW}${OUTPUT_K}${RESET}"

--- a/files/pi/agent/extensions/user/lib/status/footer.ts
+++ b/files/pi/agent/extensions/user/lib/status/footer.ts
@@ -1,4 +1,3 @@
-import { homedir } from "node:os";
 import type {
 	ExtensionAPI,
 	ExtensionContext,
@@ -8,12 +7,7 @@ import type {
 import type { Component, TUI } from "@earendil-works/pi-tui";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { colors, fg } from "../theme";
-import {
-	formatCount,
-	formatCwd,
-	formatPercent,
-	pickRemainingColor,
-} from "./format";
+import { formatCount, formatPercent, pickRemainingColor } from "./format";
 import type { FooterNoticeState } from "./notice";
 import type { RequestRender } from "./render-trigger";
 import { type LiveAgentUsageTracker, getAssistantTotals } from "./usage";
@@ -22,8 +16,6 @@ type FooterFactory = NonNullable<
 	Parameters<ExtensionUIContext["setFooter"]>[0]
 >;
 type FooterComponent = Component & { dispose?(): void };
-
-const HOME = homedir();
 
 export function createStatusBarFooter(
 	pi: ExtensionAPI,
@@ -39,11 +31,6 @@ export function createStatusBarFooter(
 	): FooterComponent => {
 		setRequestRender(() => tui.requestRender());
 
-		const cwdSegment =
-			ctx.cwd === HOME
-				? `${fg(colors.muted, "in ")}${fg(colors.positive, "HOME")}`
-				: fg(colors.positive, formatCwd(ctx.cwd));
-
 		const unsubscribeBranchChange = footerData.onBranchChange(() =>
 			tui.requestRender(),
 		);
@@ -55,8 +42,7 @@ export function createStatusBarFooter(
 
 		function renderLocation(): string {
 			const branch = footerData.getGitBranch();
-			if (!branch) return cwdSegment;
-			return `${cwdSegment}${fg(colors.muted, ":")}${fg(colors.accent, branch)}`;
+			return branch ? fg(colors.accent, branch) : "";
 		}
 
 		function renderContextUsage(): string {

--- a/files/pi/agent/extensions/user/lib/status/format.ts
+++ b/files/pi/agent/extensions/user/lib/status/format.ts
@@ -1,9 +1,5 @@
-import { homedir } from "node:os";
-import { basename } from "node:path";
 import type { Color } from "../theme";
 import { colors } from "../theme";
-
-const HOME = homedir();
 
 export function formatCount(value: number): string {
 	if (!Number.isFinite(value) || value <= 0) return "0";
@@ -16,16 +12,6 @@ export function formatCount(value: number): string {
 
 export function formatPercent(value: number): string {
 	return `${value.toFixed(1)}%`;
-}
-
-export function formatCwd(cwd: string): string {
-	if (cwd === HOME) return "~";
-	const name = basename(cwd);
-	return name || cwd;
-}
-
-export function formatHomeCwdSegment(): string {
-	return HOME;
 }
 
 export function pickRemainingColor(remaining: number): Color {

--- a/modules/recipes/codex.nix
+++ b/modules/recipes/codex.nix
@@ -9,7 +9,6 @@ _:
       model_auto_compact_token_limit = 265200;
       tui.status_line = [
         "model-with-reasoning"
-        "current-dir"
         "context-remaining"
         "weekly-limit"
       ];

--- a/tests/pi/agent/extensions/user/lib/status/footer.test.ts
+++ b/tests/pi/agent/extensions/user/lib/status/footer.test.ts
@@ -24,6 +24,33 @@ function assistant(input: number, cacheRead: number): unknown {
 }
 
 describe("createStatusBarFooter", () => {
+	it("shows the branch without the current working directory", () => {
+		const pi = {
+			getThinkingLevel: () => "",
+		} as unknown as ExtensionAPI;
+		const ctx = {
+			cwd: "/repo",
+			model: { id: "model" },
+			getContextUsage: () => undefined,
+			sessionManager: { getBranch: () => [] },
+		} as unknown as ExtensionContext;
+		const footerData = {
+			onBranchChange: () => () => undefined,
+			getGitBranch: () => "main",
+			getExtensionStatuses: () => new Map(),
+		};
+		const footer = createStatusBarFooter(pi, ctx, () => undefined)(
+			{ requestRender: () => undefined } as never,
+			{} as never,
+			footerData as never,
+		);
+
+		const output = footer.render(200).join("\n");
+
+		assert.match(output, /main/u);
+		assert.doesNotMatch(output, /repo/u);
+	});
+
 	it("includes live in-flight agent cost in the footer", () => {
 		const pi = {
 			getThinkingLevel: () => "",

--- a/tests/pi/agent/extensions/user/lib/status/format.test.ts
+++ b/tests/pi/agent/extensions/user/lib/status/format.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import { describe, it } from "vitest";
 import {
 	formatCount,
-	formatCwd,
 	formatPercent,
 	pickRemainingColor,
 } from "#pi-user/lib/status/format";
@@ -22,11 +21,6 @@ describe("status format helpers", () => {
 	it("formats percents with one decimal place", () => {
 		assert.equal(formatPercent(12), "12.0%");
 		assert.equal(formatPercent(12.34), "12.3%");
-	});
-
-	it("keeps cwd labels short", () => {
-		assert.equal(formatCwd("/tmp/example-project"), "example-project");
-		assert.equal(formatCwd("/"), "/");
 	});
 
 	it("selects remaining-context colors by threshold", () => {


### PR DESCRIPTION
## Summary

- Remove current-directory output from the Claude and Codex status lines.
- Show only the Git branch in the Pi footer and remove the unused cwd formatting helpers.
- Update the Codex status configuration and Pi tests to match.

## Background

The status displays were repeating location information and consuming useful horizontal space. This keeps branch, context, and usage information visible without displaying the current directory.