### PR TITLE
Fix Lazygit config migration

### DIFF
--- a/modules/dot/programs/default.nix
+++ b/modules/dot/programs/default.nix
@@ -3,6 +3,7 @@
     ./agent-skills.nix
     ./aws.nix
     ./codex.nix
+    ./delta.nix
     ./fzf.nix
     ./gcloud.nix
     ./ghq.nix

--- a/modules/dot/programs/delta.nix
+++ b/modules/dot/programs/delta.nix
@@ -1,0 +1,43 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.dot.programs.delta;
+in
+{
+  options.dot.programs.delta = {
+    enable = lib.mkEnableOption "delta";
+
+    package = lib.mkPackageOption pkgs "delta" { };
+
+    integrations.lazygit.enable = lib.mkEnableOption "Delta integration for Lazygit";
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    programs.git.settings = {
+      interactive.diffFilter = "delta --color-only";
+      diff.colorMoved = "default";
+      delta = {
+        diff-so-fancy = true;
+        line-numbers = true;
+      };
+      alias.delta = "!f() { git diff \"$@\" | delta --side-by-side; }; f";
+    };
+
+    programs.lazygit.settings =
+      lib.mkIf (cfg.integrations.lazygit.enable && config.programs.lazygit.enable)
+        {
+          git.diffRenderers = [
+            {
+              command = "delta --paging=never";
+            }
+          ];
+        };
+  };
+}

--- a/modules/recipes/delta.nix
+++ b/modules/recipes/delta.nix
@@ -1,28 +1,8 @@
-{ pkgs, ... }:
+_:
 
 {
-  config = {
-    home.packages = [ pkgs.delta ];
-    programs.git.settings = {
-      interactive.diffFilter = "delta --color-only";
-      diff = {
-        colorMoved = "default";
-      };
-      delta = {
-        diff-so-fancy = true;
-        line-numbers = true;
-      };
-      alias = {
-        delta = "!f() { git diff \"$@\" | delta --side-by-side; }; f";
-      };
-    };
-
-    programs.lazygit.settings = {
-      git.pagers = [
-        {
-          pager = "delta --paging=never";
-        }
-      ];
-    };
+  dot.programs.delta = {
+    enable = true;
+    integrations.lazygit.enable = true;
   };
 }


### PR DESCRIPTION
## Summary

- Move Delta configuration into a reusable `dot.programs.delta` module.
- Migrate Lazygit configuration from `git.pagers`/`pager` to `git.diffRenderers`/`command`.
- Add opt-in `integrations.lazygit.enable`, applied only when `programs.lazygit.enable` is true.

## Background

Lazygit now expects the renamed diff renderer configuration and attempted to migrate the generated user config at runtime. Because the generated file is not writable, that migration produced a permission error. This change generates the current configuration directly and keeps the Lazygit-specific setting behind an explicit Delta integration option and Lazygit enablement check.