### PR TITLE
Fix floating terminal handling

### DIFF
--- a/files/nvim/lua/util/terminal.lua
+++ b/files/nvim/lua/util/terminal.lua
@@ -16,7 +16,7 @@ local function float_term(cmd, opts)
   local buf = vim.api.nvim_create_buf(false, true)
   vim.bo[buf].bufhidden = "wipe"
 
-  vim.api.nvim_open_win(buf, true, {
+  local win = vim.api.nvim_open_win(buf, true, {
     relative = "editor",
     width = width,
     height = height,
@@ -26,10 +26,27 @@ local function float_term(cmd, opts)
     border = "rounded",
   })
 
-  vim.fn.termopen(cmd, {
-    cwd = opts.cwd,
-    env = opts.env,
-  })
+  local term_opts = {
+    on_exit = function()
+      vim.schedule(function()
+        if vim.api.nvim_win_is_valid(win) then
+          vim.api.nvim_win_close(win, true)
+        end
+      end)
+    end,
+  }
+  if opts.cwd then
+    term_opts.cwd = opts.cwd
+  end
+  if opts.env then
+    term_opts.env = vim.tbl_isempty(opts.env) and vim.empty_dict() or opts.env
+  end
+
+  if vim.tbl_isempty(term_opts) then
+    vim.fn.termopen(cmd)
+  else
+    vim.fn.termopen(cmd, term_opts)
+  end
   vim.cmd.startinsert()
 end
 


### PR DESCRIPTION
## Summary

- Fix `termopen()` option handling when no terminal options are provided.
- Close the floating terminal window when its process exits.

## Background

On Neovim 0.12, passing an empty Lua table through `vim.fn.termopen()` is interpreted as a List, but `termopen()` requires a Dictionary. This caused Lazygit to fail with `E475: Invalid argument: expected dictionary`. After the command exited, the floating terminal also remained open with `[Process exited 0]`.