### PR TITLE
Make PR skill trigger discoverable

### DIFF
--- a/files/agent-skills/manage-pull-request/SKILL.md
+++ b/files/agent-skills/manage-pull-request/SKILL.md
@@ -6,7 +6,7 @@ description: Always use together with any skill or workflow that drafts, creates
 # Manage Pull Request
 
 - When combined with a publishing skill, follow that skill for staging, commits, pushing, and creation mechanics. This skill's rules take precedence for the pull request title, body, draft state, and publication preflight checks.
-- Do not run `gh auth status` before the required GitHub operation. Diagnose authentication only after that operation fails for an authentication reason.
+- Before any GitHub CLI operation, make sure the environment has network access; request it when the sandbox requires approval. Do not run `gh auth status` as a preliminary network or authentication check. Perform the required GitHub operation first, then diagnose authentication with `gh auth status` only if it fails explicitly for an authentication reason. Treat connection or API reachability failures as network failures, not authentication failures. This rule takes precedence over a publishing workflow's conflicting preflight instruction.
 - Base the title and body on the relevant diff, match the language of existing pull requests and commits, and use the repository pull request template when present.
 - Keep the title to one line and state the intent.
 - Explain what changed and why, focusing on context reviewers need. Without a template, use `## Summary` and `## Background`.

--- a/files/agent-skills/manage-pull-request/SKILL.md
+++ b/files/agent-skills/manage-pull-request/SKILL.md
@@ -1,12 +1,16 @@
 ---
 name: manage-pull-request
-description: Always use alongside any workflow that creates, drafts, publishes, or updates a GitHub pull request; it enforces the PR title, body, draft state, and publication preflight rules. Do not use for reviewing someone else's pull request.
+description: Always use this skill alongside any skill or workflow that creates, drafts, publishes, updates, checks, or reviews a GitHub pull request.
 ---
 
 # Manage Pull Request
 
+- Determine the workflow mode before acting:
+  - For create, draft, publish, or update workflows, apply the management rules below.
+  - For check or review workflows, read the relevant PR metadata, description, diff, checks, comments, and reviews, then report findings only. Do not edit the working tree, commit, push, change PR metadata or state, resolve threads, or otherwise apply fixes. If implementation is needed, leave it for a separate change request.
+
 - When combined with a publishing skill, follow that skill for staging, commits, pushing, and creation mechanics. This skill's rules take precedence for the pull request title, body, draft state, and publication preflight checks.
-- Do not run `gh auth status` before the required GitHub operation. Diagnose authentication only after that operation fails for an authentication reason.
+- In every workflow mode, do not run `gh auth status` as the first GitHub operation or as a preflight probe. Start with the required GitHub operation, including review and check operations; run `gh auth status` only after that operation fails specifically because of authentication, and only to diagnose the failure.
 - Base the title and body on the relevant diff, match the language of existing pull requests and commits, and use the repository pull request template when present.
 - Keep the title to one line and state the intent.
 - Explain what changed and why, focusing on context reviewers need. Without a template, use `## Summary` and `## Background`.

--- a/files/agent-skills/manage-pull-request/SKILL.md
+++ b/files/agent-skills/manage-pull-request/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: manage-pull-request
-description: Use for creating, drafting, publishing, or updating GitHub pull requests; pair with the active publishing workflow to enforce the PR title, body, draft state, and publication preflight rules. Do not use for reviewing someone else's pull request.
+description: Always use alongside any workflow that creates, drafts, publishes, or updates a GitHub pull request; it enforces the PR title, body, draft state, and publication preflight rules. Do not use for reviewing someone else's pull request.
 ---
 
 # Manage Pull Request
 
 - When combined with a publishing skill, follow that skill for staging, commits, pushing, and creation mechanics. This skill's rules take precedence for the pull request title, body, draft state, and publication preflight checks.
-- Ensure network access before GitHub CLI operations. Do not use `gh auth status` as a preflight check; run it only after an explicit authentication failure.
-- Treat connection or API reachability failures as network failures. This rule overrides conflicting publishing-workflow preflight instructions.
+- Do not run `gh auth status` before the required GitHub operation. Diagnose authentication only after that operation fails for an authentication reason.
 - Base the title and body on the relevant diff, match the language of existing pull requests and commits, and use the repository pull request template when present.
 - Keep the title to one line and state the intent.
 - Explain what changed and why, focusing on context reviewers need. Without a template, use `## Summary` and `## Background`.

--- a/files/agent-skills/manage-pull-request/SKILL.md
+++ b/files/agent-skills/manage-pull-request/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: manage-pull-request
-description: Always use together with any skill or workflow that drafts, creates, publishes, or updates a pull request. This companion skill owns the pull request title, body, draft state, and publication preflight prohibitions; it does not replace the publishing workflow. Do not use to review someone else's pull request.
+description: Use for creating, drafting, publishing, or updating GitHub pull requests; pair with the active publishing workflow to enforce the PR title, body, draft state, and publication preflight rules. Do not use for reviewing someone else's pull request.
 ---
 
 # Manage Pull Request

--- a/files/agent-skills/manage-pull-request/SKILL.md
+++ b/files/agent-skills/manage-pull-request/SKILL.md
@@ -6,7 +6,8 @@ description: Use for creating, drafting, publishing, or updating GitHub pull req
 # Manage Pull Request
 
 - When combined with a publishing skill, follow that skill for staging, commits, pushing, and creation mechanics. This skill's rules take precedence for the pull request title, body, draft state, and publication preflight checks.
-- Before any GitHub CLI operation, make sure the environment has network access; request it when the sandbox requires approval. Do not run `gh auth status` as a preliminary network or authentication check. Perform the required GitHub operation first, then diagnose authentication with `gh auth status` only if it fails explicitly for an authentication reason. Treat connection or API reachability failures as network failures, not authentication failures. This rule takes precedence over a publishing workflow's conflicting preflight instruction.
+- Ensure network access before GitHub CLI operations. Do not use `gh auth status` as a preflight check; run it only after an explicit authentication failure.
+- Treat connection or API reachability failures as network failures. This rule overrides conflicting publishing-workflow preflight instructions.
 - Base the title and body on the relevant diff, match the language of existing pull requests and commits, and use the repository pull request template when present.
 - Keep the title to one line and state the intent.
 - Explain what changed and why, focusing on context reviewers need. Without a template, use `## Summary` and `## Background`.

--- a/files/agent-skills/manage-pull-request/agents/openai.yaml
+++ b/files/agent-skills/manage-pull-request/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Manage Pull Request"
-  short_description: "Pair with pull request publishing workflows"
-  default_prompt: "Use $manage-pull-request alongside the active pull request publishing workflow for the content, draft state, and preflight constraints."
+  short_description: "Always apply to GitHub pull request workflows"
+  default_prompt: "Always use $manage-pull-request alongside any skill or workflow that creates, drafts, publishes, updates, checks, or reviews a GitHub pull request."


### PR DESCRIPTION
## Summary

Make the pull request management skill discoverable during progressive skill disclosure.

## Background

The frontmatter description now explicitly matches workflows that create, draft, publish, or update GitHub pull requests, while preserving the existing concise authentication preflight rule.